### PR TITLE
fix: prevent data race conditions in committee 

### DIFF
--- a/committee/committee.go
+++ b/committee/committee.go
@@ -29,9 +29,9 @@ func NewCommittee(validators []*validator.Validator, committeeSize int,
 	validatorList := list.New()
 	var proposerPos *list.Element
 
-	for _, v := range validators {
-		el := validatorList.PushBack(v)
-		if v.Address().EqualsTo(proposerAddress) {
+	for _, val := range validators {
+		el := validatorList.PushBack(cloneValidator(val))
+		if val.Address().EqualsTo(proposerAddress) {
 			proposerPos = el
 		}
 	}
@@ -65,7 +65,7 @@ func (c *committee) Update(lastRound int16, joined []*validator.Validator) {
 	for _, val := range joined {
 		committeeVal := c.find(val.Address())
 		if committeeVal == nil {
-			c.validatorList.InsertBefore(val, c.proposerPos)
+			c.validatorList.InsertBefore(cloneValidator(val), c.proposerPos)
 		} else {
 			committeeVal.UpdateLastJoinedHeight(val.LastJoinedHeight())
 

--- a/committee/committee_test.go
+++ b/committee/committee_test.go
@@ -81,6 +81,26 @@ func TestProposerMove(t *testing.T) {
 	assert.Equal(t, committee.Proposer(0).Number(), int32(1))
 }
 
+func TestValidatorConsistency(t *testing.T) {
+	val1, _ := validator.GenerateTestValidator(0)
+	val2, _ := validator.GenerateTestValidator(1)
+	val3, _ := validator.GenerateTestValidator(2)
+	val4, _ := validator.GenerateTestValidator(3)
+
+	committee, _ := NewCommittee([]*validator.Validator{val1, val2, val3, val4}, 4, val1.Address())
+
+	t.Run("Updating validators' stake, Should panic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("The code did not panic")
+			}
+		}()
+
+		val1.AddToStake(1)
+		committee.Update(0, []*validator.Validator{val1})
+	})
+}
+
 func TestProposerJoin(t *testing.T) {
 	pub1, _ := bls.GenerateTestKeyPair()
 	pub2, _ := bls.GenerateTestKeyPair()
@@ -111,17 +131,15 @@ func TestProposerJoin(t *testing.T) {
 
 	// Height 1000
 	// Val1 is in the committee
-	val2Copy := cloneValidator(val2)
-	val2Copy.UpdateLastJoinedHeight(1000)
-	committee.Update(0, []*validator.Validator{val2Copy})
+	val2.UpdateLastJoinedHeight(1000)
+	committee.Update(0, []*validator.Validator{val2})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(2))
 	assert.Equal(t, committee.Committers(), []int32{1, 2, 3, 4})
 	assert.Equal(t, committee.Size(), 4)
 
 	// Height 1001
-	val5Copy := cloneValidator(val5)
-	val5Copy.UpdateLastJoinedHeight(1001)
-	committee.Update(0, []*validator.Validator{val5Copy})
+	val5.UpdateLastJoinedHeight(1001)
+	committee.Update(0, []*validator.Validator{val5})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(3))
 	assert.Equal(t, committee.Proposer(1).Number(), int32(4))
 	assert.Equal(t, committee.Committers(), []int32{1, 5, 2, 3, 4})
@@ -133,13 +151,10 @@ func TestProposerJoin(t *testing.T) {
 	assert.Equal(t, committee.Proposer(1).Number(), int32(5))
 
 	// Height 1003
-	val3Copy := cloneValidator(val3)
-	val6Copy := cloneValidator(val6)
-	val7Copy := cloneValidator(val7)
-	val3Copy.UpdateLastJoinedHeight(1003)
-	val6Copy.UpdateLastJoinedHeight(1003)
-	val7Copy.UpdateLastJoinedHeight(1003)
-	committee.Update(1, []*validator.Validator{val7Copy, val3Copy, val6Copy})
+	val3.UpdateLastJoinedHeight(1003)
+	val6.UpdateLastJoinedHeight(1003)
+	val7.UpdateLastJoinedHeight(1003)
+	committee.Update(1, []*validator.Validator{val7, val3, val6})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(2))
 	assert.Equal(t, committee.Committers(), []int32{6, 7, 1, 5, 2, 3, 4})
 	assert.Equal(t, committee.Size(), 7)
@@ -216,65 +231,53 @@ func TestProposerJoinAndLeave(t *testing.T) {
 	// +-+-+-+-+-+-+-+    +-+-+-+-+-+-+-+    +-+-+-+-+-+-+-+    +-+-+-+-+-+-+-+
 
 	// Height 1001
-	val8Copy := cloneValidator(val8)
-	val8Copy.UpdateLastJoinedHeight(1001)
-	committee.Update(0, []*validator.Validator{val8Copy})
+	val8.UpdateLastJoinedHeight(1001)
+	committee.Update(0, []*validator.Validator{val8})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(2))
 	assert.Equal(t, committee.Proposer(1).Number(), int32(3))
 	assert.Equal(t, committee.Proposer(2).Number(), int32(4))
 	assert.Equal(t, committee.Committers(), []int32{8, 2, 3, 4, 5, 6, 7})
 
 	// Height 1002
-	val3Copy := cloneValidator(val3)
-	val3Copy.UpdateLastJoinedHeight(1002)
-	committee.Update(3, []*validator.Validator{val3Copy})
+	val3.UpdateLastJoinedHeight(1002)
+	committee.Update(3, []*validator.Validator{val3})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(6))
 
 	// Height 1003
-	val2Copy := cloneValidator(val2)
-	val9Copy := cloneValidator(val9)
-	val2Copy.UpdateLastJoinedHeight(1003)
-	val9Copy.UpdateLastJoinedHeight(1003)
-	committee.Update(0, []*validator.Validator{val9Copy, val2Copy})
+	val2.UpdateLastJoinedHeight(1003)
+	val9.UpdateLastJoinedHeight(1003)
+	committee.Update(0, []*validator.Validator{val9, val2})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(7))
 	assert.Equal(t, committee.Proposer(1).Number(), int32(8))
 	assert.Equal(t, committee.Committers(), []int32{8, 2, 3, 5, 9, 6, 7})
 
 	// Height 1004
-	valACopy := cloneValidator(valA)
-	valACopy.UpdateLastJoinedHeight(1004)
-	committee.Update(1, []*validator.Validator{valACopy})
+	valA.UpdateLastJoinedHeight(1004)
+	committee.Update(1, []*validator.Validator{valA})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(2))
 	assert.Equal(t, committee.Committers(), []int32{8, 2, 3, 9, 6, 10, 7})
 
 	// Height 1005
