### PR TITLE
chore: statically link release binaries

### DIFF
--- a/.github/releasers/releaser_cli.sh
+++ b/.github/releasers/releaser_cli.sh
@@ -31,8 +31,8 @@ for OS_ARCH in \
         EXE=".exe"
     fi
 
-    GOOS=${OS} GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-daemon${EXE} ./cmd/daemon
-    GOOS=${OS} GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-wallet${EXE} ./cmd/wallet
+    CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-daemon${EXE} ./cmd/daemon
+    CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-wallet${EXE} ./cmd/wallet
 
     cd ${BUILD_DIR}
     if [ $OS = "windows" ]; then

--- a/.github/releasers/releaser_gui_linux.sh
+++ b/.github/releasers/releaser_gui_linux.sh
@@ -15,8 +15,8 @@ mkdir ${PACKAGE_DIR}
 echo "Building the binaries"
 
 cd ${ROOT_DIR}
-go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-daemon ./cmd/daemon
-go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-wallet ./cmd/wallet
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-daemon ./cmd/daemon
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-wallet ./cmd/wallet
 go build -ldflags "-s -w" -trimpath -tags gtk -o ${BUILD_DIR}/pactus-gui ./cmd/gtk
 
 # Moving binaries to package directory

--- a/.github/releasers/releaser_gui_macos.sh
+++ b/.github/releasers/releaser_gui_macos.sh
@@ -15,8 +15,8 @@ mkdir ${PACKAGE_DIR}
 echo "Building the binaries"
 
 cd ${ROOT_DIR}
-go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-daemon ./cmd/daemon
-go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-wallet ./cmd/wallet
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-daemon ./cmd/daemon
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-wallet ./cmd/wallet
 go build -ldflags "-s -w" -trimpath -tags gtk -o ${BUILD_DIR}/pactus-gui ./cmd/gtk
 
 

--- a/.github/releasers/releaser_gui_windows.sh
+++ b/.github/releasers/releaser_gui_windows.sh
@@ -17,8 +17,8 @@ echo "Building the binaries"
 # This fixes a bug in pkgconfig: invalid flag in pkg-config --libs: -Wl,-luuid
 sed -i -e 's/-Wl,-luuid/-luuid/g' /mingw64/lib/pkgconfig/gdk-3.0.pc
 
-go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-daemon.exe ./cmd/daemon
-go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-wallet.exe ./cmd/wallet
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-daemon.exe ./cmd/daemon
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-wallet.exe ./cmd/wallet
 go build -ldflags "-s -w -H windowsgui" -trimpath -tags gtk -o ${BUILD_DIR}/pactus-gui.exe ./cmd/gtk
 
 # Copying the neccesary libraries


### PR DESCRIPTION
## Description

Set `CGO_ENABLED=0` to statically link the release binaries. 
It makes the application more portable without any dependencies.

## Related issue(s)

It should address #545 
