### PR TITLE
fix: removing state from cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ check:
 		--enable=misspell \
 		--enable=revive \
 		--enable=decorder \
+		--enable=reassign \
+		--enable=usestdlibvars \
 		--enable=nilerr \
 		--enable=gosec \
 		--enable=exportloopref \

--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -25,7 +25,6 @@ func Start() func(c *cli.Cmd) {
 			Name: "p password",
 			Desc: "The wallet password",
 		})
-		// TODO: do we need this?
 		pprofOpt := c.String(cli.StringOpt{
 			Name: "pprof",
 			Desc: "debug pprof server address(not recommended to expose to internet)",
@@ -39,16 +38,11 @@ func Start() func(c *cli.Cmd) {
 			err := os.Chdir(workingDir)
 			cmd.FatalErrorCheck(err)
 
-			// separate pprof handlers from DefaultServeMux.
-			pprofMux := http.DefaultServeMux
-			http.DefaultServeMux = http.NewServeMux()
-
 			if *pprofOpt != "" {
-				cmd.PrintWarnMsg("Starting Debug pprof server on: %v", *pprofOpt)
+				cmd.PrintWarnMsg("Starting Debug pprof server on: http://%s/debug/pprof/\n", *pprofOpt)
 				server := &http.Server{
 					Addr:              *pprofOpt,
 					ReadHeaderTimeout: 3 * time.Second,
-					Handler:           pprofMux,
 				}
 				go func() {
 					err := server.ListenAndServe()

--- a/cmd/daemon/start.go
+++ b/cmd/daemon/start.go
@@ -39,7 +39,7 @@ func Start() func(c *cli.Cmd) {
 			cmd.FatalErrorCheck(err)
 
 			if *pprofOpt != "" {
-				cmd.PrintWarnMsg("Starting Debug pprof server on: http://%s/debug/pprof/\n", *pprofOpt)
+				cmd.PrintWarnMsg("Starting Debug pprof server on: http://%s/debug/pprof/", *pprofOpt)
 				server := &http.Server{
 					Addr:              *pprofOpt,
 					ReadHeaderTimeout: 3 * time.Second,

--- a/sync/bundle/bundle_test.go
+++ b/sync/bundle/bundle_test.go
@@ -31,12 +31,13 @@ func TestInvalidCBOR(t *testing.T) {
 	assert.Error(t, err)
 }
 func TestMessageCompress(t *testing.T) {
-	var blocks = []*block.Block{}
+	var blocksData = [][]byte{}
 	for i := 0; i < 10; i++ {
 		b := block.GenerateTestBlock(nil, nil)
-		blocks = append(blocks, b)
+		d, _ := b.Bytes()
+		blocksData = append(blocksData, d)
 	}
-	msg := message.NewBlocksResponseMessage(message.ResponseCodeBusy, 1234, 888, blocks, nil)
+	msg := message.NewBlocksResponseMessage(message.ResponseCodeBusy, 1234, 888, blocksData, nil)
 	bdl := NewBundle(network.TestRandomPeerID(), msg)
 	bs0, err := bdl.Encode()
 	assert.NoError(t, err)

--- a/sync/bundle/message/blocks_response.go
+++ b/sync/bundle/message/blocks_response.go
@@ -14,27 +14,22 @@ type BlocksResponseMessage struct {
 	ResponseCode    ResponseCode       `cbor:"1,keyasint"`
 	SessionID       int                `cbor:"2,keyasint"`
 	From            uint32             `cbor:"3,keyasint"`
-	Blocks          []*block.Block     `cbor:"4,keyasint"`
+	BlocksData      [][]byte           `cbor:"4,keyasint"`
 	LastCertificate *block.Certificate `cbor:"6,keyasint"`
 }
 
 func NewBlocksResponseMessage(code ResponseCode, sid int, from uint32,
-	blocks []*block.Block, cert *block.Certificate) *BlocksResponseMessage {
+	blocksData [][]byte, lastCert *block.Certificate) *BlocksResponseMessage {
 	return &BlocksResponseMessage{
 		ResponseCode:    code,
 		SessionID:       sid,
 		From:            from,
-		Blocks:          blocks,
-		LastCertificate: cert,
+		BlocksData:      blocksData,
+		LastCertificate: lastCert,
 	}
 }
 func (m *BlocksResponseMessage) SanityCheck() error {
-	for _, b := range m.Blocks {
-		if err := b.SanityCheck(); err != nil {
-			return err
-		}
-	}
-	if m.From == 0 && len(m.Blocks) != 0 {
+	if m.From == 0 && len(m.BlocksData) != 0 {
 		return errors.Errorf(errors.ErrInvalidHeight, "unexpected block for height zero")
 	}
 	if m.LastCertificate != nil {
@@ -51,12 +46,12 @@ func (m *BlocksResponseMessage) Type() Type {
 }
 
 func (m *BlocksResponseMessage) Count() uint32 {
-	return uint32(len(m.Blocks))
+	return uint32(len(m.BlocksData))
 }
 
 func (m *BlocksResponseMessage) To() uint32 {
 	// response message without any block
-	if len(m.Blocks) == 0 {
+	if len(m.BlocksData) == 0 {
 		return 0
 	}
 	return m.From + m.Count() - 1

--- a/sync/bundle/message/blocks_response_test.go
+++ b/sync/bundle/message/blocks_response_test.go
@@ -19,14 +19,16 @@ func TestBlocksResponseMessage(t *testing.T) {
 	t.Run("Invalid certificate", func(t *testing.T) {
 		b := block.GenerateTestBlock(nil, nil)
 		c := block.NewCertificate(-1, nil, nil, nil)
-		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, sid, 100, []*block.Block{b}, c)
+		d, _ := b.Bytes()
+		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, sid, 100, [][]byte{d}, c)
 
 		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidRound)
 	})
 
 	t.Run("Unexpected block for height zero", func(t *testing.T) {
 		b := block.GenerateTestBlock(nil, nil)
-		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, sid, 0, []*block.Block{b}, nil)
+		d, _ := b.Bytes()
+		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, sid, 0, [][]byte{d}, nil)
 
 		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidHeight)
 	})
@@ -34,7 +36,9 @@ func TestBlocksResponseMessage(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		b1 := block.GenerateTestBlock(nil, nil)
 		b2 := block.GenerateTestBlock(nil, nil)
-		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, sid, 100, []*block.Block{b1, b2}, nil)
+		d1, _ := b1.Bytes()
+		d2, _ := b2.Bytes()
+		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, sid, 100, [][]byte{d1, d2}, nil)
 
 		assert.NoError(t, m.SanityCheck())
 		assert.Zero(t, m.LastCertificateHeight())
@@ -66,8 +70,10 @@ func TestLatestBlocksResponseCode(t *testing.T) {
 	t.Run("OK - MoreBlocks", func(t *testing.T) {
 		b1 := block.GenerateTestBlock(nil, nil)
 		b2 := block.GenerateTestBlock(nil, nil)
+		d1, _ := b1.Bytes()
+		d2, _ := b2.Bytes()
+		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, 1, 100, [][]byte{d1, d2}, nil)
 
-		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, 1, 100, []*block.Block{b1, b2}, nil)
 		assert.NoError(t, m.SanityCheck())
 		assert.Equal(t, m.From, uint32(100))
 		assert.Equal(t, m.To(), uint32(101))

--- a/sync/handler_blocks_request.go
+++ b/sync/handler_blocks_request.go
@@ -76,17 +76,17 @@ func (handler *blocksRequestHandler) ParsMessage(m message.Message, initiator pe
 	// Help this peer to sync up
 	for {
 		blockToRead := util.MinU32(handler.config.BlockPerMessage, count)
-		blocks := handler.prepareBlocks(height, blockToRead)
-		if len(blocks) == 0 {
+		blocksData := handler.prepareBlocks(height, blockToRead)
+		if len(blocksData) == 0 {
 			break
 		}
 
 		response := message.NewBlocksResponseMessage(message.ResponseCodeMoreBlocks,
-			msg.SessionID, height, blocks, nil)
+			msg.SessionID, height, blocksData, nil)
 		handler.sendTo(response, initiator, msg.SessionID)
 
-		height += uint32(len(blocks))
-		count -= uint32(len(blocks))
+		height += uint32(len(blocksData))
+		count -= uint32(len(blocksData))
 		if count <= 0 {
 			break
 		}

--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestInvalidBlockData(t *testing.T) {
+	setup(t)
+
+	pid := network.TestRandomPeerID()
+	sid := tSync.peerSet.OpenSession(pid).SessionID()
+	msg := message.NewBlocksResponseMessage(message.ResponseCodeMoreBlocks, sid,
+		0, [][]byte{{1, 2, 3}}, nil)
+
+	assert.Error(t, testReceivingNewMessage(tSync, msg, pid))
+}
+
 func TestOneBlockShorter(t *testing.T) {
 	setup(t)
 
@@ -22,6 +33,7 @@ func TestOneBlockShorter(t *testing.T) {
 	lastBlockHeight := tState.LastBlockHeight()
 	b1 := block.GenerateTestBlock(nil, &lastBlockHash)
 	c1 := block.GenerateTestCertificate(b1.Hash())
+	d1, _ := b1.Bytes()
 	pid := network.TestRandomPeerID()
 
 	pub, _ := bls.GenerateTestKeyPair()
@@ -48,7 +60,7 @@ func TestOneBlockShorter(t *testing.T) {
 	t.Run("Commit one block", func(t *testing.T) {
 		sid := tSync.peerSet.OpenSession(pid).SessionID()
 		msg := message.NewBlocksResponseMessage(message.ResponseCodeSynced, sid,
-			lastBlockHeight+1, []*block.Block{b1}, c1)
+			lastBlockHeight+1, [][]byte{d1}, c1)
 		assert.NoError(t, testReceivingNewMessage(tSync, msg, pid))
 
 		assert.Nil(t, tSync.peerSet.FindSession(sid))


### PR DESCRIPTION
## Description

This PR removes the `state` instance from the `cache` in the `sync` package. 
Additionally, the block data is now directly passed to the `block_response` message without parsing the block, which is expected to improve the performance of the node when processing the `block_request` messages.

