### PR TITLE
Starting the consensus if the node is sync with the network

### DIFF
--- a/consensus/mock.go
+++ b/consensus/mock.go
@@ -15,15 +15,16 @@ type MockConsensus struct {
 	Lock     sync.RWMutex
 	Votes    []*vote.Vote
 	Proposal *proposal.Proposal
-	//Scheduled bool
-	State *state.MockState
-	Round int16
+	State    *state.MockState
+	Height   uint32
+	Round    int16
 }
 
 func MockingConsensus(state *state.MockState) *MockConsensus {
 	return &MockConsensus{State: state}
 }
 func (m *MockConsensus) MoveToNewHeight() {
+	m.Height = m.State.LastBlockHeight() + 1
 }
 func (m *MockConsensus) Start() error {
 	return nil

--- a/sync/bundle/message/query_proposal.go
+++ b/sync/bundle/message/query_proposal.go
@@ -31,5 +31,5 @@ func (m *QueryProposalMessage) Type() Type {
 }
 
 func (m *QueryProposalMessage) Fingerprint() string {
-	return fmt.Sprintf("%v/%v", m.Height, m.Round)
+	return fmt.Sprintf("{%v/%v}", m.Height, m.Round)
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -132,7 +132,10 @@ func (sync *synchronizer) onStartingTimeout() {
 	ourHeight := sync.state.LastBlockHeight()
 	networkHeight := sync.peerSet.MaxClaimedHeight()
 
-	if ourHeight >= networkHeight {
+	// Consensus should start if our height is the same as the network height.
+	// Note that State height is always one height less than the Consensus height
+	// and it should be plus one to get the consensu height.
+	if ourHeight+1 >= networkHeight {
 		sync.synced()
 	}
 }
@@ -237,7 +240,7 @@ func (sync *synchronizer) processIncomingBundle(bdl *bundle.Bundle) error {
 		return nil
 	}
 
-	sync.logger.Debug("received a bundle", "initiator", bdl.Initiator, "bundle", bdl)
+	sync.logger.Info("received a bundle", "initiator", bdl.Initiator, "bundle", bdl)
 	h := sync.handlers[bdl.Message.Type()]
 	if h == nil {
 		return errors.Errorf(errors.ErrInvalidMessage, "invalid message type: %v", bdl.Message.Type())
@@ -320,7 +323,7 @@ func (sync *synchronizer) sendTo(msg message.Message, to peer.ID) {
 		if err != nil {
 			sync.logger.Error("error on sending bundle", "bundle", bdl, "err", err, "to", to)
 		} else {
-			sync.logger.Debug("sending bundle to a peer", "bundle", bdl, "to", to)
+			sync.logger.Info("sending bundle to a peer", "bundle", bdl, "to", to)
 		}
 	}
 }
@@ -334,7 +337,7 @@ func (sync *synchronizer) broadcast(msg message.Message) {
 		if err != nil {
 			sync.logger.Error("error on broadcasting bundle", "bundle", bdl, "err", err)
 		} else {
-			sync.logger.Debug("broadcasting new bundle", "bundle", bdl)
+			sync.logger.Info("broadcasting new bundle", "bundle", bdl)
 		}
 	}
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -201,3 +201,15 @@ func TestTestNetFlags(t *testing.T) {
 	require.False(t, util.IsFlagSet(bdl.Flags, bundle.BundleFlagNetworkMainnet), "invalid flag: %v", bdl)
 	require.True(t, util.IsFlagSet(bdl.Flags, bundle.BundleFlagNetworkTestnet), "invalid flag: %v", bdl)
 }
+
+func TestStartingConsensus(t *testing.T) {
+	tConfig.StartingTimeout = 1 * time.Minute
+	setup(t)
+
+	pid := network.TestRandomPeerID()
+	msg := message.NewHeartBeatMessage(tState.LastBlockHeight()+1, 0, hash.GenerateTestHash())
+	assert.NoError(t, testReceivingNewMessage(tSync, msg, pid))
+
+	tSync.onStartingTimeout()
+	assert.Equal(t, tConsensus.Height, tState.LastBlockHeight()+1)
+}


### PR DESCRIPTION
## Description

Starting the consensus if the node is sync with the network. A test is added to cover this special case.


## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
