### PR TITLE
Updating peer height

### DIFF
--- a/state/mock.go
+++ b/state/mock.go
@@ -45,10 +45,11 @@ func MockingState() *MockState {
 
 func (m *MockState) CommitTestBlocks(num int) {
 	for i := 0; i < num; i++ {
-		b := block.GenerateTestBlock(nil, nil)
+		lastHash := m.LastBlockHash()
+		b := block.GenerateTestBlock(nil, &lastHash)
 		cert := block.GenerateTestCertificate(b.Hash())
 
-		m.TestStore.SaveBlock(uint32(i+1), b, cert)
+		m.TestStore.SaveBlock(m.LastBlockHeight()+1, b, cert)
 	}
 }
 func (m *MockState) LastBlockHeight() uint32 {

--- a/sync/bundle/message/blocks_request.go
+++ b/sync/bundle/message/blocks_request.go
@@ -21,6 +21,9 @@ func NewBlocksRequestMessage(sid int, from, to uint32) *BlocksRequestMessage {
 }
 
 func (m *BlocksRequestMessage) SanityCheck() error {
+	if m.From == 0 {
+		return errors.Errorf(errors.ErrInvalidHeight, "invalid height")
+	}
 	if m.From > m.To {
 		return errors.Errorf(errors.ErrInvalidHeight, "invalid range")
 	}

--- a/sync/bundle/message/blocks_request_test.go
+++ b/sync/bundle/message/blocks_request_test.go
@@ -13,6 +13,11 @@ func TestLatestBlocksRequestType(t *testing.T) {
 }
 
 func TestBlocksRequestMessage(t *testing.T) {
+	t.Run("Invalid height", func(t *testing.T) {
+		m := NewBlocksRequestMessage(1, 0, 0)
+
+		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidHeight)
+	})
 	t.Run("Invalid range", func(t *testing.T) {
 		m := NewBlocksRequestMessage(1, 200, 100)
 

--- a/sync/bundle/message/heart_beat.go
+++ b/sync/bundle/message/heart_beat.go
@@ -22,6 +22,9 @@ func NewHeartBeatMessage(h uint32, r int16, hash hash.Hash) *HeartBeatMessage {
 }
 
 func (m *HeartBeatMessage) SanityCheck() error {
+	if m.Height == 0 {
+		return errors.Errorf(errors.ErrInvalidHeight, "invalid height")
+	}
 	if m.Round < 0 {
 		return errors.Error(errors.ErrInvalidRound)
 	}

--- a/sync/bundle/message/heart_beat_test.go
+++ b/sync/bundle/message/heart_beat_test.go
@@ -14,6 +14,11 @@ func TestHeartBeatType(t *testing.T) {
 }
 
 func TestHeartBeatMessage(t *testing.T) {
+	t.Run("Invalid height", func(t *testing.T) {
+		m := NewHeartBeatMessage(0, 0, hash.GenerateTestHash())
+
+		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidHeight)
+	})
 	t.Run("Invalid round", func(t *testing.T) {
 		m := NewHeartBeatMessage(100, -1, hash.GenerateTestHash())
 

--- a/sync/cache/cache.go
+++ b/sync/cache/cache.go
@@ -30,12 +30,12 @@ func certificateKey(height uint32) key {
 }
 
 type Cache struct {
-	cache *lru.ARCCache // it's thread safe
+	cache *lru.Cache // it's thread safe
 	state state.Facade
 }
 
 func NewCache(size int, state state.Facade) (*Cache, error) {
-	c, err := lru.NewARC(size)
+	c, err := lru.New(size)
 	if err != nil {
 		return nil, err
 	}

--- a/sync/handler_block_announce_test.go
+++ b/sync/handler_block_announce_test.go
@@ -16,21 +16,37 @@ func TestParsingBlockAnnounceMessages(t *testing.T) {
 	lastBlockHash := tState.LastBlockHash()
 	lastBlockHeight := tState.LastBlockHeight()
 	b1 := block.GenerateTestBlock(nil, &lastBlockHash)
-	lastBlockHash = b1.Hash()
-	b2 := block.GenerateTestBlock(nil, &lastBlockHash)
+	c1 := block.GenerateTestCertificate(b1.Hash())
+	b1Hash := b1.Hash()
+	b2 := block.GenerateTestBlock(nil, &b1Hash)
 	c2 := block.GenerateTestCertificate(b2.Hash())
 
 	pid := network.TestRandomPeerID()
-	msg := message.NewBlockAnnounceMessage(lastBlockHeight+2, b2, c2)
+	msg1 := message.NewBlockAnnounceMessage(lastBlockHeight+1, b1, c1)
+	msg2 := message.NewBlockAnnounceMessage(lastBlockHeight+2, b2, c2)
 
 	pub, _ := bls.GenerateTestKeyPair()
 	testAddPeer(t, pub, pid)
 
 	t.Run("Receiving new block announce message, without committing previous block", func(t *testing.T) {
-		assert.NoError(t, testReceivingNewMessage(tSync, msg, pid))
+		assert.NoError(t, testReceivingNewMessage(tSync, msg2, pid))
 
 		msg1 := shouldPublishMessageWithThisType(t, tNetwork, message.MessageTypeBlocksRequest)
 		assert.Equal(t, msg1.Message.(*message.BlocksRequestMessage).From, lastBlockHeight+1)
+
+		peer := tSync.peerSet.GetPeer(pid)
+		assert.Equal(t, peer.Height, lastBlockHeight+2)
+		assert.Equal(t, tSync.state.LastBlockHeight(), lastBlockHeight)
+		assert.Equal(t, tSync.peerSet.MaxClaimedHeight(), lastBlockHeight+2)
+	})
+
+	t.Run("Receiving missed block, should commit both blocks", func(t *testing.T) {
+		assert.NoError(t, testReceivingNewMessage(tSync, msg1, pid))
+
+		peer := tSync.peerSet.GetPeer(pid)
+		assert.Equal(t, peer.Height, lastBlockHeight+2)
+		assert.Equal(t, tSync.state.LastBlockHeight(), lastBlockHeight+2)
+		assert.Equal(t, tSync.peerSet.MaxClaimedHeight(), lastBlockHeight+2)
 	})
 }
 

--- a/sync/handler_blocks_request.go
+++ b/sync/handler_blocks_request.go
@@ -77,6 +77,7 @@ func (handler *blocksRequestHandler) ParsMessage(m message.Message, initiator pe
 		}
 	}
 	// To avoid sending blocks again, we update height for this peer
+	// Height is always greater than zeo.
 	handler.peerSet.UpdateHeight(initiator, height-1)
 
 	if msg.To >= handler.state.LastBlockHeight() {

--- a/sync/handler_heart_beat.go
+++ b/sync/handler_heart_beat.go
@@ -37,7 +37,7 @@ func (handler *heartBeatHandler) ParsMessage(m message.Message, initiator peer.I
 		}
 	}
 
-	handler.peerSet.UpdateHeight(initiator, msg.Height-1)
+	handler.peerSet.UpdateHeight(initiator, msg.Height)
 
 	return nil
 }

--- a/sync/peerset/peer_set.go
+++ b/sync/peerset/peer_set.go
@@ -202,7 +202,7 @@ func (ps *PeerSet) UpdateHeight(pid peer.ID, height uint32) {
 	defer ps.lk.Unlock()
 
 	p := ps.mustGetPeer(pid)
-	p.Height = height
+	p.Height = util.MaxU32(p.Height, height)
 	ps.maxClaimedHeight = util.MaxU32(ps.maxClaimedHeight, height)
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -420,22 +420,23 @@ func (sync *synchronizer) weAreInTheCommittee() bool {
 }
 
 func (sync *synchronizer) tryCommitBlocks() {
+	height := sync.state.LastBlockHeight() + 1
 	for {
-		ourHeight := sync.state.LastBlockHeight()
-		b := sync.cache.GetBlock(ourHeight + 1)
+		b := sync.cache.GetBlock(height)
 		if b == nil {
 			break
 		}
-		c := sync.cache.GetCertificate(ourHeight + 1)
+		c := sync.cache.GetCertificate(height)
 		if c == nil {
 			break
 		}
-		sync.logger.Trace("committing block", "height", ourHeight+1, "block", b)
-		if err := sync.state.CommitBlock(ourHeight+1, b, c); err != nil {
-			sync.logger.Warn("committing block failed", "block", b, "err", err, "height", ourHeight+1)
+		sync.logger.Trace("committing block", "height", height, "block", b)
+		if err := sync.state.CommitBlock(height, b, c); err != nil {
+			sync.logger.Warn("committing block failed", "block", b, "err", err, "height", height)
 			// We will ask network to re-send this block again ...
 			break
 		}
+		height = height + 1
 	}
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -167,8 +167,10 @@ func (sync *synchronizer) broadcastHeartBeat() {
 	}
 
 	height, round := sync.consensus.HeightRound()
-	msg := message.NewHeartBeatMessage(height, round, sync.state.LastBlockHash())
-	sync.broadcast(msg)
+	if height > 0 {
+		msg := message.NewHeartBeatMessage(height, round, sync.state.LastBlockHash())
+		sync.broadcast(msg)
+	}
 }
 
 func (sync *synchronizer) sayHello(helloAck bool) {


### PR DESCRIPTION
## Description

Peer height wrongly set to 0xffffffff. This caused a critical issue in the sync module. In this PR I updated the height more accurately and ignored messages with height zero. Tests are added to cover the changes.

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
