### PR TITLE
style: rename ParsMessage to ParseMessage

### DIFF
--- a/sync/handler.go
+++ b/sync/handler.go
@@ -7,6 +7,6 @@ import (
 )
 
 type messageHandler interface {
-	ParsMessage(message.Message, peer.ID) error
+	ParseMessage(message.Message, peer.ID) error
 	PrepareBundle(message.Message) *bundle.Bundle
 }

--- a/sync/handler_block_announce.go
+++ b/sync/handler_block_announce.go
@@ -16,7 +16,7 @@ func newBlockAnnounceHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *blockAnnounceHandler) ParsMessage(m message.Message, initiator peer.ID) error {
+func (handler *blockAnnounceHandler) ParseMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.BlockAnnounceMessage)
 	handler.logger.Trace("parsing BlockAnnounce message", "message", msg)
 

--- a/sync/handler_blocks_request.go
+++ b/sync/handler_blocks_request.go
@@ -18,7 +18,7 @@ func newBlocksRequestHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *blocksRequestHandler) ParsMessage(m message.Message, initiator peer.ID) error {
+func (handler *blocksRequestHandler) ParseMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.BlocksRequestMessage)
 	handler.logger.Trace("parsing BlocksRequest message", "message", msg)
 

--- a/sync/handler_blocks_response.go
+++ b/sync/handler_blocks_response.go
@@ -17,7 +17,7 @@ func newBlocksResponseHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *blocksResponseHandler) ParsMessage(m message.Message, initiator peer.ID) error {
+func (handler *blocksResponseHandler) ParseMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.BlocksResponseMessage)
 	handler.logger.Trace("parsing BlocksResponse message", "message", msg)
 

--- a/sync/handler_heart_beat.go
+++ b/sync/handler_heart_beat.go
@@ -16,7 +16,7 @@ func newHeartBeatHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *heartBeatHandler) ParsMessage(m message.Message, initiator peer.ID) error {
+func (handler *heartBeatHandler) ParseMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.HeartBeatMessage)
 	handler.logger.Trace("parsing HeartBeat message", "message", msg)
 

--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -19,7 +19,7 @@ func newHelloHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *helloHandler) ParsMessage(m message.Message, initiator peer.ID) error {
+func (handler *helloHandler) ParseMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.HelloMessage)
 	handler.logger.Trace("parsing Hello message", "message", msg)
 

--- a/sync/handler_proposal.go
+++ b/sync/handler_proposal.go
@@ -16,7 +16,7 @@ func newProposalHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *proposalHandler) ParsMessage(m message.Message, _ peer.ID) error {
+func (handler *proposalHandler) ParseMessage(m message.Message, _ peer.ID) error {
 	msg := m.(*message.ProposalMessage)
 	handler.logger.Trace("parsing Proposal message", "message", msg)
 

--- a/sync/handler_query_proposal.go
+++ b/sync/handler_query_proposal.go
@@ -17,7 +17,7 @@ func newQueryProposalHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *queryProposalHandler) ParsMessage(m message.Message, initiator peer.ID) error {
+func (handler *queryProposalHandler) ParseMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.QueryProposalMessage)
 	handler.logger.Trace("parsing QueryProposal message", "message", msg)
 

--- a/sync/handler_query_votes.go
+++ b/sync/handler_query_votes.go
@@ -17,7 +17,7 @@ func newQueryVotesHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *queryVotesHandler) ParsMessage(m message.Message, initiator peer.ID) error {
+func (handler *queryVotesHandler) ParseMessage(m message.Message, initiator peer.ID) error {
 	msg := m.(*message.QueryVotesMessage)
 	handler.logger.Trace("parsing QueryVotes message", "message", msg)
 

--- a/sync/handler_transactions.go
+++ b/sync/handler_transactions.go
@@ -16,7 +16,7 @@ func newTransactionsHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *transactionsHandler) ParsMessage(m message.Message, _ peer.ID) error {
+func (handler *transactionsHandler) ParseMessage(m message.Message, _ peer.ID) error {
 	msg := m.(*message.TransactionsMessage)
 	handler.logger.Trace("parsing Transactions message", "message", msg)
 

--- a/sync/handler_vote.go
+++ b/sync/handler_vote.go
@@ -16,7 +16,7 @@ func newVoteHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *voteHandler) ParsMessage(m message.Message, _ peer.ID) error {
+func (handler *voteHandler) ParseMessage(m message.Message, _ peer.ID) error {
 	msg := m.(*message.VoteMessage)
 	handler.logger.Trace("parsing Vote message", "message", msg)
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -232,7 +232,7 @@ func (sync *synchronizer) processIncomingBundle(bdl *bundle.Bundle) error {
 		return errors.Errorf(errors.ErrInvalidMessage, "invalid message type: %v", bdl.Message.Type())
 	}
 
-	return h.ParsMessage(bdl.Message, bdl.Initiator)
+	return h.ParseMessage(bdl.Message, bdl.Initiator)
 }
 
 func (sync *synchronizer) Fingerprint() string {


### PR DESCRIPTION
## Description

there was a typo about ParsMessage in messageHandler interface which I've fixed and converted to ParseMessage
