### PR TITLE
chore: updating alpine to support go1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as builder
+FROM alpine:3.18 as builder
 
 RUN apk add --no-cache git go gmp-dev build-base g++ openssl-dev
 ADD . /pactus


### PR DESCRIPTION
## Description

alpine 1.16 supports go 1.18 causing this error: https://github.com/pactus-project/pactus/actions/runs/5046027649/jobs/9051025182
