### PR TITLE
fix: missing swagger ui for grpc get account by number

### DIFF
--- a/www/grpc/grpc-gateway.config.yaml
+++ b/www/grpc/grpc-gateway.config.yaml
@@ -16,6 +16,9 @@ http:
     - selector: pactus.Blockchain.GetAccount
       get: "/v1/blockchain/account/address/{address}"
 
+    - selector: pactus.Blockchain.GetAccountByNumber
+      get: "/v1/blockchain/account/number/{number}"
+
     - selector: pactus.Blockchain.GetValidators
       get: "/v1/blockchain/validators"
 


### PR DESCRIPTION
## Description
add the missing API `GetAccountByNumber` in grpc-gateway.config.yaml

## Related issue
#527 
