### PR TITLE
fix: restoring config file to the default

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -333,18 +333,20 @@ func StartNode(workingDir string, passwordFetcher func(*wallet.Wallet) (string, 
 		PrintWarnMsg("Unable to load the config: %s", err)
 		PrintInfoMsg("Attempting to restore the config to the default values...")
 
-		// Let's backup the config first
+		// First, try to open the old config file in non-strict mode
 		confBack, err := config.LoadFromFile(confPath, false)
 		if err != nil {
 			return nil, nil, err
 		}
 
+		// Let's create a backup of the config
 		confBackupPath := fmt.Sprintf("%v_bak_%s", confPath, time.Now().Format("2006_01_02"))
 		err = os.Rename(confPath, confBackupPath)
 		if err != nil {
 			return nil, nil, err
 		}
 
+		// Now, attempt to restore the config file with the number of validators from the old config.
 		switch gen.ChainType() {
 		case genesis.Testnet:
 			err = config.SaveTestnetConfig(confPath, confBack.Node.NumValidators)
@@ -352,7 +354,7 @@ func StartNode(workingDir string, passwordFetcher func(*wallet.Wallet) (string, 
 				return nil, nil, err
 			}
 		case genesis.Mainnet:
-			panic("not yet!")
+			panic("not yet implemented!")
 		}
 
 		PrintSuccessMsg("Config restored to the default values")

--- a/config/config.go
+++ b/config/config.go
@@ -127,7 +127,7 @@ func (conf *Config) toTOML() []byte {
 	return buf.Bytes()
 }
 
-func LoadFromFile(file string) (*Config, error) {
+func LoadFromFile(file string, strict bool) (*Config, error) {
 	data, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
@@ -136,7 +136,7 @@ func LoadFromFile(file string) (*Config, error) {
 	conf := DefaultConfig()
 	buf := bytes.NewBuffer(data)
 	decoder := toml.NewDecoder(buf)
-	decoder.Strict(true)
+	decoder.Strict(strict)
 	if err := decoder.Decode(conf); err != nil {
 		return nil, err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ func TestSaveMainnetConfig(t *testing.T) {
 	path := util.TempFilePath()
 	assert.NoError(t, SaveMainnetConfig(path, 7))
 
-	conf, err := LoadFromFile(path)
+	conf, err := LoadFromFile(path, true)
 	assert.NoError(t, err)
 
 	assert.NoError(t, conf.SanityCheck())
@@ -24,7 +24,7 @@ func TestSaveTestnetConfig(t *testing.T) {
 	path := util.TempFilePath()
 	assert.NoError(t, SaveTestnetConfig(path, 7))
 
-	conf, err := LoadFromFile(path)
+	conf, err := LoadFromFile(path, true)
 	assert.NoError(t, err)
 
 	assert.NoError(t, conf.SanityCheck())
@@ -33,12 +33,15 @@ func TestSaveTestnetConfig(t *testing.T) {
 
 func TestLoadFromFile(t *testing.T) {
 	path := util.TempFilePath()
-	_, err := LoadFromFile(path)
+	_, err := LoadFromFile(path, true)
 	assert.Error(t, err, "not exists")
 
 	assert.NoError(t, util.WriteFile(path, []byte(`foo = "bar"`)))
-	_, err = LoadFromFile(path)
+	_, err = LoadFromFile(path, true)
 	assert.Error(t, err, "unknown field")
+
+	_, err = LoadFromFile(path, false)
+	assert.NoError(t, err)
 }
 
 func TestExampleConfig(t *testing.T) {


### PR DESCRIPTION
## Description

This pull request fixes the issue with restoring the configuration file to the default values when unable to load the config.

## Related issue(s)

Related to #478 