-	valBCopy := cloneValidator(valB)
-	valCCopy := cloneValidator(valC)
-	valBCopy.UpdateLastJoinedHeight(1005)
-	valCCopy.UpdateLastJoinedHeight(1005)
-	committee.Update(0, []*validator.Validator{valCCopy, valBCopy})
+	valB.UpdateLastJoinedHeight(1005)
+	valC.UpdateLastJoinedHeight(1005)
+	committee.Update(0, []*validator.Validator{valC, valB})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(3))
 	assert.Equal(t, committee.Proposer(1).Number(), int32(9))
 	assert.Equal(t, committee.Proposer(2).Number(), int32(10))
 	assert.Equal(t, committee.Committers(), []int32{8, 11, 12, 2, 3, 9, 10})
 
 	// Height 1006
-	val1Copy := cloneValidator(val1)
-	val1Copy.UpdateLastJoinedHeight(1006)
-	committee.Update(2, []*validator.Validator{val1Copy})
+	val1.UpdateLastJoinedHeight(1006)
+	committee.Update(2, []*validator.Validator{val1})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(11))
 	assert.Equal(t, committee.Committers(), []int32{11, 12, 2, 1, 3, 9, 10})
 
 	// Height 1007
-	val2Copy = cloneValidator(val2)
-	val3Copy = cloneValidator(val3)
-	val5Copy := cloneValidator(val5)
-	val6Copy := cloneValidator(val6)
-	val2Copy.UpdateLastJoinedHeight(1007)
-	val3Copy.UpdateLastJoinedHeight(1007)
-	val5Copy.UpdateLastJoinedHeight(1007)
-	val6Copy.UpdateLastJoinedHeight(1007)
-	committee.Update(4, []*validator.Validator{val2Copy, val3Copy, val5Copy, val6Copy})
+	val2.UpdateLastJoinedHeight(1007)
+	val3.UpdateLastJoinedHeight(1007)
+	val5.UpdateLastJoinedHeight(1007)
+	val6.UpdateLastJoinedHeight(1007)
+	committee.Update(4, []*validator.Validator{val2, val3, val5, val6})
 	assert.Equal(t, committee.Proposer(0).Number(), int32(5))
 	assert.Equal(t, committee.Committers(), []int32{5, 6, 11, 12, 2, 1, 3})
 }

