### PR TITLE
fix: reducing the default Argon2d to consume less memory

### DIFF
--- a/wallet/encrypter/encrypter.go
+++ b/wallet/encrypter/encrypter.go
@@ -81,9 +81,11 @@ func NopeEncrypter() Encrypter {
 // The default encrypter uses Argon2ID as password hasher and AES_256_CTR as
 // encryption algorithm.
 func DefaultEncrypter(opts ...Option) Encrypter {
+	// Parameter Choice
+	// https://www.rfc-editor.org/rfc/rfc9106.html#section-4
 	argon2dParameters := &argon2dParameters{
-		iterations:  uint32(1),
-		memory:      uint32(2 * 1024 * 1024),
+		iterations:  uint32(3),
+		memory:      uint32(65536), // 2 ^ 16
 		parallelism: uint8(4),
 	}
 	for _, opt := range opts {


### PR DESCRIPTION
## Description

The Argon2d parameters changed to consume less memory. This specially fix the allocation failure in the clouding platforms with memory less than 2 GB.

> If much less memory is available, a uniformly safe option is Argon2id with t=3 iterations, p=4 lanes, m=2^(16) (64 MiB of RAM), 128-bit salt, and 256-bit tag size. This is the SECOND RECOMMENDED option.
