### PR TITLE
fix: Set Context properly 

### DIFF
--- a/network/mdns_test.go
+++ b/network/mdns_test.go
@@ -10,15 +10,15 @@ import (
 
 func TestMDNS(t *testing.T) {
 	conf1 := testConfig()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
 	conf1.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 	conf1.EnableMdns = true
-	net1, _ := newNetwork(ctx, cancel, conf1, nil)
+	net1, _ := newNetwork(ctx, conf1, nil)
 
 	conf2 := testConfig()
 	conf2.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 	conf2.EnableMdns = true
-	net2, _ := newNetwork(ctx, cancel, conf2, nil)
+	net2, _ := newNetwork(ctx, conf2, nil)
 
 	assert.NoError(t, net1.Start())
 	time.Sleep(250 * time.Millisecond)

--- a/network/mdns_test.go
+++ b/network/mdns_test.go
@@ -13,12 +13,12 @@ func TestMDNS(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	conf1.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 	conf1.EnableMdns = true
-	net1, _ := newNetwork(conf1, nil, ctx, cancel)
+	net1, _ := newNetwork(ctx, cancel, conf1, nil)
 
 	conf2 := testConfig()
 	conf2.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 	conf2.EnableMdns = true
-	net2, _ := newNetwork(conf2, nil, ctx, cancel)
+	net2, _ := newNetwork(ctx, cancel, conf2, nil)
 
 	assert.NoError(t, net1.Start())
 	time.Sleep(250 * time.Millisecond)

--- a/network/mdns_test.go
+++ b/network/mdns_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,14 +10,15 @@ import (
 
 func TestMDNS(t *testing.T) {
 	conf1 := testConfig()
+	ctx, cancel := context.WithCancel(context.Background())
 	conf1.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 	conf1.EnableMdns = true
-	net1, _ := newNetwork(conf1, nil)
+	net1, _ := newNetwork(conf1, nil, ctx, cancel)
 
 	conf2 := testConfig()
 	conf2.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 	conf2.EnableMdns = true
-	net2, _ := newNetwork(conf2, nil)
+	net2, _ := newNetwork(conf2, nil, ctx, cancel)
 
 	assert.NoError(t, net1.Start())
 	time.Sleep(250 * time.Millisecond)

--- a/network/network.go
+++ b/network/network.go
@@ -26,7 +26,6 @@ type network struct {
 	// We should remove it from here and pass it as first argument of functions
 	// Adding these linter later:  contextcheck and containedctx
 	ctx            context.Context
-	cancel         func()
 	config         *Config
 	host           lp2phost.Host
 	mdns           *mdnsService
@@ -71,11 +70,11 @@ func loadOrCreateKey(path string) (lp2pcrypto.PrivKey, error) {
 	return key, nil
 }
 
-func NewNetwork(ctx context.Context, cancel func(), conf *Config) (Network, error) {
-	return newNetwork(ctx, cancel, conf, []lp2p.Option{})
+func NewNetwork(ctx context.Context, conf *Config) (Network, error) {
+	return newNetwork(ctx, conf, []lp2p.Option{})
 }
 
-func newNetwork(ctx context.Context, cancel func(), conf *Config, opts []lp2p.Option) (*network, error) {
+func newNetwork(ctx context.Context, conf *Config, opts []lp2p.Option) (*network, error) {
 	networkKey, err := loadOrCreateKey(conf.NetworkKey)
 	if err != nil {
 		return nil, errors.Errorf(errors.ErrNetwork, err.Error())
@@ -125,7 +124,6 @@ func newNetwork(ctx context.Context, cancel func(), conf *Config, opts []lp2p.Op
 
 	n := &network{
 		ctx:          ctx,
-		cancel:       cancel,
 		config:       conf,
 		host:         host,
 		eventChannel: make(chan Event, 100),
@@ -176,8 +174,6 @@ func (n *network) Start() error {
 }
 
 func (n *network) Stop() {
-	n.cancel()
-
 	if n.mdns != nil {
 		n.mdns.Stop()
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -126,7 +126,7 @@ func newNetwork(conf *Config, opts []lp2p.Option) (*network, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	n := &network{
-		ctx:          ctx,
+		ctx:          ctx, //
 		cancel:       cancel,
 		config:       conf,
 		host:         host,

--- a/network/network.go
+++ b/network/network.go
@@ -71,11 +71,11 @@ func loadOrCreateKey(path string) (lp2pcrypto.PrivKey, error) {
 	return key, nil
 }
 
-func NewNetwork(conf *Config, ctx context.Context, cancel func()) (Network, error) {
-	return newNetwork(conf, []lp2p.Option{}, ctx, cancel)
+func NewNetwork(ctx context.Context, cancel func(), conf *Config) (Network, error) {
+	return newNetwork(ctx, cancel, conf, []lp2p.Option{})
 }
 
-func newNetwork(conf *Config, opts []lp2p.Option, ctx context.Context, cancel func()) (*network, error) {
+func newNetwork(ctx context.Context, cancel func(), conf *Config, opts []lp2p.Option) (*network, error) {
 	networkKey, err := loadOrCreateKey(conf.NetworkKey)
 	if err != nil {
 		return nil, errors.Errorf(errors.ErrNetwork, err.Error())

--- a/network/network.go
+++ b/network/network.go
@@ -71,11 +71,11 @@ func loadOrCreateKey(path string) (lp2pcrypto.PrivKey, error) {
 	return key, nil
 }
 
-func NewNetwork(conf *Config) (Network, error) {
-	return newNetwork(conf, []lp2p.Option{})
+func NewNetwork(conf *Config, ctx context.Context, cancel func()) (Network, error) {
+	return newNetwork(conf, []lp2p.Option{}, ctx, cancel)
 }
 
-func newNetwork(conf *Config, opts []lp2p.Option) (*network, error) {
+func newNetwork(conf *Config, opts []lp2p.Option, ctx context.Context, cancel func()) (*network, error) {
 	networkKey, err := loadOrCreateKey(conf.NetworkKey)
 	if err != nil {
 		return nil, errors.Errorf(errors.ErrNetwork, err.Error())
@@ -123,10 +123,8 @@ func newNetwork(conf *Config, opts []lp2p.Option) (*network, error) {
 		return nil, errors.Errorf(errors.ErrNetwork, err.Error())
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-
 	n := &network{
-		ctx:          ctx, //
+		ctx:          ctx,
 		cancel:       cancel,
 		config:       conf,
 		host:         host,

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -41,8 +41,8 @@ func makeTestRelay(t *testing.T) host.Host {
 }
 
 func makeTestNetwork(t *testing.T, conf *Config, opts []lp2p.Option) *network {
-	ctx, cancel := context.WithCancel(context.Background())
-	net, err := newNetwork(ctx, cancel, conf, opts)
+	ctx := context.Background()
+	net, err := newNetwork(ctx, conf, opts)
 	assert.NoError(t, err)
 
 	assert.NoError(t, net.Start())
@@ -106,8 +106,8 @@ func readData(t *testing.T, r io.ReadCloser, len int) []byte {
 }
 
 func TestStoppingNetwork(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	net, err := NewNetwork(ctx, cancel, testConfig())
+	ctx := context.Background()
+	net, err := NewNetwork(ctx, testConfig())
 	assert.NoError(t, err)
 
 	assert.NoError(t, net.Start())
@@ -304,8 +304,8 @@ func TestNetwork(t *testing.T) {
 }
 
 func TestInvalidTopic(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	net, err := NewNetwork(ctx, cancel, testConfig())
+	ctx := context.Background()
+	net, err := NewNetwork(ctx, testConfig())
 	assert.NoError(t, err)
 
 	msg := []byte("test-invalid-topic")
@@ -317,13 +317,13 @@ func TestInvalidRelayAddress(t *testing.T) {
 	conf := testConfig()
 	conf.EnableRelay = true
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
 
 	conf.RelayAddrs = []string{"127.0.0.1:4001"}
-	_, err := NewNetwork(ctx, cancel, conf)
+	_, err := NewNetwork(ctx, conf)
 	assert.Error(t, err)
 
 	conf.RelayAddrs = []string{"/ip4/127.0.0.1/tcp/4001"}
-	_, err = NewNetwork(ctx, cancel, conf)
+	_, err = NewNetwork(ctx, conf)
 	assert.Error(t, err)
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -40,7 +41,8 @@ func makeTestRelay(t *testing.T) host.Host {
 }
 
 func makeTestNetwork(t *testing.T, conf *Config, opts []lp2p.Option) *network {
-	net, err := newNetwork(conf, opts)
+	ctx, cancel := context.WithCancel(context.Background())
+	net, err := newNetwork(conf, opts, ctx, cancel)
 	assert.NoError(t, err)
 
 	assert.NoError(t, net.Start())
@@ -104,7 +106,8 @@ func readData(t *testing.T, r io.ReadCloser, len int) []byte {
 }
 
 func TestStoppingNetwork(t *testing.T) {
-	net, err := NewNetwork(testConfig())
+	ctx, cancel := context.WithCancel(context.Background())
+	net, err := NewNetwork(testConfig(), ctx, cancel)
 	assert.NoError(t, err)
 
 	assert.NoError(t, net.Start())
@@ -301,7 +304,8 @@ func TestNetwork(t *testing.T) {
 }
 
 func TestInvalidTopic(t *testing.T) {
-	net, err := NewNetwork(testConfig())
+	ctx, cancel := context.WithCancel(context.Background())
+	net, err := NewNetwork(testConfig(), ctx, cancel)
 	assert.NoError(t, err)
 
 	msg := []byte("test-invalid-topic")
@@ -313,11 +317,13 @@ func TestInvalidRelayAddress(t *testing.T) {
 	conf := testConfig()
 	conf.EnableRelay = true
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	conf.RelayAddrs = []string{"127.0.0.1:4001"}
-	_, err := NewNetwork(conf)
+	_, err := NewNetwork(conf, ctx, cancel)
 	assert.Error(t, err)
 
 	conf.RelayAddrs = []string{"/ip4/127.0.0.1/tcp/4001"}
-	_, err = NewNetwork(conf)
+	_, err = NewNetwork(conf, ctx, cancel)
 	assert.Error(t, err)
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -42,7 +42,7 @@ func makeTestRelay(t *testing.T) host.Host {
 
 func makeTestNetwork(t *testing.T, conf *Config, opts []lp2p.Option) *network {
 	ctx, cancel := context.WithCancel(context.Background())
-	net, err := newNetwork(conf, opts, ctx, cancel)
+	net, err := newNetwork(ctx, cancel, conf, opts)
 	assert.NoError(t, err)
 
 	assert.NoError(t, net.Start())
@@ -107,7 +107,7 @@ func readData(t *testing.T, r io.ReadCloser, len int) []byte {
 
 func TestStoppingNetwork(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	net, err := NewNetwork(testConfig(), ctx, cancel)
+	net, err := NewNetwork(ctx, cancel, testConfig())
 	assert.NoError(t, err)
 
 	assert.NoError(t, net.Start())
@@ -305,7 +305,7 @@ func TestNetwork(t *testing.T) {
 
 func TestInvalidTopic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	net, err := NewNetwork(testConfig(), ctx, cancel)
+	net, err := NewNetwork(ctx, cancel, testConfig())
 	assert.NoError(t, err)
 
 	msg := []byte("test-invalid-topic")
@@ -320,10 +320,10 @@ func TestInvalidRelayAddress(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	conf.RelayAddrs = []string{"127.0.0.1:4001"}
-	_, err := NewNetwork(conf, ctx, cancel)
+	_, err := NewNetwork(ctx, cancel, conf)
 	assert.Error(t, err)
 
 	conf.RelayAddrs = []string{"/ip4/127.0.0.1/tcp/4001"}
-	_, err = NewNetwork(conf, ctx, cancel)
+	_, err = NewNetwork(ctx, cancel, conf)
 	assert.Error(t, err)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -49,8 +49,8 @@ func NewNode(genDoc *genesis.Genesis, conf *config.Config,
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	
-	network, err := network.NewNetwork(conf.Network)
+
+	network, err := network.NewNetwork(conf.Network, ctx, cancel)
 	if err != nil {
 		return nil, err
 	}
@@ -74,14 +74,14 @@ func NewNode(genDoc *genesis.Genesis, conf *config.Config,
 
 	consMgr := consensus.NewManager(conf.Consensus, state, signers, rewardAddrs, messageCh)
 
-	sync, err := sync.NewSynchronizer(conf.Sync, signers, state, consMgr, network, messageCh)
+	sync, err := sync.NewSynchronizer(conf.Sync, signers, state, consMgr, network, messageCh, ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	http := http.NewServer(conf.HTTP)
-	grpc := grpc.NewServer(conf.GRPC, state, sync, consMgr)
-	nanomsg := nanomsg.NewServer(conf.Nanomsg, eventCh)
+	http := http.NewServer(conf.HTTP, ctx)
+	grpc := grpc.NewServer(conf.GRPC, state, sync, consMgr, ctx)
+	nanomsg := nanomsg.NewServer(conf.Nanomsg, eventCh, ctx)
 
 	node := &Node{
 		config:     conf,

--- a/node/node.go
+++ b/node/node.go
@@ -48,7 +48,6 @@ func NewNode(genDoc *genesis.Genesis, conf *config.Config,
 		"network", genDoc.ChainType())
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	network, err := network.NewNetwork(conf.Network, ctx, cancel)
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"time"
 
 	"github.com/pactus-project/pactus/config"
@@ -46,6 +47,9 @@ func NewNode(genDoc *genesis.Genesis, conf *config.Config,
 		"version", version.Version(),
 		"network", genDoc.ChainType())
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	
 	network, err := network.NewNetwork(conf.Network)
 	if err != nil {
 		return nil, err

--- a/node/node.go
+++ b/node/node.go
@@ -49,7 +49,7 @@ func NewNode(genDoc *genesis.Genesis, conf *config.Config,
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	network, err := network.NewNetwork(conf.Network, ctx, cancel)
+	network, err := network.NewNetwork(ctx, cancel, conf.Network)
 	if err != nil {
 		return nil, err
 	}
@@ -73,14 +73,14 @@ func NewNode(genDoc *genesis.Genesis, conf *config.Config,
 
 	consMgr := consensus.NewManager(conf.Consensus, state, signers, rewardAddrs, messageCh)
 
-	sync, err := sync.NewSynchronizer(conf.Sync, signers, state, consMgr, network, messageCh, ctx)
+	sync, err := sync.NewSynchronizer(ctx, conf.Sync, signers, state, consMgr, network, messageCh)
 	if err != nil {
 		return nil, err
 	}
 
-	http := http.NewServer(conf.HTTP, ctx)
-	grpc := grpc.NewServer(conf.GRPC, state, sync, consMgr, ctx)
-	nanomsg := nanomsg.NewServer(conf.Nanomsg, eventCh, ctx)
+	http := http.NewServer(ctx, conf.HTTP)
+	grpc := grpc.NewServer(ctx, conf.GRPC, state, sync, consMgr)
+	nanomsg := nanomsg.NewServer(ctx, conf.Nanomsg, eventCh)
 
 	node := &Node{
 		config:     conf,

--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -94,24 +94,24 @@ func TestSyncing(t *testing.T) {
 	networkBob.AddAnotherNetwork(networkAlice)
 	addBlocks(t, stateBob, 100)
 
-	sync1, err := NewSynchronizer(configAlice,
+	sync1, err := NewSynchronizer(ctx,
+		configAlice,
 		signersAlice,
 		stateAlice,
 		consMgrAlice,
 		networkAlice,
 		broadcastChAlice,
-		ctx,
 	)
 	assert.NoError(t, err)
 	syncAlice := sync1.(*synchronizer)
 
-	sync2, err := NewSynchronizer(configBob,
+	sync2, err := NewSynchronizer(ctx,
+		configBob,
 		signersBob,
 		stateBob,
 		consMgrBob,
 		networkBob,
 		broadcastChBob,
-		ctx,
 	)
 	assert.NoError(t, err)
 	syncBob := sync2.(*synchronizer)

--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -86,6 +87,8 @@ func TestSyncing(t *testing.T) {
 	networkAlice := network.MockingNetwork(ts, ts.RandomPeerID())
 	networkBob := network.MockingNetwork(ts, ts.RandomPeerID())
 
+	ctx := context.Background()
+
 	configBob.NodeNetwork = true
 	networkAlice.AddAnotherNetwork(networkBob)
 	networkBob.AddAnotherNetwork(networkAlice)
@@ -97,6 +100,7 @@ func TestSyncing(t *testing.T) {
 		consMgrAlice,
 		networkAlice,
 		broadcastChAlice,
+		ctx,
 	)
 	assert.NoError(t, err)
 	syncAlice := sync1.(*synchronizer)
@@ -107,6 +111,7 @@ func TestSyncing(t *testing.T) {
 		consMgrBob,
 		networkBob,
 		broadcastChBob,
+		ctx,
 	)
 	assert.NoError(t, err)
 	syncBob := sync2.(*synchronizer)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -52,9 +52,10 @@ func NewSynchronizer(
 	state state.Facade,
 	consMgr consensus.Manager,
 	net network.Network,
-	broadcastCh <-chan message.Message) (Synchronizer, error) {
+	broadcastCh <-chan message.Message,
+	ctx context.Context) (Synchronizer, error) {
 	sync := &synchronizer{
-		ctx:         context.Background(), // // TODO, set proper context
+		ctx:         ctx,
 		config:      conf,
 		signers:     signers,
 		state:       state,

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -54,7 +54,7 @@ func NewSynchronizer(
 	net network.Network,
 	broadcastCh <-chan message.Message) (Synchronizer, error) {
 	sync := &synchronizer{
-		ctx:         context.Background(), // TODO, set proper context
+		ctx:         context.Background(), // // TODO, set proper context
 		config:      conf,
 		signers:     signers,
 		state:       state,

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -47,13 +47,14 @@ type synchronizer struct {
 }
 
 func NewSynchronizer(
+	ctx context.Context,
 	conf *Config,
 	signers []crypto.Signer,
 	state state.Facade,
 	consMgr consensus.Manager,
 	net network.Network,
 	broadcastCh <-chan message.Message,
-	ctx context.Context) (Synchronizer, error) {
+) (Synchronizer, error) {
 	sync := &synchronizer{
 		ctx:         ctx,
 		config:      conf,

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -75,6 +76,7 @@ func setup(t *testing.T, config *Config) *testData {
 	consMgr, consMocks := consensus.MockingManager(ts, signers)
 	broadcastCh := make(chan message.Message, 1000)
 	network := network.MockingNetwork(ts, ts.RandomPeerID())
+	ctx := context.Background()
 
 	Sync, err := NewSynchronizer(config,
 		signers,
@@ -82,6 +84,7 @@ func setup(t *testing.T, config *Config) *testData {
 		consMgr,
 		network,
 		broadcastCh,
+		ctx,
 	)
 	assert.NoError(t, err)
 	sync := Sync.(*synchronizer)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -78,13 +78,13 @@ func setup(t *testing.T, config *Config) *testData {
 	network := network.MockingNetwork(ts, ts.RandomPeerID())
 	ctx := context.Background()
 
-	Sync, err := NewSynchronizer(config,
+	Sync, err := NewSynchronizer(ctx,
+		config,
 		signers,
 		state,
 		consMgr,
 		network,
 		broadcastCh,
-		ctx,
 	)
 	assert.NoError(t, err)
 	sync := Sync.(*synchronizer)

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -25,9 +25,9 @@ type Server struct {
 }
 
 func NewServer(conf *Config, state state.Facade, sync sync.Synchronizer,
-	consMgr consensus.ManagerReader) *Server {
+	consMgr consensus.ManagerReader, ctx context.Context) *Server {
 	return &Server{
-		ctx:     context.Background(),//
+		ctx:     ctx,
 		config:  conf,
 		state:   state,
 		sync:    sync,

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -27,7 +27,7 @@ type Server struct {
 func NewServer(conf *Config, state state.Facade, sync sync.Synchronizer,
 	consMgr consensus.ManagerReader) *Server {
 	return &Server{
-		ctx:     context.Background(),
+		ctx:     context.Background(),//
 		config:  conf,
 		state:   state,
 		sync:    sync,

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -24,8 +24,8 @@ type Server struct {
 	logger   *logger.Logger
 }
 
-func NewServer(conf *Config, state state.Facade, sync sync.Synchronizer,
-	consMgr consensus.ManagerReader, ctx context.Context) *Server {
+func NewServer(ctx context.Context, conf *Config, state state.Facade, sync sync.Synchronizer,
+	consMgr consensus.ManagerReader) *Server {
 	return &Server{
 		ctx:     ctx,
 		config:  conf,

--- a/www/http/http_test.go
+++ b/www/http/http_test.go
@@ -52,10 +52,10 @@ func setup(t *testing.T) *testData {
 		Listen: "[::]:0",
 	}
 
-	gRPCServer := grpc.NewServer(grpcConf, mockState, mockSync, mockConsMgr, ctx)
+	gRPCServer := grpc.NewServer(ctx, grpcConf, mockState, mockSync, mockConsMgr)
 	assert.NoError(t, gRPCServer.StartServer())
 
-	httpServer := NewServer(httpConf, ctx)
+	httpServer := NewServer(ctx, httpConf)
 	assert.NoError(t, httpServer.StartServer(gRPCServer.Address()))
 
 	tTestData = &testData{

--- a/www/http/http_test.go
+++ b/www/http/http_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -32,6 +33,8 @@ func setup(t *testing.T) *testData {
 		return tTestData
 	}
 
+	ctx := context.Background()
+
 	ts := testsuite.NewTestSuite(t)
 
 	mockState := state.MockingState(ts)
@@ -49,10 +52,10 @@ func setup(t *testing.T) *testData {
 		Listen: "[::]:0",
 	}
 
-	gRPCServer := grpc.NewServer(grpcConf, mockState, mockSync, mockConsMgr)
+	gRPCServer := grpc.NewServer(grpcConf, mockState, mockSync, mockConsMgr, ctx)
 	assert.NoError(t, gRPCServer.StartServer())
 
-	httpServer := NewServer(httpConf)
+	httpServer := NewServer(httpConf, ctx)
 	assert.NoError(t, httpServer.StartServer(gRPCServer.Address()))
 
 	tTestData = &testData{

--- a/www/http/server.go
+++ b/www/http/server.go
@@ -31,9 +31,9 @@ type Server struct {
 	logger      *logger.Logger
 }
 
-func NewServer(conf *Config) *Server {
+func NewServer(conf *Config, ctx context.Context) *Server {
 	return &Server{
-		ctx:    context.Background(),//
+		ctx:    ctx,
 		config: conf,
 		logger: logger.NewLogger("_http", nil),
 	}

--- a/www/http/server.go
+++ b/www/http/server.go
@@ -33,7 +33,7 @@ type Server struct {
 
 func NewServer(conf *Config) *Server {
 	return &Server{
-		ctx:    context.Background(),
+		ctx:    context.Background(),//
 		config: conf,
 		logger: logger.NewLogger("_http", nil),
 	}

--- a/www/http/server.go
+++ b/www/http/server.go
@@ -31,7 +31,7 @@ type Server struct {
 	logger      *logger.Logger
 }
 
-func NewServer(conf *Config, ctx context.Context) *Server {
+func NewServer(ctx context.Context, conf *Config) *Server {
 	return &Server{
 		ctx:    ctx,
 		config: conf,

--- a/www/nanomsg/server.go
+++ b/www/nanomsg/server.go
@@ -25,9 +25,9 @@ type Server struct {
 	seqNum    uint32
 }
 
-func NewServer(conf *Config, eventCh <-chan event.Event) *Server {
+func NewServer(conf *Config, eventCh <-chan event.Event, ctx context.Context) *Server {
 	return &Server{
-		ctx:     context.Background(),//
+		ctx:     ctx,
 		config:  conf,
 		logger:  logger.NewLogger("_nonomsg", nil),
 		eventCh: eventCh,

--- a/www/nanomsg/server.go
+++ b/www/nanomsg/server.go
@@ -25,7 +25,7 @@ type Server struct {
 	seqNum    uint32
 }
 
-func NewServer(conf *Config, eventCh <-chan event.Event, ctx context.Context) *Server {
+func NewServer(ctx context.Context, conf *Config, eventCh <-chan event.Event) *Server {
 	return &Server{
 		ctx:     ctx,
 		config:  conf,

--- a/www/nanomsg/server.go
+++ b/www/nanomsg/server.go
@@ -27,7 +27,7 @@ type Server struct {
 
 func NewServer(conf *Config, eventCh <-chan event.Event) *Server {
 	return &Server{
-		ctx:     context.Background(),
+		ctx:     context.Background(),//
 		config:  conf,
 		logger:  logger.NewLogger("_nonomsg", nil),
 		eventCh: eventCh,


### PR DESCRIPTION
## Description

This PR introduces a global context and passed it to all modules when the node starts. By shutting down the node, the context will be cancelled and all modules will receive the cancellation signal. 

## Related issue(s)

- Fixes #368 