### PR TITLE
fix: closing the mDNS connection upon stopping the network

### DIFF
--- a/network/mdns.go
+++ b/network/mdns.go
@@ -27,7 +27,7 @@ func newMdnsService(ctx context.Context, host lp2phost.Host, logger *logger.Logg
 		logger: logger,
 	}
 	// setup mDNS discovery to find local peers
-	mdns.service = lp2pmdns.NewMdnsService(host, "", mdns)
+	mdns.service = lp2pmdns.NewMdnsService(host, "pactus-mdns", mdns)
 
 	return mdns
 }
@@ -57,5 +57,8 @@ func (mdns *mdnsService) Start() error {
 }
 
 func (mdns *mdnsService) Stop() {
-
+	err := mdns.service.Close()
+	if err != nil {
+		mdns.logger.Error("unable to close the network", "err", err)
+	}
 }

--- a/network/mdns_test.go
+++ b/network/mdns_test.go
@@ -9,22 +9,24 @@ import (
 
 func TestMDNS(t *testing.T) {
 	conf1 := testConfig()
+	conf1.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 	conf1.EnableMdns = true
-	net1, err := NewNetwork(conf1)
-	assert.NoError(t, err)
+	net1, _ := newNetwork(conf1, nil)
 
 	conf2 := testConfig()
+	conf2.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 	conf2.EnableMdns = true
-	net2, err := NewNetwork(conf2)
-	assert.NoError(t, err)
+	net2, _ := newNetwork(conf2, nil)
 
 	assert.NoError(t, net1.Start())
+	time.Sleep(250 * time.Millisecond)
+
 	assert.NoError(t, net2.Start())
+	time.Sleep(250 * time.Millisecond)
 
-	assert.NoError(t, net1.JoinGeneralTopic())
-	assert.NoError(t, net2.JoinGeneralTopic())
-
-	time.Sleep(200 * time.Millisecond)
-
-	assert.NoError(t, net1.SendTo([]byte("test"), net2.SelfID()))
+	msg := []byte("test-mdns")
+	assert.NoError(t, net1.SendTo(msg, net2.SelfID()))
+	e := shouldReceiveEvent(t, net2).(*StreamMessage)
+	assert.Equal(t, e.Source, net1.SelfID())
+	assert.Equal(t, readData(t, e.Reader, len(msg)), msg)
 }

--- a/network/network.go
+++ b/network/network.go
@@ -75,7 +75,7 @@ func NewNetwork(conf *Config) (Network, error) {
 	return newNetwork(conf, []lp2p.Option{})
 }
 
-func newNetwork(conf *Config, opts []lp2p.Option) (Network, error) {
+func newNetwork(conf *Config, opts []lp2p.Option) (*network, error) {
 	networkKey, err := loadOrCreateKey(conf.NetworkKey)
 	if err != nil {
 		return nil, errors.Errorf(errors.ErrNetwork, err.Error())
@@ -183,9 +183,8 @@ func (n *network) Stop() {
 	if n.mdns != nil {
 		n.mdns.Stop()
 	}
-	if n.dht != nil {
-		n.dht.Stop()
-	}
+
+	n.dht.Stop()
 	n.gossip.Stop()
 	n.stream.Stop()
 

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -40,13 +40,13 @@ func makeTestRelay(t *testing.T) host.Host {
 }
 
 func makeTestNetwork(t *testing.T, conf *Config, opts []lp2p.Option) *network {
-	Net, err := newNetwork(conf, opts)
+	net, err := newNetwork(conf, opts)
 	assert.NoError(t, err)
 
-	assert.NoError(t, Net.Start())
-	assert.NoError(t, Net.JoinGeneralTopic())
+	assert.NoError(t, net.Start())
+	assert.NoError(t, net.JoinGeneralTopic())
 
-	return Net.(*network)
+	return net
 }
 
 func testConfig() *Config {
@@ -98,6 +98,7 @@ func readData(t *testing.T, r io.ReadCloser, len int) []byte {
 	buf := make([]byte, len)
 	_, err := r.Read(buf)
 	assert.NoError(t, err)
+	assert.NoError(t, r.Close())
 
 	return buf
 }
@@ -143,6 +144,7 @@ func TestNetwork(t *testing.T) {
 		fmt.Sprintf("/ip4/0.0.0.0/tcp/%v", bootstrapPort),
 		fmt.Sprintf("/ip6/::/tcp/%v", bootstrapPort),
 	}
+	fmt.Println("Starting Bootstrap node")
 	networkB := makeTestNetwork(t, confB, []lp2p.Option{})
 	bootstrapAddresses := []string{
 		fmt.Sprintf("/ip4/127.0.0.1/tcp/%v/p2p/%v", bootstrapPort, networkB.SelfID().String()),
@@ -158,6 +160,7 @@ func TestNetwork(t *testing.T) {
 		"/ip4/0.0.0.0/tcp/0",
 		"/ip6/::/tcp/0",
 	}
+	fmt.Println("Starting Public node")
 	networkP := makeTestNetwork(t, confP, []lp2p.Option{
 		lp2p.ForceReachabilityPublic(),
 	})
@@ -172,6 +175,7 @@ func TestNetwork(t *testing.T) {
 		"/ip4/0.0.0.0/tcp/0",
 		"/ip6/::/tcp/0",
 	}
+	fmt.Println("Starting Private node M")
 	networkM := makeTestNetwork(t, confM, []lp2p.Option{
 		lp2p.ForceReachabilityPrivate(),
 	})
@@ -186,6 +190,7 @@ func TestNetwork(t *testing.T) {
 		"/ip4/0.0.0.0/tcp/0",
 		"/ip6/::/tcp/0",
 	}
+	fmt.Println("Starting Private node N")
 	networkN := makeTestNetwork(t, confN, []lp2p.Option{
 		lp2p.ForceReachabilityPrivate(),
 	})
@@ -199,10 +204,11 @@ func TestNetwork(t *testing.T) {
 		"/ip4/0.0.0.0/tcp/0",
 		"/ip6/::/tcp/0",
 	}
+	fmt.Println("Starting Private node X")
 	networkX := makeTestNetwork(t, confX, []lp2p.Option{
 		lp2p.ForceReachabilityPrivate(),
 	})
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	t.Run("all nodes have at least one connection to the bootstrap node B", func(t *testing.T) {
 		assert.GreaterOrEqual(t, networkP.NumConnectedPeers(), 1)


### PR DESCRIPTION
## Description

The mDNS service was not closed after stopping the network. This PR addresses this issue by implementing the necessary closure. Additionally, it aims to resolve a random test failure that occurs in GitHub Actions, particularly on Windows. An example of such failure can be found at: https://github.com/pactus-project/pactus/actions/runs/5255419093/jobs/9495309402
