### PR TITLE
refactor: optimization of total power calculation

### DIFF
--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -142,7 +142,7 @@ func TestLockTime(t *testing.T) {
 		val := sb.MakeNewValidator(pub)
 		sb.UpdateValidator(val)
 
-		sb.AcceptTestSortition = true
+		sb.TestAcceptSortition = true
 		pld := &payload.SortitionPayload{
 			Address: pub.Address(),
 			Proof:   sortition.GenerateRandomProof(),

--- a/execution/executor/bond.go
+++ b/execution/executor/bond.go
@@ -77,6 +77,7 @@ func (e *BondExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 	receiverVal.AddToStake(pld.Stake)
 	receiverVal.UpdateLastBondingHeight(sb.CurrentHeight())
 
+	sb.UpdatePowerDelta(pld.Stake)
 	sb.UpdateAccount(pld.Sender, senderAcc)
 	sb.UpdateValidator(receiverVal)
 

--- a/execution/executor/sortition_test.go
+++ b/execution/executor/sortition_test.go
@@ -33,7 +33,7 @@ func TestExecuteSortitionTx(t *testing.T) {
 
 	t.Run("Should fail, Invalid address", func(t *testing.T) {
 		trx := tx.NewSortitionTx(tStamp500000, 1, crypto.GenerateTestAddress(), proof)
-		tSandbox.AcceptTestSortition = true
+		tSandbox.TestAcceptSortition = true
 		assert.Equal(t, errors.Code(exe.Execute(trx, tSandbox)), errors.ErrInvalidAddress)
 	})
 
@@ -41,7 +41,7 @@ func TestExecuteSortitionTx(t *testing.T) {
 	tSandbox.UpdateValidator(newVal)
 	t.Run("Should fail, Bonding period", func(t *testing.T) {
 		trx := tx.NewSortitionTx(tStamp500000, newVal.Sequence()+1, newVal.Address(), proof)
-		tSandbox.AcceptTestSortition = true
+		tSandbox.TestAcceptSortition = true
 		assert.Equal(t, errors.Code(exe.Execute(trx, tSandbox)), errors.ErrInvalidHeight)
 	})
 
@@ -49,25 +49,25 @@ func TestExecuteSortitionTx(t *testing.T) {
 
 	t.Run("Should fail, Invalid sequence", func(t *testing.T) {
 		trx := tx.NewSortitionTx(tStamp500000, newVal.Sequence()+2, newVal.Address(), proof)
-		tSandbox.AcceptTestSortition = true
+		tSandbox.TestAcceptSortition = true
 		assert.Equal(t, errors.Code(exe.Execute(trx, tSandbox)), errors.ErrInvalidSequence)
 	})
 
 	t.Run("Should fail, Invalid proof", func(t *testing.T) {
 		trx := tx.NewSortitionTx(tStamp500000, newVal.Sequence()+1, newVal.Address(), proof)
-		tSandbox.AcceptTestSortition = false
+		tSandbox.TestAcceptSortition = false
 		assert.Equal(t, errors.Code(exe.Execute(trx, tSandbox)), errors.ErrInvalidProof)
 	})
 
 	t.Run("Should fail, Committee has free seats and validator is in the committee", func(t *testing.T) {
 		trx := tx.NewSortitionTx(tStamp500000, existingVal.Sequence()+1, existingVal.Address(), proof)
-		tSandbox.AcceptTestSortition = true
+		tSandbox.TestAcceptSortition = true
 		assert.Equal(t, errors.Code(exe.Execute(trx, tSandbox)), errors.ErrInvalidTx)
 	})
 
 	t.Run("Should be ok", func(t *testing.T) {
 		trx := tx.NewSortitionTx(tStamp500000, newVal.Sequence()+1, newVal.Address(), proof)
-		tSandbox.AcceptTestSortition = true
+		tSandbox.TestAcceptSortition = true
 		assert.NoError(t, exe.Execute(trx, tSandbox))
 
 		// Execute again, should fail
@@ -88,7 +88,7 @@ func TestSortitionNonStrictMode(t *testing.T) {
 	val := tSandbox.TestStore.RandomTestVal()
 	proof := sortition.GenerateRandomProof()
 
-	tSandbox.AcceptTestSortition = true
+	tSandbox.TestAcceptSortition = true
 	trx := tx.NewSortitionTx(tStamp500000, val.Sequence(), val.Address(), proof)
 	assert.Error(t, exe1.Execute(trx, tSandbox))
 	assert.NoError(t, exe2.Execute(trx, tSandbox))
@@ -119,7 +119,7 @@ func TestChangePower1(t *testing.T) {
 	proof3 := sortition.GenerateRandomProof()
 
 	tSandbox.TestParams.CommitteeSize = 4
-	tSandbox.AcceptTestSortition = true
+	tSandbox.TestAcceptSortition = true
 	trx1 := tx.NewSortitionTx(tStamp500000, val1.Sequence()+1, val1.Address(), proof1)
 	assert.NoError(t, exe.Execute(trx1, tSandbox))
 
@@ -162,7 +162,7 @@ func TestChangePower2(t *testing.T) {
 	proof4 := sortition.GenerateRandomProof()
 
 	tSandbox.TestParams.CommitteeSize = 7
-	tSandbox.AcceptTestSortition = true
+	tSandbox.TestAcceptSortition = true
 	trx1 := tx.NewSortitionTx(tStamp500000, val1.Sequence()+1, val1.Address(), proof1)
 	assert.NoError(t, exe.Execute(trx1, tSandbox))
 
@@ -196,7 +196,7 @@ func TestOldestDidNotPropose(t *testing.T) {
 	}
 
 	tSandbox.TestParams.CommitteeSize = 7
-	tSandbox.AcceptTestSortition = true
+	tSandbox.TestAcceptSortition = true
 
 	stamp := tStamp500000
 	for i := 0; i < 8; i = i + 2 {

--- a/execution/executor/unbond.go
+++ b/execution/executor/unbond.go
@@ -53,6 +53,11 @@ func (e *UnbondExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 
 	val.IncSequence()
 	val.UpdateUnbondingHeight(sb.CurrentHeight())
+
+	// At this point, the validator's power is zero.
+	// However, we know the validator's stake.
+	// So, we can update the power delta with the negative of the validator's stake.
+	sb.UpdatePowerDelta(-1 * val.Power())
 	sb.UpdateValidator(val)
 
 	return nil

--- a/execution/executor/unbond_test.go
+++ b/execution/executor/unbond_test.go
@@ -15,6 +15,7 @@ func TestExecuteUnbondTx(t *testing.T) {
 	exe := NewUnbondExecutor(true)
 
 	pub, _ := bls.GenerateTestKeyPair()
+	valAddr := pub.Address()
 	val := tSandbox.MakeNewValidator(pub)
 	tSandbox.UpdateValidator(val)
 
@@ -24,7 +25,7 @@ func TestExecuteUnbondTx(t *testing.T) {
 	})
 
 	t.Run("Should fail, Invalid sequence", func(t *testing.T) {
-		trx := tx.NewUnbondTx(tStamp500000, val.Sequence()+2, pub.Address(), "invalid sequence")
+		trx := tx.NewUnbondTx(tStamp500000, val.Sequence()+2, valAddr, "invalid sequence")
 		assert.Equal(t, errors.Code(exe.Execute(trx, tSandbox)), errors.ErrInvalidSequence)
 	})
 
@@ -45,7 +46,7 @@ func TestExecuteUnbondTx(t *testing.T) {
 	})
 
 	t.Run("Ok", func(t *testing.T) {
-		trx := tx.NewUnbondTx(tStamp500000, val.Sequence()+1, pub.Address(), "Ok")
+		trx := tx.NewUnbondTx(tStamp500000, val.Sequence()+1, valAddr, "Ok")
 
 		assert.NoError(t, exe.Execute(trx, tSandbox))
 
@@ -53,9 +54,10 @@ func TestExecuteUnbondTx(t *testing.T) {
 		assert.Error(t, exe.Execute(trx, tSandbox))
 	})
 
-	assert.Zero(t, tSandbox.Validator(pub.Address()).Stake())
-	assert.Zero(t, tSandbox.Validator(pub.Address()).Power())
-	assert.Equal(t, tSandbox.Validator(pub.Address()).UnbondingHeight(), tSandbox.CurrentHeight())
+	assert.Zero(t, tSandbox.Validator(valAddr).Stake())
+	assert.Zero(t, tSandbox.Validator(valAddr).Power())
+	assert.Equal(t, tSandbox.Validator(valAddr).UnbondingHeight(), tSandbox.CurrentHeight())
+	assert.Equal(t, tSandbox.PowerDelta(), -1*val.Stake())
 	assert.Zero(t, exe.Fee())
 
 	checkTotalCoin(t, 0)

--- a/sandbox/interface.go
+++ b/sandbox/interface.go
@@ -20,6 +20,8 @@ type Sandbox interface {
 	Validator(crypto.Address) *validator.Validator
 	MakeNewValidator(*bls.PublicKey) *validator.Validator
 	UpdateValidator(*validator.Validator)
+	UpdatePowerDelta(delta int64)
+	PowerDelta() int64
 
 	VerifyProof(hash.Stamp, sortition.Proof, *validator.Validator) bool
 	Committee() committee.Reader

--- a/sandbox/mock.go
+++ b/sandbox/mock.go
@@ -21,7 +21,8 @@ type MockSandbox struct {
 	TestStore            *store.MockStore
 	TestCommittee        committee.Committee
 	TestCommitteeSigners []crypto.Signer
-	AcceptTestSortition  bool
+	TestAcceptSortition  bool
+	TestPowerDelta       int64
 }
 
 func MockingSandbox() *MockSandbox {
@@ -97,7 +98,12 @@ func (m *MockSandbox) IterateValidators(consumer func(*validator.Validator, bool
 func (m *MockSandbox) Committee() committee.Reader {
 	return m.TestCommittee
 }
-
+func (m *MockSandbox) UpdatePowerDelta(delta int64) {
+	m.TestPowerDelta += delta
+}
+func (m *MockSandbox) PowerDelta() int64 {
+	return m.TestPowerDelta
+}
 func (m *MockSandbox) VerifyProof(hash.Stamp, sortition.Proof, *validator.Validator) bool {
-	return m.AcceptTestSortition
+	return m.TestAcceptSortition
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -585,7 +585,7 @@ func TestLoadState(t *testing.T) {
 	assert.Equal(t, tState1.store.TotalValidators(), st1Load.(*state).store.TotalValidators())
 	assert.Equal(t, tState1.committee.Committers(), st1Load.(*state).committee.Committers())
 	assert.Equal(t, tState1.committee.TotalPower(), st1Load.(*state).committee.TotalPower())
-	assert.Equal(t, tState1.TotalPower(), st1Load.(*state).totalPower())
+	assert.Equal(t, tState1.TotalPower(), st1Load.(*state).TotalPower())
 	assert.Equal(t, tState1.store.TotalAccounts(), int32(5))
 
 	require.NoError(t, st1Load.CommitBlock(6, b6, c6))

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -151,7 +151,7 @@ func TestPrepareBlockTransactions(t *testing.T) {
 		crypto.GenerateTestAddress(), 1000, 1000, "withdraw-tx")
 	val2Signer.SignMsg(withdrawTx)
 
-	tSandbox.AcceptTestSortition = true
+	tSandbox.TestAcceptSortition = true
 	sortitionTx := tx.NewSortitionTx(block1000000.Stamp(), val3.Sequence()+1, val3.Address(),
 		sortition.GenerateRandomProof())
 	val3Signer.SignMsg(sortitionTx)


### PR DESCRIPTION
## Description

Prior to this PR, the total power (the total staked coins) was calculated at each height by iterating over all validators and summing up the power (stakes). This was not an efficient method for calculating total power.

With this PR, a more efficient approach has been implemented. Now, whenever a validator bonds or unbonds a stake, we record this as a power delta (change) and apply it to the total power. This removes the need for iterating over all validators at every height, thereby optimizing the total power calculation process.