### PR TITLE
fix: increase failed counter when stream encounters errors

### DIFF
--- a/consensus/manager_test.go
+++ b/consensus/manager_test.go
@@ -67,16 +67,6 @@ func TestManager(t *testing.T) {
 
 	assert.False(t, mgr.HasActiveInstance())
 
-	mgr.MoveToNewHeight()
-
-	checkHeightRoundWait(t, consA, 1, 0)
-	checkHeightRoundWait(t, consB, 1, 0)
-	checkHeightRoundWait(t, consC, 1, 0)
-	checkHeightRoundWait(t, consD, 1, 0)
-	checkHeightRoundWait(t, consE, 1, 0)
-
-	assert.True(t, mgr.HasActiveInstance())
-
 	t.Run("Check if keys are assigned properly", func(t *testing.T) {
 		instances := mgr.Instances()
 
@@ -87,13 +77,16 @@ func TestManager(t *testing.T) {
 		assert.Equal(t, signers[4].PublicKey(), instances[4].SignerKey())
 	})
 
-	t.Run("Check if one instance publishes a proposal, the other instances receive it", func(t *testing.T) {
-		p := shouldPublishProposal(t, consA, 1, 0)
+	t.Run("Check if all instances move to new height", func(t *testing.T) {
+		mgr.MoveToNewHeight()
 
-		assert.Equal(t, consA.RoundProposal(0), p)
-		assert.Equal(t, consB.RoundProposal(0), p)
-		assert.Nil(t, consC.RoundProposal(0))
-		assert.Nil(t, consD.RoundProposal(0))
+		checkHeightRoundWait(t, consA, 1, 0)
+		checkHeightRoundWait(t, consB, 1, 0)
+		checkHeightRoundWait(t, consC, 1, 0)
+		checkHeightRoundWait(t, consD, 1, 0)
+		checkHeightRoundWait(t, consE, 1, 0)
+
+		assert.True(t, mgr.HasActiveInstance())
 	})
 
 	t.Run("Testing add vote", func(t *testing.T) {
@@ -109,8 +102,8 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("Testing set proposal", func(t *testing.T) {
-		blk, _ := state.ProposeBlock(committeeSigners[2], committeeSigners[2].Address(), 2)
-		p := proposal.NewProposal(1, 2, blk)
+		b, _ := state.ProposeBlock(committeeSigners[2], committeeSigners[2].Address(), 2)
+		p := proposal.NewProposal(1, 2, b)
 		committeeSigners[2].SignMsg(p)
 
 		mgr.SetProposal(p)
@@ -119,6 +112,15 @@ func TestManager(t *testing.T) {
 		assert.Equal(t, consB.RoundProposal(2), p)
 		assert.Nil(t, consC.RoundProposal(2))
 		assert.Nil(t, consD.RoundProposal(2))
+	})
+
+	t.Run("Check if one instance publishes a proposal, the other instances receive it", func(t *testing.T) {
+		p := shouldPublishProposal(t, consA, 1, 0)
+
+		assert.Equal(t, consA.RoundProposal(0), p)
+		assert.Equal(t, consB.RoundProposal(0), p)
+		assert.Nil(t, consC.RoundProposal(0))
+		assert.Nil(t, consD.RoundProposal(0))
 	})
 
 	t.Run("Testing moving to the next round proposal", func(t *testing.T) {

--- a/sync/firewall/firewall_test.go
+++ b/sync/firewall/firewall_test.go
@@ -86,8 +86,10 @@ func TestGossipMessage(t *testing.T) {
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 		d, _ := bdl.Encode()
 
+		assert.False(t, tNetwork.IsClosed(tUnknownPeerID))
 		assert.False(t, tNetwork.IsClosed(tBadPeerID))
 		assert.Nil(t, tFirewall.OpenGossipBundle(d, tUnknownPeerID, tBadPeerID))
+		assert.False(t, tNetwork.IsClosed(tUnknownPeerID))
 		assert.True(t, tNetwork.IsClosed(tBadPeerID))
 	})
 
@@ -99,8 +101,10 @@ func TestGossipMessage(t *testing.T) {
 		d, _ := bdl.Encode()
 
 		assert.False(t, tNetwork.IsClosed(tBadPeerID))
+		assert.False(t, tNetwork.IsClosed(tUnknownPeerID))
 		assert.Nil(t, tFirewall.OpenGossipBundle(d, tBadPeerID, tUnknownPeerID))
 		assert.True(t, tNetwork.IsClosed(tBadPeerID))
+		assert.True(t, tNetwork.IsClosed(tUnknownPeerID))
 	})
 
 	t.Run("Message initiator is not the same as source => should close the connection", func(t *testing.T) {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -207,6 +207,8 @@ func (sync *synchronizer) receiveLoop() {
 				se := e.(*network.StreamMessage)
 				bdl = sync.firewall.OpenStreamBundle(se.Reader, se.Source)
 				if err := se.Reader.Close(); err != nil {
+					// TODO: write test for me
+					sync.peerSet.IncreaseSendFailedCounter(se.Source)
 					sync.logger.Warn("error on closing stream", "err", err)
 				}
 			}
@@ -306,7 +308,7 @@ func (sync *synchronizer) sendTo(msg message.Message, to peer.ID, sessionID int)
 		data, _ := bdl.Encode()
 		err := sync.network.SendTo(data, to)
 		if err != nil {
-			sync.logger.Error("error on sending bundle", "bundle", bdl, "err", err, "to", to)
+			sync.logger.Warn("error on sending bundle", "bundle", bdl, "err", err, "to", to)
 			sync.peerSet.IncreaseSendFailedCounter(to)
 
 			// Let's close the session with this peer because we couldn't establish a connection.


### PR DESCRIPTION
## Description

Sometimes, the relay connection encounters errors and gets closed. In such cases, we have increased the 'Send Filed' counter to track the connectivity.