--- a/consensus/commit.go
+++ b/consensus/commit.go
@@ -46,7 +46,8 @@ func (s *commitState) decide() {
 	}
 
 	s.logger.Info("block committed, schedule new height", "precommitQH", precommitQH)
-	// Now we can broadcast the committed block
+
+	// Now we can announce the committed block and certificate
 	s.announceNewBlock(s.height, certBlock, cert)
 
 	s.enterNewState(s.newHeightState)

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -89,13 +90,13 @@ func setup(t *testing.T) {
 	require.NoError(t, err)
 
 	consX := NewConsensus(testConfig(), stX, tSigners[tIndexX], tSigners[tIndexX].Address(),
-		make(chan message.Message, 100), newMediator())
+		make(chan message.Message, 100), newMediator(&sync.RWMutex{}))
 	consY := NewConsensus(testConfig(), stY, tSigners[tIndexY], tSigners[tIndexY].Address(),
-		make(chan message.Message, 100), newMediator())
+		make(chan message.Message, 100), newMediator(&sync.RWMutex{}))
 	consB := NewConsensus(testConfig(), stB, tSigners[tIndexB], tSigners[tIndexB].Address(),
-		make(chan message.Message, 100), newMediator())
+		make(chan message.Message, 100), newMediator(&sync.RWMutex{}))
 	consP := NewConsensus(testConfig(), stP, tSigners[tIndexP], tSigners[tIndexP].Address(),
-		make(chan message.Message, 100), newMediator())
+		make(chan message.Message, 100), newMediator(&sync.RWMutex{}))
 
 	tConsX = consX.(*consensus)
 	tConsY = consY.(*consensus)
