### PR TITLE
refactor: rename SanityCheck to BasicCheck

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -373,7 +373,7 @@ func StartNode(workingDir string, passwordFetcher func(*wallet.Wallet) (string, 
 		conf, _ = config.LoadFromFile(confPath, true) // This time it should be OK
 	}
 
-	err = conf.SanityCheck()
+	err = conf.BasicCheck()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -49,8 +49,8 @@ func DefaultNodeConfig() *NodeConfig {
 	}
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *NodeConfig) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *NodeConfig) BasicCheck() error {
 	if conf.NumValidators < 1 || conf.NumValidators > 32 {
 		return errors.Errorf(errors.ErrInvalidConfig, "number of validators must be between 1 and 32")
 	}
@@ -174,28 +174,28 @@ func LoadFromFile(file string, strict bool) (*Config, error) {
 	return conf, nil
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
-	if err := conf.Store.SanityCheck(); err != nil {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
+	if err := conf.Store.BasicCheck(); err != nil {
 		return err
 	}
-	if err := conf.TxPool.SanityCheck(); err != nil {
+	if err := conf.TxPool.BasicCheck(); err != nil {
 		return err
 	}
-	if err := conf.Consensus.SanityCheck(); err != nil {
+	if err := conf.Consensus.BasicCheck(); err != nil {
 		return err
 	}
-	if err := conf.Network.SanityCheck(); err != nil {
+	if err := conf.Network.BasicCheck(); err != nil {
 		return err
 	}
-	if err := conf.Logger.SanityCheck(); err != nil {
+	if err := conf.Logger.BasicCheck(); err != nil {
 		return err
 	}
-	if err := conf.Sync.SanityCheck(); err != nil {
+	if err := conf.Sync.BasicCheck(); err != nil {
 		return err
 	}
-	if err := conf.Nanomsg.SanityCheck(); err != nil {
+	if err := conf.Nanomsg.BasicCheck(); err != nil {
 		return err
 	}
-	return conf.HTTP.SanityCheck()
+	return conf.HTTP.BasicCheck()
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,7 +16,7 @@ func TestSaveMainnetConfig(t *testing.T) {
 	conf, err := LoadFromFile(path, true)
 	assert.NoError(t, err)
 
-	assert.NoError(t, conf.SanityCheck())
+	assert.NoError(t, conf.BasicCheck())
 	assert.Equal(t, conf.Network.Name, "pactus")
 }
 
@@ -27,7 +27,7 @@ func TestSaveTestnetConfig(t *testing.T) {
 	conf, err := LoadFromFile(path, true)
 	assert.NoError(t, err)
 
-	assert.NoError(t, conf.SanityCheck())
+	assert.NoError(t, conf.BasicCheck())
 	assert.Equal(t, conf.Network.Name, "pactus-testnet")
 }
 
@@ -38,7 +38,7 @@ func TestSaveLocalnetConfig(t *testing.T) {
 	conf, err := LoadFromFile(path, true)
 	assert.NoError(t, err)
 
-	assert.NoError(t, conf.SanityCheck())
+	assert.NoError(t, conf.BasicCheck())
 	assert.Equal(t, conf.Network.Name, "pactus-localnet")
 	assert.Empty(t, conf.Network.Listens)
 	assert.Empty(t, conf.Network.RelayAddrs)
@@ -84,14 +84,14 @@ func TestExampleConfig(t *testing.T) {
 	assert.Equal(t, defaultToml, exampleToml)
 }
 
-func TestNodeConfigSanityCheck(t *testing.T) {
+func TestNodeConfigBasicCheck(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	t.Run("invalid number of validators", func(t *testing.T) {
 		conf := DefaultNodeConfig()
 		conf.NumValidators = 0
 
-		assert.Error(t, conf.SanityCheck())
+		assert.Error(t, conf.BasicCheck())
 	})
 
 	t.Run("invalid number of reward addresses", func(t *testing.T) {
@@ -100,7 +100,7 @@ func TestNodeConfigSanityCheck(t *testing.T) {
 			ts.RandomAddress().String(),
 		}
 
-		assert.Error(t, conf.SanityCheck())
+		assert.Error(t, conf.BasicCheck())
 	})
 
 	t.Run("invalid reward addresses", func(t *testing.T) {
@@ -111,7 +111,7 @@ func TestNodeConfigSanityCheck(t *testing.T) {
 			"abcd",
 		}
 
-		assert.Error(t, conf.SanityCheck())
+		assert.Error(t, conf.BasicCheck())
 	})
 
 	t.Run("ok", func(t *testing.T) {
@@ -122,6 +122,6 @@ func TestNodeConfigSanityCheck(t *testing.T) {
 			ts.RandomAddress().String(),
 		}
 
-		assert.NoError(t, conf.SanityCheck())
+		assert.NoError(t, conf.BasicCheck())
 	})
 }

--- a/consensus/config.go
+++ b/consensus/config.go
@@ -18,8 +18,8 @@ func DefaultConfig() *Config {
 	}
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
 	if conf.ChangeProposerTimeout <= 0 {
 		return errors.Errorf(errors.ErrInvalidConfig, "timeout for change proposer can't be negative")
 	}

--- a/consensus/config_test.go
+++ b/consensus/config_test.go
@@ -12,16 +12,16 @@ func TestDefaultConfigCheck(t *testing.T) {
 	c2 := DefaultConfig()
 	c3 := DefaultConfig()
 	c4 := DefaultConfig()
-	assert.NoError(t, c1.SanityCheck())
+	assert.NoError(t, c1.BasicCheck())
 
 	c2.ChangeProposerDelta = 0 * time.Second
-	assert.Error(t, c2.SanityCheck())
+	assert.Error(t, c2.BasicCheck())
 
 	c3.ChangeProposerTimeout = 0 * time.Second
-	assert.Error(t, c3.SanityCheck())
+	assert.Error(t, c3.BasicCheck())
 
 	c4.ChangeProposerTimeout = -1 * time.Second
-	assert.Error(t, c4.SanityCheck())
+	assert.Error(t, c4.BasicCheck())
 }
 
 func TestCalculateChangeProposerTimeout(t *testing.T) {

--- a/consensus/prepare_test.go
+++ b/consensus/prepare_test.go
@@ -133,8 +133,8 @@ func TestByzantineVote2(t *testing.T) {
 	p := td.makeProposal(t, h, r)
 
 	// This simple trick prevents "DATA RACE" errors in this test
-	// by memoizing tx.sanityChecked.
-	assert.NoError(t, p.SanityCheck())
+	// by memoizing tx.basicChecked.
+	assert.NoError(t, p.BasicCheck())
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)

--- a/crypto/address.go
+++ b/crypto/address.go
@@ -86,7 +86,7 @@ func (addr Address) String() string {
 	return str
 }
 
-func (addr *Address) SanityCheck() error {
+func (addr *Address) BasicCheck() error {
 	if addr[0] == 0 {
 		if !addr.EqualsTo(TreasuryAddress) {
 			return errors.Errorf(errors.ErrInvalidAddress, "invalid address data")

--- a/crypto/address_test.go
+++ b/crypto/address_test.go
@@ -123,7 +123,7 @@ func TestToString(t *testing.T) {
 	}
 }
 
-func TestAddressSanityCheck(t *testing.T) {
+func TestAddressBasicCheck(t *testing.T) {
 	tests := []struct {
 		errMsg  string
 		hex     string
@@ -155,7 +155,7 @@ func TestAddressSanityCheck(t *testing.T) {
 		addr := crypto.Address{}
 		copy(addr[:], data)
 
-		err := addr.SanityCheck()
+		err := addr.BasicCheck()
 		if !test.invalid {
 			assert.NoError(t, err, "test %v unexpected error", no)
 		} else {

--- a/crypto/hash/hash.go
+++ b/crypto/hash/hash.go
@@ -80,7 +80,7 @@ func (h Hash) IsUndef() bool {
 	return h.EqualsTo(UndefHash)
 }
 
-func (h Hash) SanityCheck() error {
+func (h Hash) BasicCheck() error {
 	if h.IsUndef() {
 		return fmt.Errorf("hash is zero")
 	}

--- a/crypto/hash/hash_test.go
+++ b/crypto/hash/hash_test.go
@@ -31,7 +31,7 @@ func TestHashFromString(t *testing.T) {
 
 func TestHashEmpty(t *testing.T) {
 	h := hash.Hash{}
-	assert.Error(t, h.SanityCheck())
+	assert.Error(t, h.BasicCheck())
 
 	_, err := hash.FromBytes(nil)
 	assert.Error(t, err)
@@ -58,10 +58,10 @@ func TestHash160(t *testing.T) {
 	assert.Equal(t, h, expected)
 }
 
-func TestHashSanityCheck(t *testing.T) {
+func TestHashBasicCheck(t *testing.T) {
 	h, err := hash.FromString("0000000000000000000000000000000000000000000000000000000000000000")
 	assert.NoError(t, err)
 	assert.True(t, h.IsUndef())
-	assert.Error(t, h.SanityCheck())
+	assert.Error(t, h.BasicCheck())
 	assert.Equal(t, hash.UndefHash.Bytes(), h.Bytes())
 }

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -43,7 +43,7 @@ func NewChecker() *Execution {
 }
 
 func (exe *Execution) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
-	if err := trx.SanityCheck(); err != nil {
+	if err := trx.BasicCheck(); err != nil {
 		return err
 	}
 	if trx.IsLockTime() {

--- a/network/config.go
+++ b/network/config.go
@@ -74,8 +74,8 @@ func validateAddresses(address []string) error {
 	return nil
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
 	if conf.EnableRelay {
 		if len(conf.RelayAddrs) == 0 {
 			return errors.Errorf(errors.ErrInvalidConfig, "at least one relay address should be defined")

--- a/network/config_test.go
+++ b/network/config_test.go
@@ -10,26 +10,26 @@ func TestDefaultConfigCheck(t *testing.T) {
 	conf := DefaultConfig()
 
 	conf.EnableRelay = true
-	assert.Error(t, conf.SanityCheck())
+	assert.Error(t, conf.BasicCheck())
 
 	conf.Listens = []string{""}
-	assert.Error(t, conf.SanityCheck())
+	assert.Error(t, conf.BasicCheck())
 
 	conf.Listens = []string{"127.0.0.1"}
-	assert.Error(t, conf.SanityCheck())
+	assert.Error(t, conf.BasicCheck())
 
 	conf.Listens = []string{"/ip4"}
-	assert.Error(t, conf.SanityCheck())
+	assert.Error(t, conf.BasicCheck())
 
 	conf.RelayAddrs = []string{"/ip4"}
-	assert.Error(t, conf.SanityCheck())
+	assert.Error(t, conf.BasicCheck())
 
 	conf.RelayAddrs = []string{}
 	conf.Listens = []string{}
 
 	conf.RelayAddrs = []string{"/ip4/127.0.0.1"}
-	assert.NoError(t, conf.SanityCheck())
+	assert.NoError(t, conf.BasicCheck())
 
 	conf.Listens = []string{"/ip4/127.0.0.1"}
-	assert.NoError(t, conf.SanityCheck())
+	assert.NoError(t, conf.BasicCheck())
 }

--- a/state/validation.go
+++ b/state/validation.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (st *state) validateBlock(block *block.Block) error {
-	if err := block.SanityCheck(); err != nil {
+	if err := block.BasicCheck(); err != nil {
 		return err
 	}
 
@@ -27,7 +27,7 @@ func (st *state) validateBlock(block *block.Block) error {
 }
 
 func (st *state) checkCertificate(blockHash hash.Hash, cert *block.Certificate) error {
-	if err := cert.SanityCheck(); err != nil {
+	if err := cert.BasicCheck(); err != nil {
 		return err
 	}
 

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -181,7 +181,7 @@ func TestBlockValidation(t *testing.T) {
 	// UnixTime				(TestValidateBlockTime)
 	// PrevBlockHash		(OK)
 	// StateRoot			(OK)
-	// TxsRoot			    (SanityCheck)
+	// TxsRoot			    (BasicCheck)
 	// PrevCertificate   	(OK)
 	// SortitionSeed		(OK)
 	// ProposerAddress		(OK)

--- a/store/config.go
+++ b/store/config.go
@@ -26,8 +26,8 @@ func (conf *Config) StorePath() string {
 	return fmt.Sprintf("%s%c%s", conf.DataPath(), os.PathSeparator, "store.db")
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
 	if !util.IsValidDirPath(conf.Path) {
 		return errors.Errorf(errors.ErrInvalidConfig, "path is not valid")
 	}

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestDefaultConfigCheck(t *testing.T) {
 	c := DefaultConfig()
-	assert.NoError(t, c.SanityCheck())
+	assert.NoError(t, c.BasicCheck())
 
 	if runtime.GOOS != "windows" {
 		c.Path = util.TempDirPath()
-		assert.NoError(t, c.SanityCheck())
+		assert.NoError(t, c.BasicCheck())
 		assert.Equal(t, c.StorePath(), c.Path+"/store.db")
 	}
 }

--- a/sync/bundle/bundle.go
+++ b/sync/bundle/bundle.go
@@ -34,8 +34,8 @@ func NewBundle(initiator peer.ID, msg message.Message) *Bundle {
 	}
 }
 
-func (b *Bundle) SanityCheck() error {
-	if err := b.Message.SanityCheck(); err != nil {
+func (b *Bundle) BasicCheck() error {
+	if err := b.Message.BasicCheck(); err != nil {
 		return err
 	}
 	if err := b.Initiator.Validate(); err != nil {

--- a/sync/bundle/bundle_test.go
+++ b/sync/bundle/bundle_test.go
@@ -57,8 +57,8 @@ func TestMessageCompress(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = msg3.Decode(bytes.NewReader(bs1))
 	assert.NoError(t, err)
-	assert.NoError(t, msg2.SanityCheck())
-	assert.NoError(t, msg3.SanityCheck())
+	assert.NoError(t, msg2.BasicCheck())
+	assert.NoError(t, msg3.BasicCheck())
 	assert.True(t, util.IsFlagSet(bdl.Flags, BundleFlagCompressed))
 }
 
@@ -95,7 +95,7 @@ func TestDecodeVoteCBOR(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = m2.Decode(bytes.NewReader(d2))
 	assert.NoError(t, err)
-	assert.NoError(t, m2.SanityCheck())
+	assert.NoError(t, m2.BasicCheck())
 
 	assert.Equal(t, m1.Message, m2.Message)
 }

--- a/sync/bundle/message/block_announce.go
+++ b/sync/bundle/message/block_announce.go
@@ -20,11 +20,11 @@ func NewBlockAnnounceMessage(h uint32, b *block.Block, c *block.Certificate) *Bl
 	}
 }
 
-func (m *BlockAnnounceMessage) SanityCheck() error {
-	if err := m.Block.SanityCheck(); err != nil {
+func (m *BlockAnnounceMessage) BasicCheck() error {
+	if err := m.Block.BasicCheck(); err != nil {
 		return err
 	}
-	return m.Certificate.SanityCheck()
+	return m.Certificate.BasicCheck()
 }
 
 func (m *BlockAnnounceMessage) Type() Type {

--- a/sync/bundle/message/block_announce_test.go
+++ b/sync/bundle/message/block_announce_test.go
@@ -22,7 +22,7 @@ func TestBlockAnnounceMessage(t *testing.T) {
 		c := block.NewCertificate(-1, nil, nil, nil)
 		m := NewBlockAnnounceMessage(100, b, c)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidRound)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidRound)
 	})
 
 	t.Run("OK", func(t *testing.T) {
@@ -30,7 +30,7 @@ func TestBlockAnnounceMessage(t *testing.T) {
 		c := ts.GenerateTestCertificate(b.Hash())
 		m := NewBlockAnnounceMessage(100, b, c)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), "100")
 	})
 }

--- a/sync/bundle/message/blocks_request.go
+++ b/sync/bundle/message/blocks_request.go
@@ -24,7 +24,7 @@ func (m *BlocksRequestMessage) To() uint32 {
 	return m.From + m.Count - 1
 }
 
-func (m *BlocksRequestMessage) SanityCheck() error {
+func (m *BlocksRequestMessage) BasicCheck() error {
 	if m.From == 0 {
 		return errors.Errorf(errors.ErrInvalidHeight, "height is zero")
 	}

--- a/sync/bundle/message/blocks_request_test.go
+++ b/sync/bundle/message/blocks_request_test.go
@@ -16,18 +16,18 @@ func TestBlocksRequestMessage(t *testing.T) {
 	t.Run("Invalid height", func(t *testing.T) {
 		m := NewBlocksRequestMessage(1, 0, 0)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidHeight)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidHeight)
 	})
 	t.Run("Invalid count", func(t *testing.T) {
 		m := NewBlocksRequestMessage(1, 200, 0)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidMessage)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidMessage)
 	})
 
 	t.Run("OK", func(t *testing.T) {
 		m := NewBlocksRequestMessage(1, 100, 7)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Equal(t, m.To(), uint32(106))
 		assert.Contains(t, m.String(), "100")
 	})

--- a/sync/bundle/message/blocks_response.go
+++ b/sync/bundle/message/blocks_response.go
@@ -34,12 +34,12 @@ func NewBlocksResponseMessage(code ResponseCode, reason string, sid int, from ui
 	}
 }
 
-func (m *BlocksResponseMessage) SanityCheck() error {
+func (m *BlocksResponseMessage) BasicCheck() error {
 	if m.From == 0 && len(m.BlocksData) != 0 {
 		return errors.Errorf(errors.ErrInvalidHeight, "unexpected block for height zero")
 	}
 	if m.LastCertificate != nil {
-		if err := m.LastCertificate.SanityCheck(); err != nil {
+		if err := m.LastCertificate.BasicCheck(); err != nil {
 			return err
 		}
 	}

--- a/sync/bundle/message/blocks_response_test.go
+++ b/sync/bundle/message/blocks_response_test.go
@@ -24,7 +24,7 @@ func TestBlocksResponseMessage(t *testing.T) {
 		d, _ := b.Bytes()
 		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, ResponseCodeMoreBlocks.String(), sid, 100, [][]byte{d}, c)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidRound)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidRound)
 		assert.Equal(t, m.Reason, ResponseCodeMoreBlocks.String())
 	})
 
@@ -33,7 +33,7 @@ func TestBlocksResponseMessage(t *testing.T) {
 		d, _ := b.Bytes()
 		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, ResponseCodeMoreBlocks.String(), sid, 0, [][]byte{d}, nil)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidHeight)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidHeight)
 		assert.Equal(t, m.Reason, ResponseCodeMoreBlocks.String())
 	})
 
@@ -45,7 +45,7 @@ func TestBlocksResponseMessage(t *testing.T) {
 		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, ResponseCodeMoreBlocks.String(), sid, 100,
 			[][]byte{d1, d2}, nil)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Zero(t, m.LastCertificateHeight())
 		assert.Contains(t, m.String(), "100")
 		assert.Equal(t, m.Reason, ResponseCodeMoreBlocks.String())
@@ -58,7 +58,7 @@ func TestLatestBlocksResponseCode(t *testing.T) {
 	t.Run("busy", func(t *testing.T) {
 		m := NewBlocksResponseMessage(ResponseCodeRejected, ResponseCodeRejected.String(), 1, 0, nil, nil)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Zero(t, m.From)
 		assert.Zero(t, m.To())
 		assert.Zero(t, m.Count())
@@ -69,7 +69,7 @@ func TestLatestBlocksResponseCode(t *testing.T) {
 	t.Run("rejected", func(t *testing.T) {
 		m := NewBlocksResponseMessage(ResponseCodeRejected, ResponseCodeRejected.String(), 1, 0, nil, nil)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Zero(t, m.From)
 		assert.Zero(t, m.To())
 		assert.Zero(t, m.Count())
@@ -84,7 +84,7 @@ func TestLatestBlocksResponseCode(t *testing.T) {
 		d2, _ := b2.Bytes()
 		m := NewBlocksResponseMessage(ResponseCodeMoreBlocks, ResponseCodeMoreBlocks.String(), 1, 100, [][]byte{d1, d2}, nil)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Equal(t, m.From, uint32(100))
 		assert.Equal(t, m.To(), uint32(101))
 		assert.Equal(t, m.Count(), uint32(2))
@@ -97,7 +97,7 @@ func TestLatestBlocksResponseCode(t *testing.T) {
 		cert := ts.GenerateTestCertificate(ts.RandomHash())
 
 		m := NewBlocksResponseMessage(ResponseCodeSynced, ResponseCodeSynced.String(), 1, 100, nil, cert)
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Equal(t, m.From, uint32(100))
 		assert.Zero(t, m.To())
 		assert.Zero(t, m.Count())

--- a/sync/bundle/message/heart_beat.go
+++ b/sync/bundle/message/heart_beat.go
@@ -21,7 +21,7 @@ func NewHeartBeatMessage(h uint32, r int16, hash hash.Hash) *HeartBeatMessage {
 	}
 }
 
-func (m *HeartBeatMessage) SanityCheck() error {
+func (m *HeartBeatMessage) BasicCheck() error {
 	if m.Height == 0 {
 		return errors.Errorf(errors.ErrInvalidHeight, "invalid height")
 	}

--- a/sync/bundle/message/heart_beat_test.go
+++ b/sync/bundle/message/heart_beat_test.go
@@ -19,13 +19,13 @@ func TestHeartBeatMessage(t *testing.T) {
 	t.Run("Invalid height", func(t *testing.T) {
 		m := NewHeartBeatMessage(0, 0, ts.RandomHash())
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidHeight)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidHeight)
 	})
 
 	t.Run("OK", func(t *testing.T) {
 		m := NewHeartBeatMessage(100, 1, ts.RandomHash())
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), "100")
 	})
 }

--- a/sync/bundle/message/hello.go
+++ b/sync/bundle/message/hello.go
@@ -43,7 +43,7 @@ func NewHelloMessage(pid peer.ID, moniker string,
 	}
 }
 
-func (m *HelloMessage) SanityCheck() error {
+func (m *HelloMessage) BasicCheck() error {
 	if m.Signature == nil {
 		return errors.Error(errors.ErrInvalidSignature)
 	}

--- a/sync/bundle/message/hello_test.go
+++ b/sync/bundle/message/hello_test.go
@@ -24,7 +24,7 @@ func TestHelloMessage(t *testing.T) {
 		m.Sign(signer)
 		m.Signature = ts.RandomBLSSignature()
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidSignature)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidSignature)
 	})
 
 	t.Run("Signature is nil", func(t *testing.T) {
@@ -33,7 +33,7 @@ func TestHelloMessage(t *testing.T) {
 		m.Sign(signer)
 		m.Signature = nil
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidSignature)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidSignature)
 	})
 
 	t.Run("PublicKeys are empty", func(t *testing.T) {
@@ -42,7 +42,7 @@ func TestHelloMessage(t *testing.T) {
 		m.Sign(signer)
 		m.PublicKeys = make([]*bls.PublicKey, 0)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidPublicKey)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidPublicKey)
 	})
 
 	t.Run("Ok", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestHelloMessage(t *testing.T) {
 		m := NewHelloMessage(ts.RandomPeerID(), "Alice", 100, 0, ts.RandomHash(), ts.RandomHash())
 		m.Sign(signer)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), "Alice")
 	})
 }

--- a/sync/bundle/message/message.go
+++ b/sync/bundle/message/message.go
@@ -123,7 +123,7 @@ func MakeMessage(t Type) Message {
 }
 
 type Message interface {
-	SanityCheck() error
+	BasicCheck() error
 	Type() Type
 	String() string
 }

--- a/sync/bundle/message/proposal.go
+++ b/sync/bundle/message/proposal.go
@@ -14,8 +14,8 @@ func NewProposalMessage(p *proposal.Proposal) *ProposalMessage {
 	}
 }
 
-func (m *ProposalMessage) SanityCheck() error {
-	return m.Proposal.SanityCheck()
+func (m *ProposalMessage) BasicCheck() error {
+	return m.Proposal.BasicCheck()
 }
 
 func (m *ProposalMessage) Type() Type {

--- a/sync/bundle/message/proposal_test.go
+++ b/sync/bundle/message/proposal_test.go
@@ -20,14 +20,14 @@ func TestProposalMessage(t *testing.T) {
 		proposal, _ := ts.GenerateTestProposal(100, -1)
 		m := NewProposalMessage(proposal)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidRound)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidRound)
 	})
 
 	t.Run("OK", func(t *testing.T) {
 		proposal, _ := ts.GenerateTestProposal(100, 0)
 		m := NewProposalMessage(proposal)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), "100")
 	})
 }

--- a/sync/bundle/message/query_proposal.go
+++ b/sync/bundle/message/query_proposal.go
@@ -18,7 +18,7 @@ func NewQueryProposalMessage(h uint32, r int16) *QueryProposalMessage {
 	}
 }
 
-func (m *QueryProposalMessage) SanityCheck() error {
+func (m *QueryProposalMessage) BasicCheck() error {
 	if m.Round < 0 {
 		return errors.Error(errors.ErrInvalidRound)
 	}

--- a/sync/bundle/message/query_proposal_test.go
+++ b/sync/bundle/message/query_proposal_test.go
@@ -16,13 +16,13 @@ func TestQueryProposalMessage(t *testing.T) {
 	t.Run("Invalid round", func(t *testing.T) {
 		m := NewQueryProposalMessage(0, -1)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidRound)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidRound)
 	})
 
 	t.Run("OK", func(t *testing.T) {
 		m := NewQueryProposalMessage(100, 0)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), "100")
 	})
 }

--- a/sync/bundle/message/query_votes.go
+++ b/sync/bundle/message/query_votes.go
@@ -18,7 +18,7 @@ func NewQueryVotesMessage(h uint32, r int16) *QueryVotesMessage {
 	}
 }
 
-func (m *QueryVotesMessage) SanityCheck() error {
+func (m *QueryVotesMessage) BasicCheck() error {
 	if m.Round < 0 {
 		return errors.Error(errors.ErrInvalidRound)
 	}

--- a/sync/bundle/message/query_votes_test.go
+++ b/sync/bundle/message/query_votes_test.go
@@ -16,13 +16,13 @@ func TestQueryVotesMessage(t *testing.T) {
 	t.Run("Invalid round", func(t *testing.T) {
 		m := NewQueryVotesMessage(0, -1)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidRound)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidRound)
 	})
 
 	t.Run("OK", func(t *testing.T) {
 		m := NewQueryVotesMessage(100, 0)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), "100")
 	})
 }

--- a/sync/bundle/message/transactions.go
+++ b/sync/bundle/message/transactions.go
@@ -18,12 +18,12 @@ func NewTransactionsMessage(trxs []*tx.Tx) *TransactionsMessage {
 	}
 }
 
-func (m *TransactionsMessage) SanityCheck() error {
+func (m *TransactionsMessage) BasicCheck() error {
 	if len(m.Transactions) == 0 {
 		return errors.Errorf(errors.ErrInvalidMessage, "no transaction")
 	}
 	for _, tx := range m.Transactions {
-		if err := tx.SanityCheck(); err != nil {
+		if err := tx.BasicCheck(); err != nil {
 			return err
 		}
 	}

--- a/sync/bundle/message/transactions_test.go
+++ b/sync/bundle/message/transactions_test.go
@@ -20,14 +20,14 @@ func TestTransactionsMessage(t *testing.T) {
 	t.Run("No transactions", func(t *testing.T) {
 		m := NewTransactionsMessage(nil)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidMessage)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidMessage)
 	})
 
 	t.Run("OK", func(t *testing.T) {
 		trx, _ := ts.GenerateTestTransferTx()
 		m := NewTransactionsMessage([]*tx.Tx{trx})
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), trx.ID().ShortString())
 	})
 }

--- a/sync/bundle/message/vote.go
+++ b/sync/bundle/message/vote.go
@@ -14,8 +14,8 @@ func NewVoteMessage(v *vote.Vote) *VoteMessage {
 	}
 }
 
-func (m *VoteMessage) SanityCheck() error {
-	return m.Vote.SanityCheck()
+func (m *VoteMessage) BasicCheck() error {
+	return m.Vote.BasicCheck()
 }
 
 func (m *VoteMessage) Type() Type {

--- a/sync/bundle/message/vote_test.go
+++ b/sync/bundle/message/vote_test.go
@@ -20,14 +20,14 @@ func TestVoteMessage(t *testing.T) {
 		v, _ := ts.GenerateTestPrepareVote(100, -1)
 		m := NewVoteMessage(v)
 
-		assert.Equal(t, errors.Code(m.SanityCheck()), errors.ErrInvalidRound)
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidRound)
 	})
 
 	t.Run("OK", func(t *testing.T) {
 		v, _ := ts.GenerateTestPrepareVote(100, 0)
 		m := NewVoteMessage(v)
 
-		assert.NoError(t, m.SanityCheck())
+		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), v.String())
 	})
 }

--- a/sync/config.go
+++ b/sync/config.go
@@ -31,7 +31,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
 	return nil
 }

--- a/sync/config_test.go
+++ b/sync/config_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestDefaultConfigCheck(t *testing.T) {
 	c := DefaultConfig()
-	assert.NoError(t, c.SanityCheck())
+	assert.NoError(t, c.BasicCheck())
 }

--- a/sync/firewall/config.go
+++ b/sync/firewall/config.go
@@ -10,7 +10,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
 	return nil
 }

--- a/sync/firewall/firewall.go
+++ b/sync/firewall/firewall.go
@@ -110,7 +110,7 @@ func (f *Firewall) decodeBundle(r io.Reader, pid peer.ID) (*bundle.Bundle, error
 }
 
 func (f *Firewall) checkBundle(bdl *bundle.Bundle, pid peer.ID) error {
-	if err := bdl.SanityCheck(); err != nil {
+	if err := bdl.BasicCheck(); err != nil {
 		return errors.Errorf(errors.ErrInvalidMessage, err.Error())
 	}
 

--- a/sync/handler_blocks_response.go
+++ b/sync/handler_blocks_response.go
@@ -30,7 +30,7 @@ func (handler *blocksResponseHandler) ParseMessage(m message.Message, initiator 
 			if err != nil {
 				return err
 			}
-			if err := b.SanityCheck(); err != nil {
+			if err := b.BasicCheck(); err != nil {
 				return err
 			}
 			handler.cache.AddBlock(height, b)

--- a/txpool/config.go
+++ b/txpool/config.go
@@ -14,8 +14,8 @@ func DefaultConfig() *Config {
 	}
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
 	if conf.MaxSize == 0 {
 		return errors.Errorf(errors.ErrInvalidConfig, "maxSize can't be negative or zero")
 	}

--- a/txpool/config_test.go
+++ b/txpool/config_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDefaultConfigCheck(t *testing.T) {
 	c := DefaultConfig()
-	assert.NoError(t, c.SanityCheck())
+	assert.NoError(t, c.BasicCheck())
 
 	assert.Equal(t,
 		c.sendPoolSize()+
@@ -18,5 +18,5 @@ func TestDefaultConfigCheck(t *testing.T) {
 			c.sortitionPoolSize(), c.MaxSize)
 
 	c.MaxSize = 0
-	assert.Error(t, c.SanityCheck())
+	assert.Error(t, c.BasicCheck())
 }

--- a/types/block/block.go
+++ b/types/block/block.go
@@ -63,8 +63,8 @@ func (b *Block) Header() *Header               { return b.data.Header }
 func (b *Block) PrevCertificate() *Certificate { return b.data.PrevCert }
 func (b *Block) Transactions() Txs             { return b.data.Txs }
 
-func (b *Block) SanityCheck() error {
-	if err := b.Header().SanityCheck(); err != nil {
+func (b *Block) BasicCheck() error {
+	if err := b.Header().BasicCheck(); err != nil {
 		return err
 	}
 	if b.Transactions().Len() == 0 {
@@ -74,7 +74,7 @@ func (b *Block) SanityCheck() error {
 		return errors.Errorf(errors.ErrInvalidBlock, "block is full")
 	}
 	if b.PrevCertificate() != nil {
-		if err := b.PrevCertificate().SanityCheck(); err != nil {
+		if err := b.PrevCertificate().BasicCheck(); err != nil {
 			return err
 		}
 	} else {
@@ -85,7 +85,7 @@ func (b *Block) SanityCheck() error {
 	}
 
 	for _, trx := range b.Transactions() {
-		if err := trx.SanityCheck(); err != nil {
+		if err := trx.BasicCheck(); err != nil {
 			return errors.Errorf(errors.ErrInvalidBlock, err.Error())
 		}
 	}

--- a/types/block/block_test.go
+++ b/types/block/block_test.go
@@ -14,21 +14,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSanityCheck(t *testing.T) {
+func TestBasicCheck(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	t.Run("No transactions", func(t *testing.T) {
 		b0 := ts.GenerateTestBlock(nil, nil)
 		b := block.NewBlock(b0.Header(), b0.PrevCertificate(), block.Txs{})
 
-		assert.Error(t, b.SanityCheck())
+		assert.Error(t, b.BasicCheck())
 	})
 
 	t.Run("Without the previous certificate", func(t *testing.T) {
 		b0 := ts.GenerateTestBlock(nil, nil)
 		b := block.NewBlock(b0.Header(), nil, b0.Transactions())
 
-		assert.Error(t, b.SanityCheck())
+		assert.Error(t, b.BasicCheck())
 	})
 
 	t.Run("Invalid certificate round", func(t *testing.T) {
@@ -37,7 +37,7 @@ func TestSanityCheck(t *testing.T) {
 		invCert := block.NewCertificate(-1, cert0.Committers(), cert0.Absentees(), cert0.Signature())
 		b := block.NewBlock(b0.Header(), invCert, b0.Transactions())
 
-		assert.Error(t, b.SanityCheck())
+		assert.Error(t, b.BasicCheck())
 	})
 
 	t.Run("Invalid transaction", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestSanityCheck(t *testing.T) {
 		invalidSigner.SignMsg(trxs0[0])
 		b := block.NewBlock(b0.Header(), b0.PrevCertificate(), trxs0)
 
-		assert.Error(t, b.SanityCheck())
+		assert.Error(t, b.BasicCheck())
 	})
 
 	t.Run("Invalid state root hash", func(t *testing.T) {
@@ -64,7 +64,7 @@ func TestSanityCheck(t *testing.T) {
 		b, err := block.FromBytes(d)
 		assert.NoError(t, err)
 
-		assert.Error(t, b.SanityCheck())
+		assert.Error(t, b.BasicCheck())
 	})
 
 	t.Run("Invalid previous block hash", func(t *testing.T) {
@@ -96,12 +96,12 @@ func TestSanityCheck(t *testing.T) {
 		b, err := block.FromBytes(d)
 		assert.NoError(t, err)
 
-		assert.Error(t, b.SanityCheck())
+		assert.Error(t, b.BasicCheck())
 	})
 
 	t.Run("Ok", func(t *testing.T) {
 		b := ts.GenerateTestBlock(nil, nil)
-		assert.NoError(t, b.SanityCheck())
+		assert.NoError(t, b.BasicCheck())
 		assert.LessOrEqual(t, b.Header().Time(), time.Now())
 		assert.NotZero(t, b.Header().UnixTime())
 		assert.Equal(t, b.Header().Version(), uint8(1))
@@ -117,7 +117,7 @@ func TestCBORMarshaling(t *testing.T) {
 	var b2 block.Block
 	err = cbor.Unmarshal(bz1, &b2)
 	assert.NoError(t, err)
-	assert.NoError(t, b2.SanityCheck())
+	assert.NoError(t, b2.BasicCheck())
 	assert.Equal(t, b1.Hash(), b2.Hash())
 
 	assert.Equal(t, b1.Hash(), b2.Hash())

--- a/types/block/certificate.go
+++ b/types/block/certificate.go
@@ -51,7 +51,7 @@ func (cert *Certificate) Signature() *bls.Signature {
 	return cert.data.Signature
 }
 
-func (cert *Certificate) SanityCheck() error {
+func (cert *Certificate) BasicCheck() error {
 	if cert.Round() < 0 {
 		return errors.Error(errors.ErrInvalidRound)
 	}

--- a/types/block/certificate_test.go
+++ b/types/block/certificate_test.go
@@ -19,7 +19,7 @@ func TestCertificateCBORMarshaling(t *testing.T) {
 	var c2 block.Certificate
 	err = cbor.Unmarshal(bz1, &c2)
 	assert.NoError(t, err)
-	assert.NoError(t, c2.SanityCheck())
+	assert.NoError(t, c2.BasicCheck())
 	assert.Equal(t, c1.Hash(), c1.Hash())
 
 	assert.Equal(t, c1.Hash(), c2.Hash())
@@ -46,28 +46,28 @@ func TestInvalidCertificate(t *testing.T) {
 	t.Run("Invalid round", func(t *testing.T) {
 		cert := block.NewCertificate(-1, cert0.Committers(), cert0.Absentees(), cert0.Signature())
 
-		err := cert.SanityCheck()
+		err := cert.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidRound)
 	})
 
 	t.Run("Committers is nil", func(t *testing.T) {
 		cert := block.NewCertificate(cert0.Round(), nil, cert0.Absentees(), cert0.Signature())
 
-		err := cert.SanityCheck()
+		err := cert.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidBlock)
 	})
 
 	t.Run("Absentees is nil", func(t *testing.T) {
 		cert := block.NewCertificate(cert0.Round(), cert0.Committers(), nil, cert0.Signature())
 
-		err := cert.SanityCheck()
+		err := cert.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidBlock)
 	})
 
 	t.Run("Signature is nil", func(t *testing.T) {
 		cert := block.NewCertificate(cert0.Round(), cert0.Committers(), cert0.Absentees(), nil)
 
-		err := cert.SanityCheck()
+		err := cert.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidSignature)
 	})
 
@@ -76,7 +76,7 @@ func TestInvalidCertificate(t *testing.T) {
 		abs = append(abs, 0)
 		cert := block.NewCertificate(cert0.Round(), cert0.Committers(), abs, cert0.Signature())
 
-		err := cert.SanityCheck()
+		err := cert.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidBlock)
 	})
 
@@ -84,7 +84,7 @@ func TestInvalidCertificate(t *testing.T) {
 		abs := []int32{2, 1}
 		cert := block.NewCertificate(cert0.Round(), cert0.Committers(), abs, cert0.Signature())
 
-		err := cert.SanityCheck()
+		err := cert.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidBlock)
 	})
 }
@@ -97,15 +97,15 @@ func TestCertificateHash(t *testing.T) {
 	cert1 := block.NewCertificate(temp.Round(), []int32{10, 18, 2, 6}, []int32{}, temp.Signature())
 	assert.Equal(t, cert1.Committers(), []int32{10, 18, 2, 6})
 	assert.Equal(t, cert1.Absentees(), []int32{})
-	assert.NoError(t, cert1.SanityCheck())
+	assert.NoError(t, cert1.BasicCheck())
 
 	cert2 := block.NewCertificate(temp.Round(), []int32{10, 18, 2, 6}, []int32{2, 6}, temp.Signature())
 	assert.Equal(t, cert2.Committers(), []int32{10, 18, 2, 6})
 	assert.Equal(t, cert2.Absentees(), []int32{2, 6})
-	assert.NoError(t, cert2.SanityCheck())
+	assert.NoError(t, cert2.BasicCheck())
 
 	cert3 := block.NewCertificate(temp.Round(), []int32{10, 18, 2, 6}, []int32{18}, temp.Signature())
 	assert.Equal(t, cert3.Committers(), []int32{10, 18, 2, 6})
 	assert.Equal(t, cert3.Absentees(), []int32{18})
-	assert.NoError(t, cert3.SanityCheck())
+	assert.NoError(t, cert3.BasicCheck())
 }

--- a/types/block/header.go
+++ b/types/block/header.go
@@ -74,11 +74,11 @@ func NewHeader(version uint8, time time.Time, stateRoot, prevBlockHash hash.Hash
 	}
 }
 
-func (h *Header) SanityCheck() error {
-	if err := h.data.StateRoot.SanityCheck(); err != nil {
+func (h *Header) BasicCheck() error {
+	if err := h.data.StateRoot.BasicCheck(); err != nil {
 		return errors.Errorf(errors.ErrInvalidBlock, "invalid state root")
 	}
-	if err := h.data.ProposerAddress.SanityCheck(); err != nil {
+	if err := h.data.ProposerAddress.BasicCheck(); err != nil {
 		return errors.Errorf(errors.ErrInvalidBlock, "invalid proposer address")
 	}
 

--- a/types/proposal/proposal.go
+++ b/types/proposal/proposal.go
@@ -36,14 +36,14 @@ func (p *Proposal) Round() int16                { return p.data.Round }
 func (p *Proposal) Block() *block.Block         { return p.data.Block }
 func (p *Proposal) Signature() crypto.Signature { return p.data.Signature }
 
-func (p *Proposal) SanityCheck() error {
+func (p *Proposal) BasicCheck() error {
 	if p.data.Block == nil {
 		return errors.Errorf(errors.ErrInvalidSignature, "no block")
 	}
 	if p.data.Signature == nil {
 		return errors.Errorf(errors.ErrInvalidSignature, "no signature")
 	}
-	if err := p.data.Block.SanityCheck(); err != nil {
+	if err := p.data.Block.BasicCheck(); err != nil {
 		return err
 	}
 	if p.data.Height <= 0 {

--- a/types/proposal/proposal_test.go
+++ b/types/proposal/proposal_test.go
@@ -53,22 +53,22 @@ func TestProposalSignature(t *testing.T) {
 	assert.Equal(t, errors.Code(err), errors.ErrInvalidSignature)
 }
 
-func TestSanityCheck(t *testing.T) {
+func TestBasicCheck(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	t.Run("No block", func(t *testing.T) {
 		p := &proposal.Proposal{}
-		assert.Error(t, p.SanityCheck())
+		assert.Error(t, p.BasicCheck())
 	})
 
 	t.Run("Invalid height", func(t *testing.T) {
 		p, _ := ts.GenerateTestProposal(0, 0)
-		assert.Error(t, p.SanityCheck())
+		assert.Error(t, p.BasicCheck())
 	})
 
 	t.Run("Invalid round", func(t *testing.T) {
 		p, _ := ts.GenerateTestProposal(1, -1)
-		assert.Error(t, p.SanityCheck())
+		assert.Error(t, p.BasicCheck())
 	})
 
 	t.Run("No signature", func(t *testing.T) {
@@ -82,12 +82,12 @@ func TestSanityCheck(t *testing.T) {
 		err := cbor.Unmarshal(d, &p)
 
 		assert.NoError(t, err)
-		assert.Error(t, p.SanityCheck())
+		assert.Error(t, p.BasicCheck())
 		assert.Error(t, p.Verify(pub))
 	})
 
 	t.Run("Ok", func(t *testing.T) {
 		p, _ := ts.GenerateTestProposal(100, 0)
-		assert.NoError(t, p.SanityCheck())
+		assert.NoError(t, p.BasicCheck())
 	})
 }

--- a/types/tx/payload/bond.go
+++ b/types/tx/payload/bond.go
@@ -29,11 +29,11 @@ func (p *BondPayload) Value() int64 {
 	return p.Stake
 }
 
-func (p *BondPayload) SanityCheck() error {
-	if err := p.Sender.SanityCheck(); err != nil {
+func (p *BondPayload) BasicCheck() error {
+	if err := p.Sender.BasicCheck(); err != nil {
 		return err
 	}
-	if err := p.Receiver.SanityCheck(); err != nil {
+	if err := p.Receiver.BasicCheck(); err != nil {
 		return err
 	}
 	if p.PublicKey != nil {

--- a/types/tx/payload/bond_test.go
+++ b/types/tx/payload/bond_test.go
@@ -238,11 +238,11 @@ func TestBondDecoding(t *testing.T) {
 			assert.Equal(t, len(w.Bytes()), pld.SerializeSize())
 			assert.Equal(t, w.Bytes(), test.raw)
 
-			// Sanity check
+			// Basic check
 			if test.sanityErr != nil {
-				assert.ErrorIs(t, pld.SanityCheck(), test.sanityErr)
+				assert.ErrorIs(t, pld.BasicCheck(), test.sanityErr)
 			} else {
-				assert.NoError(t, pld.SanityCheck())
+				assert.NoError(t, pld.BasicCheck())
 
 				// Check signer
 				assert.Equal(t, pld.Signer().Bytes(), test.raw[:21])

--- a/types/tx/payload/payload.go
+++ b/types/tx/payload/payload.go
@@ -40,6 +40,6 @@ type Payload interface {
 	SerializeSize() int
 	Encode(io.Writer) error
 	Decode(io.Reader) error
-	SanityCheck() error
+	BasicCheck() error
 	String() string
 }

--- a/types/tx/payload/sortition.go
+++ b/types/tx/payload/sortition.go
@@ -27,8 +27,8 @@ func (p *SortitionPayload) Value() int64 {
 	return 0
 }
 
-func (p *SortitionPayload) SanityCheck() error {
-	if err := p.Address.SanityCheck(); err != nil {
+func (p *SortitionPayload) BasicCheck() error {
+	if err := p.Address.BasicCheck(); err != nil {
 		return errors.Error(errors.ErrInvalidAddress)
 	}
 

--- a/types/tx/payload/sortition_test.go
+++ b/types/tx/payload/sortition_test.go
@@ -106,11 +106,11 @@ func TestSortitionDecoding(t *testing.T) {
 			assert.Equal(t, len(w.Bytes()), pld.SerializeSize())
 			assert.Equal(t, w.Bytes(), test.raw)
 
-			// Sanity check
+			// Basic check
 			if test.sanityErr != nil {
-				assert.ErrorIs(t, pld.SanityCheck(), test.sanityErr)
+				assert.ErrorIs(t, pld.BasicCheck(), test.sanityErr)
 			} else {
-				assert.NoError(t, pld.SanityCheck())
+				assert.NoError(t, pld.BasicCheck())
 
 				// Check signer
 				if test.raw[0] != 0 {

--- a/types/tx/payload/transfer.go
+++ b/types/tx/payload/transfer.go
@@ -26,11 +26,11 @@ func (p *TransferPayload) Value() int64 {
 	return p.Amount
 }
 
-func (p *TransferPayload) SanityCheck() error {
-	if err := p.Sender.SanityCheck(); err != nil {
+func (p *TransferPayload) BasicCheck() error {
+	if err := p.Sender.BasicCheck(); err != nil {
 		return err
 	}
-	return p.Receiver.SanityCheck()
+	return p.Receiver.BasicCheck()
 }
 
 func (p *TransferPayload) SerializeSize() int {

--- a/types/tx/payload/transfer_test.go
+++ b/types/tx/payload/transfer_test.go
@@ -149,11 +149,11 @@ func TestTransferDecoding(t *testing.T) {
 			assert.Equal(t, len(w.Bytes()), pld.SerializeSize())
 			assert.Equal(t, w.Bytes(), test.raw)
 
-			// Sanity check
+			// Basic check
 			if test.sanityErr != nil {
-				assert.ErrorIs(t, pld.SanityCheck(), test.sanityErr)
+				assert.ErrorIs(t, pld.BasicCheck(), test.sanityErr)
 			} else {
-				assert.NoError(t, pld.SanityCheck())
+				assert.NoError(t, pld.BasicCheck())
 
 				// Check signer
 				if test.raw[0] != 0 {

--- a/types/tx/payload/unbond.go
+++ b/types/tx/payload/unbond.go
@@ -26,8 +26,8 @@ func (p *UnbondPayload) Value() int64 {
 }
 
 // TODO: write test for me.
-func (p *UnbondPayload) SanityCheck() error {
-	if err := p.Validator.SanityCheck(); err != nil {
+func (p *UnbondPayload) BasicCheck() error {
+	if err := p.Validator.BasicCheck(); err != nil {
 		return errors.Error(errors.ErrInvalidAddress)
 	}
 

--- a/types/tx/payload/withdraw.go
+++ b/types/tx/payload/withdraw.go
@@ -28,11 +28,11 @@ func (p *WithdrawPayload) Value() int64 {
 }
 
 // TODO: write test for me.
-func (p *WithdrawPayload) SanityCheck() error {
-	if err := p.From.SanityCheck(); err != nil {
+func (p *WithdrawPayload) BasicCheck() error {
+	if err := p.From.BasicCheck(); err != nil {
 		return errors.Error(errors.ErrInvalidAddress)
 	}
-	if err := p.To.SanityCheck(); err != nil {
+	if err := p.To.BasicCheck(); err != nil {
 		return errors.Error(errors.ErrInvalidAddress)
 	}
 

--- a/types/tx/tx.go
+++ b/types/tx/tx.go
@@ -24,8 +24,8 @@ const maxMemoLength = 64
 type ID = hash.Hash
 
 type Tx struct {
-	memorizedID   *ID
-	sanityChecked bool
+	memorizedID  *ID
+	basicChecked bool
 
 	data txData
 }
@@ -139,17 +139,17 @@ func (tx *Tx) IsLockTime() bool {
 }
 
 func (tx *Tx) SetSignature(sig crypto.Signature) {
-	tx.sanityChecked = false
+	tx.basicChecked = false
 	tx.data.Signature = sig
 }
 
 func (tx *Tx) SetPublicKey(pub crypto.PublicKey) {
-	tx.sanityChecked = false
+	tx.basicChecked = false
 	tx.data.PublicKey = pub
 }
 
-func (tx *Tx) SanityCheck() error {
-	if tx.sanityChecked {
+func (tx *Tx) BasicCheck() error {
+	if tx.basicChecked {
 		return nil
 	}
 	if tx.Version() != versionLatest {
@@ -164,7 +164,7 @@ func (tx *Tx) SanityCheck() error {
 	if err := tx.checkFee(); err != nil {
 		return err
 	}
-	if err := tx.Payload().SanityCheck(); err != nil {
+	if err := tx.Payload().BasicCheck(); err != nil {
 		return err
 	}
 	if len(tx.Memo()) > maxMemoLength {
@@ -174,7 +174,7 @@ func (tx *Tx) SanityCheck() error {
 		return err
 	}
 
-	tx.sanityChecked = true
+	tx.basicChecked = true
 
 	return nil
 }

--- a/types/vote/vote.go
+++ b/types/vote/vote.go
@@ -88,7 +88,7 @@ func (v *Vote) Verify(pubKey *bls.PublicKey) error {
 	return pubKey.Verify(v.SignBytes(), v.Signature())
 }
 
-func (v *Vote) SanityCheck() error {
+func (v *Vote) BasicCheck() error {
 	if !v.data.Type.IsValid() {
 		return errors.Errorf(errors.ErrInvalidVote, "invalid vote type")
 	}
@@ -98,7 +98,7 @@ func (v *Vote) SanityCheck() error {
 	if v.data.Round < 0 {
 		return errors.Error(errors.ErrInvalidRound)
 	}
-	if err := v.data.Signer.SanityCheck(); err != nil {
+	if err := v.data.Signer.BasicCheck(); err != nil {
 		return err
 	}
 	if v.Signature() == nil {

--- a/types/vote/vote_test.go
+++ b/types/vote/vote_test.go
@@ -54,40 +54,40 @@ func TestVoteSignature(t *testing.T) {
 	assert.Error(t, v2.Verify(pb2), "invalid signature")
 }
 
-func TestSanityCheck(t *testing.T) {
+func TestBasicCheck(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	t.Run("Invalid type", func(t *testing.T) {
 		v := vote.NewVote(4, 100, 0, ts.RandomHash(), ts.RandomAddress())
 
-		err := v.SanityCheck()
+		err := v.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidVote)
 	})
 
 	t.Run("Invalid height", func(t *testing.T) {
 		v := vote.NewVote(vote.VoteTypePrepare, 0, 0, ts.RandomHash(), ts.RandomAddress())
 
-		err := v.SanityCheck()
+		err := v.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidHeight)
 	})
 
 	t.Run("Invalid round", func(t *testing.T) {
 		v := vote.NewVote(vote.VoteTypePrepare, 100, -1, ts.RandomHash(), ts.RandomAddress())
 
-		err := v.SanityCheck()
+		err := v.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidRound)
 	})
 
 	t.Run("No signature", func(t *testing.T) {
 		v := vote.NewVote(vote.VoteTypePrepare, 100, 0, ts.RandomHash(), ts.RandomAddress())
 
-		err := v.SanityCheck()
+		err := v.BasicCheck()
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidVote)
 	})
 
 	t.Run("Ok", func(t *testing.T) {
 		v, _ := ts.GenerateTestChangeProposerVote(5, 5)
-		assert.NoError(t, v.SanityCheck())
+		assert.NoError(t, v.BasicCheck())
 	})
 }
 

--- a/util/bech32m/bech32m_test.go
+++ b/util/bech32m/bech32m_test.go
@@ -180,7 +180,7 @@ func TestMixedCaseEncode(t *testing.T) {
 func TestCanDecodeUnlimtedBech32(t *testing.T) {
 	input := "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp2krp0"
 
-	// Sanity check that an input of this length errors on regular Decode()
+	// basic check that an input of this length errors on regular Decode()
 	_, _, err := Decode(input)
 	if err == nil {
 		t.Fatalf("Test vector not appropriate")

--- a/util/logger/config.go
+++ b/util/logger/config.go
@@ -23,7 +23,7 @@ func DefaultConfig() *Config {
 	return conf
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
 	return nil
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -265,7 +265,7 @@ func TestSigningTx(t *testing.T) {
 	err = td.wallet.SignTransaction(td.password, trx)
 	assert.NoError(t, err)
 	assert.NotNil(t, trx.Signature())
-	assert.NoError(t, trx.SanityCheck())
+	assert.NoError(t, trx.BasicCheck())
 
 	id, err := td.wallet.BroadcastTransaction(trx)
 	assert.NoError(t, err)

--- a/www/grpc/transaction.go
+++ b/www/grpc/transaction.go
@@ -51,7 +51,7 @@ func (s *transactionServer) SendRawTransaction(_ context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "couldn't decode transaction: %v", err.Error())
 	}
 
-	if err := trx.SanityCheck(); err != nil {
+	if err := trx.BasicCheck(); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "couldn't verify transaction: %v", err.Error())
 	}
 

--- a/www/http/config.go
+++ b/www/http/config.go
@@ -12,7 +12,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
 	return nil
 }

--- a/www/nanomsg/config.go
+++ b/www/nanomsg/config.go
@@ -12,7 +12,7 @@ func DefaultConfig() *Config {
 	}
 }
 
-// SanityCheck performs basic checks on the configuration.
-func (conf *Config) SanityCheck() error {
+// BasicCheck performs basic checks on the configuration.
+func (conf *Config) BasicCheck() error {
 	return nil
 }


### PR DESCRIPTION
## Description

rename `SanityCheck` methods name to `BasicCheck`

## Related issue(s)

If this Pull Request is related to an issue, mention it here.
- Fixes #642 