### PR TITLE
fix(consensus): rejecting vote with round numbers exceeding the limit

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -224,6 +224,11 @@ func (cs *consensus) AddVote(v *vote.Vote) {
 		return
 	}
 
+	if v.Round() > cs.round+2 {
+		cs.logger.Trace("vote round number exceeding the round limit", "vote", v)
+		return
+	}
+
 	if cs.log.HasVote(v.Hash()) {
 		cs.logger.Trace("vote exists", "vote", v)
 		return

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -556,3 +556,16 @@ func TestNonActiveValidator(t *testing.T) {
 		checkHeightRoundWait(t, nonActiveCons, 3, 0)
 	})
 }
+
+func TestValidVoteWithBigRound(t *testing.T) {
+	setup(t)
+
+	testEnterNewHeight(tConsX)
+
+	v := vote.NewVote(vote.VoteTypeChangeProposer, 1, util.MaxInt16, hash.UndefHash,
+		tSigners[tIndexB].Address())
+	tSigners[tIndexB].SignMsg(v)
+
+	tConsX.AddVote(v)
+	assert.False(t, tConsX.log.HasVote(v.Hash()))
+}

--- a/consensus/log/log.go
+++ b/consensus/log/log.go
@@ -44,7 +44,7 @@ func (log *Log) MustGetRoundMessages(round int16) *Messages {
 			changeProposerVotes: voteset.NewVoteSet(i, vote.VoteTypeChangeProposer, log.validators),
 		}
 
-		// extendind votes slice
+		// expending votes slice
 		log.roundMessages = append(log.roundMessages, rv)
 	}
 


### PR DESCRIPTION
## Description

This commit adds a check to ensure that votes with round numbers more than two rounds larger than the current round are rejected. This prevents byzantine validators from causing network crashes by broadcasting votes with large round numbers.

## Related issue(s)

Fixing #465 