@@ -308,7 +309,8 @@ func TestNotInCommittee(t *testing.T) {
 	store := store.MockingStore()
 
 	st, _ := state.LoadOrNewState(tGenDoc, []crypto.Signer{signer}, store, tTxPool, nil)
-	Cons := NewConsensus(testConfig(), st, signer, signer.Address(), make(chan message.Message, 100), newMediator())
+	Cons := NewConsensus(testConfig(), st, signer, signer.Address(), make(chan message.Message, 100),
+		newMediator(&sync.RWMutex{}))
 	cons := Cons.(*consensus)
 
 	testEnterNewHeight(cons)
@@ -515,7 +517,8 @@ func TestNonActiveValidator(t *testing.T) {
 	setup(t)
 
 	signer := bls.GenerateTestSigner()
-	Cons := NewConsensus(testConfig(), state.MockingState(), signer, signer.Address(), make(chan message.Message, 100), newMediator())
+	Cons := NewConsensus(testConfig(), state.MockingState(), signer, signer.Address(), make(chan message.Message, 100),
+		newMediator(&sync.RWMutex{}))
 	nonActiveCons := Cons.(*consensus)
 
 	t.Run("non-active instances should be in new-height state", func(t *testing.T) {

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -90,13 +89,13 @@ func setup(t *testing.T) {
 	require.NoError(t, err)
 
 	consX := NewConsensus(testConfig(), stX, tSigners[tIndexX], tSigners[tIndexX].Address(),
-		make(chan message.Message, 100), newMediator(&sync.RWMutex{}))
+		make(chan message.Message, 100), newMediator())
 	consY := NewConsensus(testConfig(), stY, tSigners[tIndexY], tSigners[tIndexY].Address(),
-		make(chan message.Message, 100), newMediator(&sync.RWMutex{}))
+		make(chan message.Message, 100), newMediator())
 	consB := NewConsensus(testConfig(), stB, tSigners[tIndexB], tSigners[tIndexB].Address(),
-		make(chan message.Message, 100), newMediator(&sync.RWMutex{}))
+		make(chan message.Message, 100), newMediator())
 	consP := NewConsensus(testConfig(), stP, tSigners[tIndexP], tSigners[tIndexP].Address(),
-		make(chan message.Message, 100), newMediator(&sync.RWMutex{}))
+		make(chan message.Message, 100), newMediator())
 
 	tConsX = consX.(*consensus)
 	tConsY = consY.(*consensus)
@@ -310,7 +309,7 @@ func TestNotInCommittee(t *testing.T) {
 
 	st, _ := state.LoadOrNewState(tGenDoc, []crypto.Signer{signer}, store, tTxPool, nil)
 	Cons := NewConsensus(testConfig(), st, signer, signer.Address(), make(chan message.Message, 100),
-		newMediator(&sync.RWMutex{}))
+		newMediator())
 	cons := Cons.(*consensus)
 
 	testEnterNewHeight(cons)
@@ -518,7 +517,7 @@ func TestNonActiveValidator(t *testing.T) {
 
 	signer := bls.GenerateTestSigner()
 	Cons := NewConsensus(testConfig(), state.MockingState(), signer, signer.Address(), make(chan message.Message, 100),
-		newMediator(&sync.RWMutex{}))
+		newMediator())
 	nonActiveCons := Cons.(*consensus)
 
 	t.Run("non-active instances should be in new-height state", func(t *testing.T) {

--- a/consensus/height.go
+++ b/consensus/height.go
@@ -22,13 +22,12 @@ func (s *newHeightState) decide() {
 		return
 	}
 
-	// Apply last certificate. We may have more votes now
+	// Try to update the last certificate. We may have more votes now.
 	if s.height == sateHeight && s.round >= 0 {
 		vs := s.log.PrecommitVoteSet(s.round)
-		if vs == nil {
-			s.logger.Warn("entering new height without certificate")
-		} else {
-			// Update last certificate here, consensus had enough time to populate more votes
+		if vs != nil {
+			// The last certificate is updated at this point since consensus has
+			// had sufficient time to populate additional votes.
 			lastCert := vs.ToCertificate()
 			if lastCert != nil {
 				if err := s.state.UpdateLastCertificate(lastCert); err != nil {

--- a/consensus/manager.go
+++ b/consensus/manager.go
@@ -143,36 +143,3 @@ func (mgr *manager) getBestInstance() Consensus {
 
 	return mgr.instances[0]
 }
-
-func (mgr *manager) OnPublishProposal(from Consensus, proposal *proposal.Proposal) {
-	mgr.lk.Lock()
-	defer mgr.lk.Unlock()
-
-	for _, cons := range mgr.instances {
-		if cons != from {
-			cons.SetProposal(proposal)
-		}
-	}
-}
-
-func (mgr *manager) OnPublishVote(from Consensus, vote *vote.Vote) {
-	mgr.lk.Lock()
-	defer mgr.lk.Unlock()
-
-	for _, cons := range mgr.instances {
-		if cons != from {
-			cons.AddVote(vote)
-		}
-	}
-}
-
-func (mgr *manager) OnBlockAnnounce(from Consensus) {
-	mgr.lk.Lock()
-	defer mgr.lk.Unlock()
-
-	for _, cons := range mgr.instances {
-		if cons != from {
-			cons.MoveToNewHeight()
-		}
-	}
-}

--- a/consensus/manager.go
+++ b/consensus/manager.go
@@ -24,17 +24,18 @@ func NewManager(
 	signers []crypto.Signer,
 	rewardAddrs []crypto.Address,
 	broadcastCh chan message.Message) Manager {
-	mediator := newMediator()
-	instances := make([]Consensus, len(signers))
+	mgr := &manager{
+		instances: make([]Consensus, len(signers)),
+	}
+	mediator := newMediator(&mgr.lk)
+
 	for i, signer := range signers {
 		cons := NewConsensus(conf, state, signer, rewardAddrs[i], broadcastCh, mediator)
 
-		instances[i] = cons
+		mgr.instances[i] = cons
 	}
 
-	return &manager{
-		instances: instances,
-	}
+	return mgr
 }
 
 // Start starts the manager.
@@ -141,4 +142,37 @@ func (mgr *manager) getBestInstance() Consensus {
 	}
 
 	return mgr.instances[0]
+}
+
+func (mgr *manager) OnPublishProposal(from Consensus, proposal *proposal.Proposal) {
+	mgr.lk.Lock()
+	defer mgr.lk.Unlock()
+
+	for _, cons := range mgr.instances {
+		if cons != from {
+			cons.SetProposal(proposal)
+		}
+	}
+}
+
+func (mgr *manager) OnPublishVote(from Consensus, vote *vote.Vote) {
+	mgr.lk.Lock()
+	defer mgr.lk.Unlock()
+
+	for _, cons := range mgr.instances {
+		if cons != from {
+			cons.AddVote(vote)
+		}
+	}
+}
+
+func (mgr *manager) OnBlockAnnounce(from Consensus) {
+	mgr.lk.Lock()
+	defer mgr.lk.Unlock()
+
+	for _, cons := range mgr.instances {
+		if cons != from {
+			cons.MoveToNewHeight()
+		}
+	}
 }

--- a/consensus/mediator.go
+++ b/consensus/mediator.go
@@ -1,8 +1,6 @@
 package consensus
 
 import (
-	"sync"
-
 	"github.com/pactus-project/pactus/types/proposal"
 	"github.com/pactus-project/pactus/types/vote"
 )
@@ -18,19 +16,14 @@ type mediator interface {
 
 // ConcreteMediator struct
 type ConcreteMediator struct {
-	lk *sync.RWMutex
-
 	instances []Consensus
 }
 
-func newMediator(lk *sync.RWMutex) mediator {
-	return &ConcreteMediator{lk: lk}
+func newMediator() mediator {
+	return &ConcreteMediator{}
 }
 
 func (m *ConcreteMediator) OnPublishProposal(from Consensus, proposal *proposal.Proposal) {
-	m.lk.Lock()
-	defer m.lk.Unlock()
-
 	for _, cons := range m.instances {
 		if cons != from {
 			cons.SetProposal(proposal)
@@ -39,9 +32,6 @@ func (m *ConcreteMediator) OnPublishProposal(from Consensus, proposal *proposal.
 }
 
 func (m *ConcreteMediator) OnPublishVote(from Consensus, vote *vote.Vote) {
-	m.lk.Lock()
-	defer m.lk.Unlock()
-
 	for _, cons := range m.instances {
 		if cons != from {
 			cons.AddVote(vote)
@@ -50,9 +40,6 @@ func (m *ConcreteMediator) OnPublishVote(from Consensus, vote *vote.Vote) {
 }
 
 func (m *ConcreteMediator) OnBlockAnnounce(from Consensus) {
-	m.lk.Lock()
-	defer m.lk.Unlock()
-
 	for _, cons := range m.instances {
 		if cons != from {
 			cons.MoveToNewHeight()

--- a/consensus/prepare.go
+++ b/consensus/prepare.go
@@ -48,7 +48,7 @@ func (s *prepareState) vote() {
 
 	roundProposal := s.log.RoundProposal(s.round)
 	if roundProposal == nil {
-		s.logger.Warn("no proposal yet.")
+		s.logger.Debug("no proposal yet.")
 		return
 	}
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -177,11 +177,7 @@ func testAddPeerToCommittee(t *testing.T, pid peer.ID, pub crypto.PublicKey) {
 	require.True(t, tState.TestCommittee.Contains(pub.Address()))
 
 	for _, cons := range tConsMocks {
-		if cons.Signer.PublicKey().EqualsTo(pub) {
-			cons.Active = true
-		} else {
-			cons.Active = false
-		}
+		cons.SetActive(cons.Signer.PublicKey().EqualsTo(pub))
 	}
 }
 


### PR DESCRIPTION
## Description

Prevent data race conditions in committee by cloning validators.

This commit addresses a potential data race condition that can occur when a validator inside the committee updates. To prevent this, we now clone validators. This ensures that the original validators are not modified and eliminates the possibility of data race conditions.
