### PR TITLE
ci: removing depguard linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ check:
 		--enable=misspell \
 		--enable=revive \
 		--enable=decorder \
-		--enable=depguard \
 		--enable=nilerr \
 		--enable=gosec \
 		--enable=exportloopref \


### PR DESCRIPTION
## Description

This PR removed [depguard](https://github.com/OpenPeeDeeP/depguard) linter
