### PR TITLE
Nil event channel if nanomsg is disabled

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -46,8 +46,11 @@ func NewNode(genDoc *genesis.Genesis, conf *config.Config, signer crypto.Signer)
 	if err != nil {
 		return nil, err
 	}
-	messageCh := make(chan message.Message, 100)
-	eventCh := make(chan event.Event, 100)
+	messageCh := make(chan message.Message, 500)
+	eventCh := make(chan event.Event, 500)
+	if !conf.Nanomsg.Enable {
+		eventCh = nil
+	}
 
 	txPool := txpool.NewTxPool(conf.TxPool, messageCh)
 


### PR DESCRIPTION
## Description

Make sure the event channel is set to nil when the nanomsg is disabled. Otherwise after some blocks the channel becomes full and the node hangs.

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
