### PR TITLE
fix: get recent blocks by stamp

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -100,7 +100,7 @@ func (exe *Execution) checkLockTime(trx *tx.Tx, sb sandbox.Sandbox) error {
 
 func (exe *Execution) checkStamp(trx *tx.Tx, sb sandbox.Sandbox) error {
 	curHeight := sb.CurrentHeight()
-	height, ok := sb.FindBlockHeightByStamp(trx.Stamp())
+	height, _ := sb.RecentBlockByStamp(trx.Stamp())
 	interval := sb.Params().TransactionToLiveInterval
 
 	if trx.IsSubsidyTx() {
@@ -109,7 +109,7 @@ func (exe *Execution) checkStamp(trx *tx.Tx, sb sandbox.Sandbox) error {
 		interval = sb.Params().SortitionInterval
 	}
 
-	if !ok || curHeight-height > interval {
+	if curHeight-height > interval {
 		return errors.Errorf(errors.ErrInvalidTx, "invalid stamp")
 	}
 

--- a/sandbox/interface.go
+++ b/sandbox/interface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/sortition"
 	"github.com/pactus-project/pactus/types/account"
+	"github.com/pactus-project/pactus/types/block"
 	"github.com/pactus-project/pactus/types/param"
 	"github.com/pactus-project/pactus/types/validator"
 )
@@ -22,8 +23,7 @@ type Sandbox interface {
 
 	VerifyProof(hash.Stamp, sortition.Proof, *validator.Validator) bool
 	Committee() committee.Reader
-	FindBlockHashByStamp(stamp hash.Stamp) (hash.Hash, bool)
-	FindBlockHeightByStamp(stamp hash.Stamp) (uint32, bool)
+	RecentBlockByStamp(stamp hash.Stamp) (uint32, *block.Block)
 
 	Params() param.Params
 	CurrentHeight() uint32

--- a/sandbox/mock.go
+++ b/sandbox/mock.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pactus-project/pactus/sortition"
 	"github.com/pactus-project/pactus/store"
 	"github.com/pactus-project/pactus/types/account"
+	"github.com/pactus-project/pactus/types/block"
 	"github.com/pactus-project/pactus/types/param"
 	"github.com/pactus-project/pactus/types/validator"
 )
@@ -77,11 +78,8 @@ func (m *MockSandbox) CurrentHeight() uint32 {
 func (m *MockSandbox) Params() param.Params {
 	return m.TestParams
 }
-func (m *MockSandbox) FindBlockHashByStamp(stamp hash.Stamp) (hash.Hash, bool) {
-	return m.TestStore.FindBlockHashByStamp(stamp)
-}
-func (m *MockSandbox) FindBlockHeightByStamp(stamp hash.Stamp) (uint32, bool) {
-	return m.TestStore.FindBlockHeightByStamp(stamp)
+func (m *MockSandbox) RecentBlockByStamp(stamp hash.Stamp) (uint32, *block.Block) {
+	return m.TestStore.RecentBlockByStamp(stamp)
 }
 func (m *MockSandbox) IterateAccounts(consumer func(crypto.Address, *AccountStatus)) {
 	m.TestStore.IterateAccounts(func(addr crypto.Address, acc *account.Account) bool {

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -326,30 +326,16 @@ func TestDeepCopy(t *testing.T) {
 	assert.NotEqual(t, val2.Hash(), val3.Validator.Hash())
 }
 
-func TestBlockHeightByStamp(t *testing.T) {
+func TestRecentBlockByStamp(t *testing.T) {
 	setup(t)
 
-	height, ok := tSandbox.FindBlockHeightByStamp(hash.GenerateTestStamp())
-	assert.Zero(t, height)
-	assert.False(t, ok)
+	h, b := tSandbox.RecentBlockByStamp(hash.GenerateTestStamp())
+	assert.Zero(t, h)
+	assert.Nil(t, b)
 
 	lastHeight, _ := tStore.LastCertificate()
 	lastHash := tSandbox.store.BlockHash(lastHeight)
-	height, ok = tSandbox.FindBlockHeightByStamp(lastHash.Stamp())
-	assert.Equal(t, height, lastHeight)
-	assert.True(t, ok)
-}
-
-func TestBlockHashByStamp(t *testing.T) {
-	setup(t)
-
-	h, ok := tSandbox.FindBlockHashByStamp(hash.GenerateTestStamp())
-	assert.True(t, h.IsUndef())
-	assert.False(t, ok)
-
-	lastHeight, _ := tStore.LastCertificate()
-	lastHash := tSandbox.store.BlockHash(lastHeight)
-	h, ok = tSandbox.FindBlockHashByStamp(lastHash.Stamp())
-	assert.True(t, h.EqualsTo(lastHash))
-	assert.True(t, ok)
+	h, b = tSandbox.RecentBlockByStamp(lastHash.Stamp())
+	assert.Equal(t, h, lastHeight)
+	assert.Equal(t, b.Hash(), lastHash)
 }

--- a/store/account.go
+++ b/store/account.go
@@ -19,7 +19,6 @@ func newAccountStore(db *leveldb.DB) *accountStore {
 	as := &accountStore{
 		db: db,
 	}
-	// TODO: better way to get total accout number?
 	total := int32(0)
 	as.iterateAccounts(func(_ crypto.Address, _ *account.Account) bool {
 		total++

--- a/store/block.go
+++ b/store/block.go
@@ -86,7 +86,7 @@ func (bs *blockStore) block(height uint32) ([]byte, error) {
 	return data, nil
 }
 
-func (bs *blockStore) BlockHeight(hash hash.Hash) uint32 {
+func (bs *blockStore) blockHeight(hash hash.Hash) uint32 {
 	data, err := tryGet(bs.db, blockHashKey(hash))
 	if err != nil {
 		return 0

--- a/store/interface.go
+++ b/store/interface.go
@@ -55,10 +55,7 @@ type Reader interface {
 	Block(height uint32) (*StoredBlock, error)
 	BlockHeight(hash hash.Hash) uint32
 	BlockHash(height uint32) hash.Hash
-	// It only remembers most recent stamps
-	FindBlockHashByStamp(stamp hash.Stamp) (hash.Hash, bool)
-	// It only remembers most recent stamps
-	FindBlockHeightByStamp(stamp hash.Stamp) (uint32, bool)
+	RecentBlockByStamp(stamp hash.Stamp) (uint32, *block.Block)
 	Transaction(id tx.ID) (*StoredTx, error)
 	HasAccount(crypto.Address) bool
 	Account(addr crypto.Address) (*account.Account, error)

--- a/store/mock.go
+++ b/store/mock.go
@@ -151,9 +151,6 @@ func (m *MockStore) LastCertificate() (uint32, *block.Certificate) {
 	return m.LastHeight, m.LastCert
 }
 func (m *MockStore) RecentBlockByStamp(stamp hash.Stamp) (uint32, *block.Block) {
-	if stamp.EqualsTo(hash.UndefHash.Stamp()) {
-		return 0, nil
-	}
 	for h, b := range m.Blocks {
 		if b.Stamp().EqualsTo(stamp) {
 			return h, &b

--- a/store/mock.go
+++ b/store/mock.go
@@ -150,29 +150,17 @@ func (m *MockStore) LastCertificate() (uint32, *block.Certificate) {
 	}
 	return m.LastHeight, m.LastCert
 }
-func (m *MockStore) FindBlockHashByStamp(stamp hash.Stamp) (hash.Hash, bool) {
+func (m *MockStore) RecentBlockByStamp(stamp hash.Stamp) (uint32, *block.Block) {
 	if stamp.EqualsTo(hash.UndefHash.Stamp()) {
-		return hash.UndefHash, true
+		return 0, nil
 	}
-	for _, b := range m.Blocks {
+	for h, b := range m.Blocks {
 		if b.Stamp().EqualsTo(stamp) {
-			return b.Hash(), true
+			return h, &b
 		}
 	}
 
-	return hash.UndefHash, false
-}
-func (m *MockStore) FindBlockHeightByStamp(stamp hash.Stamp) (uint32, bool) {
-	if stamp.EqualsTo(hash.UndefHash.Stamp()) {
-		return 0, true
-	}
-	for i, b := range m.Blocks {
-		if b.Stamp().EqualsTo(stamp) {
-			return i, true
-		}
-	}
-
-	return 0, false
+	return 0, nil
 }
 func (m *MockStore) WriteBatch() error {
 	return nil


### PR DESCRIPTION
## Description

This PR makes it possible to fetch the latest block using the stamp, which removes the need to search the levelDB for the specific block. 
This improve the performance of executing sortition transactions that need to obtain the sortition seeds based on the block stamp.
