### PR TITLE
fixing missed dll in windows releaser

### DIFF
--- a/.github/releasers/releaser_gui_windows.sh
+++ b/.github/releasers/releaser_gui_windows.sh
@@ -71,7 +71,7 @@ cp \
   "libpangocairo-1.0-0.dll" \
   "libpangoft2-1.0-0.dll" \
   "libpangowin32-1.0-0.dll" \
-  "libpcre-1.dll" \
+  "libpcre-2.dll" \
   "libpixman-1-0.dll" \
   "libpng16-16.dll" \
   "librsvg-2-2.dll" \


### PR DESCRIPTION
## Description

fixing missed dll in windows releaser:
`cp: cannot stat 'libpcre-1.dll': No such file or directory`

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] CHANGELOG is updated.
