### PR TITLE
cli-wallet: adding server option

### DIFF
--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pactus-project/pactus/node/config"
 	"github.com/pactus-project/pactus/types/genesis"
 	"github.com/pactus-project/pactus/util"
-	"github.com/pactus-project/pactus/version"
 	"github.com/pactus-project/pactus/wallet"
 )
 
@@ -102,14 +101,6 @@ func Start() func(c *cli.Cmd) {
 				return
 			}
 
-			validatorAddr := signer.Address()
-			rewardAddr := conf.State.RewardAddress
-			if rewardAddr == "" {
-				rewardAddr = validatorAddr.String()
-			}
-			cmd.PrintInfoMsg("You are running a pactus block chain version: %s. Welcome! ", version.Version())
-			cmd.PrintInfoMsg("Validator address: %v", validatorAddr)
-			cmd.PrintInfoMsg("Reward address : %v", rewardAddr)
 			cmd.PrintLine()
 
 			node, err := node.NewNode(gen, conf, signer)

--- a/cmd/wallet/address.go
+++ b/cmd/wallet/address.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pactus-project/pactus/cmd"
 	"github.com/pactus-project/pactus/crypto/bls"
 	"github.com/pactus-project/pactus/util"
-	"github.com/pactus-project/pactus/wallet"
 )
 
 // AllAddresses lists all the wallet addresses.
@@ -27,7 +26,7 @@ func AllAddresses() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			wallet, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			wallet, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return
@@ -64,7 +63,7 @@ func NewAddress() func(c *cli.Cmd) {
 		c.Before = func() {}
 		c.Action = func() {
 			label := cmd.PromptInput("Label")
-			wallet, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			wallet, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return
@@ -95,7 +94,7 @@ func Balance() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			wallet, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			wallet, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return
@@ -126,7 +125,7 @@ func PrivateKey() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			wallet, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			wallet, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return
@@ -152,7 +151,7 @@ func PublicKey() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			wallet, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			wallet, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return
@@ -182,7 +181,7 @@ func ImportPrivateKey() func(c *cli.Cmd) {
 		c.Action = func() {
 			prvStr := cmd.PromptInput("Private Key")
 
-			wallet, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			wallet, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return
@@ -221,7 +220,7 @@ func SetLabel() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			wallet, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			wallet, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return

--- a/cmd/wallet/create.go
+++ b/cmd/wallet/create.go
@@ -57,7 +57,7 @@ func ChangePassword() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			wallet, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			wallet, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return

--- a/cmd/wallet/recover.go
+++ b/cmd/wallet/recover.go
@@ -39,7 +39,7 @@ func GetSeed() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			wallet, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			wallet, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return

--- a/cmd/wallet/tx.go
+++ b/cmd/wallet/tx.go
@@ -29,7 +29,7 @@ func SendTx() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			w, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			w, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return
@@ -88,7 +88,7 @@ func BondTx() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			w, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			w, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return
@@ -131,7 +131,7 @@ func UnbondTx() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			w, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			w, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return
@@ -180,7 +180,7 @@ func WithdrawTx() func(c *cli.Cmd) {
 
 		c.Before = func() {}
 		c.Action = func() {
-			w, err := wallet.OpenWallet(*pathOpt, *offlineOpt)
+			w, err := openWallet()
 			if err != nil {
 				cmd.PrintDangerMsg(err.Error())
 				return

--- a/node/node.go
+++ b/node/node.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pactus-project/pactus/types/genesis"
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/logger"
+	"github.com/pactus-project/pactus/version"
 	"github.com/pactus-project/pactus/www/capnp"
 	"github.com/pactus-project/pactus/www/grpc"
 	"github.com/pactus-project/pactus/www/http"
@@ -41,6 +42,16 @@ type Node struct {
 func NewNode(genDoc *genesis.Genesis, conf *config.Config, signer crypto.Signer) (*Node, error) {
 	// Initialize the logger
 	logger.InitLogger(conf.Logger)
+
+	validatorAddr := signer.Address().String()
+	rewardAddr := conf.State.RewardAddress
+	if rewardAddr == "" {
+		rewardAddr = validatorAddr
+	}
+	logger.Info("You are running a pactus block chain",
+		"version", version.Version(),
+		"Validator address", validatorAddr,
+		"Reward address", rewardAddr)
 
 	network, err := network.NewNetwork(conf.Network)
 	if err != nil {


### PR DESCRIPTION
## Description

Adding server option to wallet commands. Now users can specify to which server they want to connect.

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] CHANGELOG is updated.
