### PR TITLE
gui: start node on new os thread

### DIFF
--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -112,6 +112,7 @@ func startingNode(workingDir string,
 	//TODO: log to file
 
 	go func() {
+		// Simple trick to make sure that the node starts in a new OS thread.
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
 		err := node.Start()

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/gotk3/gotk3/glib"
@@ -63,7 +64,7 @@ func main() {
 	// Connect function to application activate event
 	app.Connect("activate", func() {
 		log.Println("application activate")
-		start(nil, workingDir, app)
+		start(workingDir, app)
 	})
 
 	// Connect function to application shutdown event, this is not required.
@@ -75,7 +76,8 @@ func main() {
 	os.Exit(app.Run(nil))
 }
 
-func startingNode(workingDir string, wallet *wallet.Wallet, password string) (*node.Node, *time.Time, error) {
+func startingNode(workingDir string,
+	wallet *wallet.Wallet, password string) (*node.Node, *time.Time, error) {
 	gen, err := genesis.LoadFromFile(cmd.PactusGenesisPath(workingDir))
 	if err != nil {
 		return nil, nil, err
@@ -109,26 +111,25 @@ func startingNode(workingDir string, wallet *wallet.Wallet, password string) (*n
 	}
 	//TODO: log to file
 
-	err = node.Start()
-	if err != nil {
-		return nil, nil, err
-	}
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		err := node.Start()
+		if err != nil {
+			fatalErrorCheck(err)
+		}
+	}()
 
 	genTime := gen.GenesisTime()
 	return node, &genTime, nil
 }
 
-func start(parent gtk.IWindow, workingDir string, app *gtk.Application) {
-	//theme, _ := gtk.IconThemeGetDefault()
-	//theme.AddResourcePath("icons")
-
+func start(workingDir string, app *gtk.Application) {
 	// change working directory
 	if err := os.Chdir(workingDir); err != nil {
 		log.Println("Aborted! Unable to changes working directory. " + err.Error())
 		return
 	}
-
-	time.Sleep(1 * time.Second)
 
 	path := cmd.PactusDefaultWalletPath(workingDir)
 	wallet, err := wallet.OpenWallet(path, false)
@@ -136,7 +137,7 @@ func start(parent gtk.IWindow, workingDir string, app *gtk.Application) {
 
 	password, ok := getWalletPassword(wallet)
 	if !ok {
-		showInfoDialog(parent, "Canceled!")
+		showInfoDialog(nil, "Canceled!")
 		return
 	}
 	// TODO: Get genTime from the node or state


### PR DESCRIPTION
## Description

Starting the node on new thread for GUI app 
Sometimes GUI app in Windows shows not responding message.

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] CHANGELOG is updated.
