### PR TITLE
feat: Connect disconnect libp2p

### DIFF
--- a/network/interface.go
+++ b/network/interface.go
@@ -26,8 +26,10 @@ func (t TopicID) String() string {
 type EventType int
 
 const (
-	EventTypeGossip EventType = 1
-	EventTypeStream EventType = 2
+	EventTypeGossip     EventType = 1
+	EventTypeStream     EventType = 2
+	EventTypeConnect    EventType = 3
+	EventTypeDisconnect EventType = 4
 )
 
 func (t EventType) String() string {
@@ -36,6 +38,10 @@ func (t EventType) String() string {
 		return "gossip-msg"
 	case EventTypeStream:
 		return "stream-msg"
+	case EventTypeConnect:
+		return "connect-peer"
+	case EventTypeDisconnect:
+		return "disconnect-peer"
 	}
 	return "invalid"
 }
@@ -66,6 +72,24 @@ type StreamMessage struct {
 
 func (*StreamMessage) Type() EventType {
 	return EventTypeStream
+}
+
+// ConnectEvent represents a peer connection event.
+type ConnectEvent struct {
+	PeerID lp2pcore.PeerID
+}
+
+func (*ConnectEvent) Type() EventType {
+	return EventTypeConnect
+}
+
+// DisconnectEvent represents a peer disconnection event.
+type DisconnectEvent struct {
+	PeerID lp2pcore.PeerID
+}
+
+func (*DisconnectEvent) Type() EventType {
+	return EventTypeDisconnect
 }
 
 type Network interface {

--- a/sync/peerset/peer_set.go
+++ b/sync/peerset/peer_set.go
@@ -29,6 +29,7 @@ type PeerSet struct {
 	sentBytes          map[message.Type]int64
 	receivedBytes      map[message.Type]int64
 	startedAt          time.Time
+	connectedPeers     []peer.ID
 }
 
 func NewPeerSet(sessionTimeout time.Duration) *PeerSet {
@@ -394,4 +395,20 @@ func (ps *PeerSet) StartedAt() time.Time {
 	defer ps.lk.RUnlock()
 
 	return ps.startedAt
+}
+
+func (ps *PeerSet) AddNewconnectedPeer(peerID peer.ID) {
+	ps.connectedPeers = append(ps.connectedPeers, peerID)
+}
+
+func (ps *PeerSet) DisconnectedPeer(peerID peer.ID) {
+	for i, p := range ps.connectedPeers {
+		if p == peerID {
+			// Remove the peer from the slice by swapping it with the last element
+			// and then reducing the slice length by one.
+			ps.connectedPeers[i] = ps.connectedPeers[len(ps.connectedPeers)-1]
+			ps.connectedPeers = ps.connectedPeers[:len(ps.connectedPeers)-1]
+			break
+		}
+	}
 }

--- a/sync/peerset/peer_set.go
+++ b/sync/peerset/peer_set.go
@@ -39,6 +39,7 @@ func NewPeerSet(sessionTimeout time.Duration) *PeerSet {
 		sessionTimeout: sessionTimeout,
 		sentBytes:      make(map[message.Type]int64),
 		receivedBytes:  make(map[message.Type]int64),
+		connectedPeers: []peer.ID{},
 		startedAt:      time.Now(),
 	}
 }
@@ -404,8 +405,6 @@ func (ps *PeerSet) AddNewconnectedPeer(peerID peer.ID) {
 func (ps *PeerSet) DisconnectedPeer(peerID peer.ID) {
 	for i, p := range ps.connectedPeers {
 		if p == peerID {
-			// Remove the peer from the slice by swapping it with the last element
-			// and then reducing the slice length by one.
 			ps.connectedPeers[i] = ps.connectedPeers[len(ps.connectedPeers)-1]
 			ps.connectedPeers = ps.connectedPeers[:len(ps.connectedPeers)-1]
 			break

--- a/sync/peerset/peer_set_test.go
+++ b/sync/peerset/peer_set_test.go
@@ -302,3 +302,20 @@ func TestRemoveExpiredSessions(t *testing.T) {
 	time.Sleep(time.Second)
 	assert.False(t, ps.HasAnyOpenSession())
 }
+
+func TestConnectedPeers(t *testing.T) {
+	ps := NewPeerSet(time.Second)
+	pid1 := peer.ID("peer1")
+	pid2 := peer.ID("peer2")
+
+	assert.Empty(t, ps.connectedPeers)
+
+	ps.AddNewconnectedPeer(pid1)
+	ps.AddNewconnectedPeer(pid2)
+	assert.Contains(t, ps.connectedPeers, pid1)
+	assert.Contains(t, ps.connectedPeers, pid2)
+
+	ps.DisconnectedPeer(pid1)
+	assert.NotContains(t, ps.connectedPeers, pid1)
+	assert.Contains(t, ps.connectedPeers, pid2)
+}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -34,8 +34,8 @@ type synchronizer struct {
 	config          *Config
 	signers         []crypto.Signer
 	state           state.Facade
-	consMgr         consensus.Manager
 	peerSet         *peerset.PeerSet
+	consMgr         consensus.Manager
 	firewall        *firewall.Firewall
 	cache           *cache.Cache
 	handlers        map[message.Type]messageHandler
@@ -219,6 +219,12 @@ func (sync *synchronizer) receiveLoop() {
 					sync.peerSet.IncreaseSendFailedCounter(se.Source)
 					sync.logger.Warn("error on closing stream", "err", err)
 				}
+			case network.EventTypeConnect:
+				ce := e.(*network.ConnectEvent)
+				sync.peerSet.AddNewconnectedPeer(ce.PeerID)
+			case network.EventTypeDisconnect:
+				de := e.(*network.DisconnectEvent)
+				sync.peerSet.AddNewconnectedPeer(de.PeerID)
 			}
 
 			err := sync.processIncomingBundle(bdl)


### PR DESCRIPTION
@b00f 

## Description

Regarding issue #622  , I made some updates to the peerSet struct which now includes `ConnectedPeers`. Additionally, I added `EventTypeConnect` and `EventTypeDisconnect` to the events. To handle the `ConnectedPeers`, 
I added two functions in `peer_set.go`:
 `AddNewconnectedPeer` and `DisconnectedPeer`.


## Related issue(s)

- Fixes #622 