### PR TITLE
Check if public key is set in bond transactions

### DIFF
--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -121,7 +121,7 @@ func TestChecker(t *testing.T) {
 		valPub := sb.TestCommitteeSigners[0].PublicKey()
 
 		trx := tx.NewBondTx(block1000.Stamp(), acc.Sequence()+1, acc.Address(),
-			valPub.Address(), valPub.(*bls.PublicKey), 1000, 1000, "")
+			valPub.Address(), nil, 1000, 1000, "")
 		signer.SignMsg(trx)
 		assert.Error(t, executor.Execute(trx, sb))
 		assert.NoError(t, checker.Execute(trx, sb))
@@ -136,7 +136,7 @@ func TestLockTime(t *testing.T) {
 	curHeight := 2 * sb.TestParams.TransactionToLiveInterval
 	sb.TestStore.AddTestBlock(curHeight)
 
-	t.Run("Should reject sortition transaxtions with lock time", func(t *testing.T) {
+	t.Run("Should reject sortition transactions with lock time", func(t *testing.T) {
 		pub, prv := bls.GenerateTestKeyPair()
 		signer := crypto.NewSigner(prv)
 		val := sb.MakeNewValidator(pub)
@@ -153,7 +153,7 @@ func TestLockTime(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("Should reject subsidy transaxtions with lock time", func(t *testing.T) {
+	t.Run("Should reject subsidy transactions with lock time", func(t *testing.T) {
 		pld := &payload.SendPayload{
 			Sender:   crypto.TreasuryAddress,
 			Receiver: crypto.GenerateTestAddress(),
@@ -164,7 +164,7 @@ func TestLockTime(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("Should reject expired transaxtions", func(t *testing.T) {
+	t.Run("Should reject expired transactions", func(t *testing.T) {
 		pub, prv := bls.GenerateTestKeyPair()
 		signer := crypto.NewSigner(prv)
 		acc := sb.MakeNewAccount(pub.Address())

--- a/execution/executor/bond.go
+++ b/execution/executor/bond.go
@@ -35,6 +35,11 @@ func (e *BondExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 				"public key is not set")
 		}
 		val = sb.MakeNewValidator(pld.PublicKey)
+	} else {
+		if pld.PublicKey != nil {
+			return errors.Errorf(errors.ErrInvalidPublicKey,
+				"public key set")
+		}
 	}
 	if val.UnbondingHeight() > 0 {
 		return errors.Errorf(errors.ErrInvalidHeight,

--- a/execution/executor/bond_test.go
+++ b/execution/executor/bond_test.go
@@ -43,7 +43,7 @@ func TestExecuteBondTx(t *testing.T) {
 	t.Run("Should fail, inside committee", func(t *testing.T) {
 		pub := tSandbox.Committee().Proposer(0).PublicKey()
 		trx := tx.NewBondTx(tStamp500000, sender.Sequence()+1, sender.Address(),
-			pub.Address(), pub, amt, fee, "inside committee")
+			pub.Address(), nil, amt, fee, "inside committee")
 		err := exe.Execute(trx, tSandbox)
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidTx)
 	})
@@ -55,7 +55,7 @@ func TestExecuteBondTx(t *testing.T) {
 		tSandbox.UpdateValidator(val)
 
 		trx := tx.NewBondTx(tStamp500000, sender.Sequence()+1, sender.Address(),
-			pub.Address(), pub, amt, fee, "unbonded before")
+			pub.Address(), nil, amt, fee, "unbonded before")
 		err := exe.Execute(trx, tSandbox)
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidHeight)
 	})
@@ -76,6 +76,14 @@ func TestExecuteBondTx(t *testing.T) {
 
 		// Execute again, should fail
 		assert.Error(t, exe.Execute(trx, tSandbox))
+	})
+
+	t.Run("Should fail, public key set for second bond", func(t *testing.T) {
+		trx := tx.NewBondTx(tStamp500000, sender.Sequence()+2, sender.Address(),
+			pub.Address(), pub, amt, fee, "with public key")
+
+		err := exe.Execute(trx, tSandbox)
+		assert.Equal(t, errors.Code(err), errors.ErrInvalidPublicKey)
 	})
 
 	assert.Equal(t, tSandbox.Account(sender.Address()).Balance(),
@@ -102,7 +110,7 @@ func TestBondInsideCommittee(t *testing.T) {
 
 	pub := tSandbox.Committee().Proposer(0).PublicKey()
 	trx := tx.NewBondTx(tStamp500000, sender.Sequence()+1, sender.Address(),
-		pub.Address(), pub, amt, fee, "inside committee")
+		pub.Address(), nil, amt, fee, "inside committee")
 
 	assert.Error(t, exe1.Execute(trx, tSandbox))
 	assert.NoError(t, exe2.Execute(trx, tSandbox))
@@ -126,7 +134,7 @@ func TestBondJoiningCommittee(t *testing.T) {
 	tSandbox.UpdateValidator(val)
 
 	trx := tx.NewBondTx(tStamp500000, sender.Sequence()+1, sender.Address(),
-		pub.Address(), pub, amt, fee, "joining committee")
+		pub.Address(), nil, amt, fee, "joining committee")
 
 	assert.Error(t, exe1.Execute(trx, tSandbox))
 	assert.NoError(t, exe2.Execute(trx, tSandbox))


### PR DESCRIPTION
## Description

For known validators public key should not set again in Bond transactions

## Related issue(s)

Fixing #367 

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
