### PR TITLE
chore: updating test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Test with coverage
-      run: go test -gcflags=-l -coverprofile=coverage.txt -covermode=atomic ./...
+      run: go test -coverpkg=./... -coverprofile=coverage.txt ./...
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
## Description

This PR updates the go test command in our GitHub Actions workflow to provide a more accurate and comprehensive test coverage report. The new command calculates coverage for all packages in the project, with default coverage mode and inlining enabled, offering better performance and smaller binaries.