### PR TITLE
fix: incorrect handler for validator by number

### DIFF
--- a/www/http/server.go
+++ b/www/http/server.go
@@ -71,7 +71,7 @@ func (s *Server) StartServer(grpcServer string) error {
 	s.router.HandleFunc("/account/address/{address}", s.GetAccountHandler)
 	s.router.HandleFunc("/account/number/{number}", s.GetAccountByNumberHandler)
 	s.router.HandleFunc("/validator/address/{address}", s.GetValidatorHandler)
-	s.router.HandleFunc("/validator/number/{number}", s.GetAccountByNumberHandler)
+	s.router.HandleFunc("/validator/number/{number}", s.GetValidatorByNumberHandler)
 	http.Handle("/", handlers.RecoveryHandler()(s.router))
 
 	l, err := net.Listen("tcp", s.config.Listen)


### PR DESCRIPTION
## Description
the route for getValidatorByNumber is using getAccountByNumber handler
I just fixed it!
