### PR TITLE
chore(linter): enable dupword linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,10 @@ issues:
       linters:
         - funlen
 
+    - path: _test.go
+      linters:
+        - dupword
+
     - linters:
         - govet
       text: "shadow: declaration of \"err\" shadows"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,9 +46,27 @@ linters:
     - nonamedreturns # Consider to enable it
     - nlreturn # Consider to enable it
     - ireturn  # Consider to enable it (??)
-    - dupword  # Consider to enable it
 
 linters-settings:
+    dupword:
+      keywords:
+        - "the"
+        - "and"
+        - "a"
+        - "abandon"
+        - "ability"
+        - "able"
+        - "about"
+        - "above"
+        - "absent"
+        - "absorb"
+        - "abstract"
+        - "absurd"
+        - "abuse"
+        - "access"
+        - "accident"
+        - "account"
+
   gosimple:
     checks: ["all"]
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,10 +102,6 @@ issues:
       linters:
         - funlen
 
-    - path: _test.go
-      linters:
-        - dupword
-
     - linters:
         - govet
       text: "shadow: declaration of \"err\" shadows"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,7 @@ linters:
     - ireturn  # Consider to enable it (??)
 
 linters-settings:
-    dupword:
+  dupword:
       keywords:
         - "the"
         - "and"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,25 +48,6 @@ linters:
     - ireturn  # Consider to enable it (??)
 
 linters-settings:
-  dupword:
-      keywords:
-        - "the"
-        - "and"
-        - "a"
-        - "abandon"
-        - "ability"
-        - "able"
-        - "about"
-        - "above"
-        - "absent"
-        - "absorb"
-        - "abstract"
-        - "absurd"
-        - "abuse"
-        - "access"
-        - "accident"
-        - "account"
-
   gosimple:
     checks: ["all"]
 

--- a/types/validator/validator.go
+++ b/types/validator/validator.go
@@ -158,7 +158,7 @@ func (val *Validator) SerializeSize() int {
 	return 124 // 96+4+4+8+4+4+4
 }
 
-// Bytes returns returns the serialized byte representation of the validator.
+// Bytes returns the serialized byte representation of the validator.
 func (val *Validator) Bytes() ([]byte, error) {
 	w := bytes.NewBuffer(make([]byte, 0, val.SerializeSize()))
 

--- a/wallet/vault/vault_test.go
+++ b/wallet/vault/vault_test.go
@@ -307,35 +307,35 @@ func TestNeuter(t *testing.T) {
 }
 
 func TestValidateMnemonic(t *testing.T) {
-	tests := []struct {
-		mnenomic string
-		errStr   string
-	}{
-		{
-			"",
-			"Invalid mnenomic",
-		},
-		{
-			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon",
-			"Invalid mnenomic",
-		},
-		{
-			"bandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon",
-			"word `bandon` not found in reverse map",
-		},
-		{
-			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon",
-			"Checksum incorrect",
-		},
-		{
-			"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon cactus",
-			"",
-		},
-	}
-	for i, test := range tests {
-		err := CheckMnemonic(test.mnenomic)
-		if err != nil {
-			assert.ErrorContains(t, err, test.errStr, "test %v failed", i)
-		}
-	}
+    tests := []struct {
+        mnenomic string
+        errStr   string
+    }{
+        {
+            "",
+            "Invalid mnenomic",
+        },
+        {
+            "abandon ability able about above absent absorb abstract absurd abuse access",
+            "Invalid mnenomic",
+        },
+        {
+            "bandon ability able about above absent absorb abstract absurd abuse access ability",
+            "word `bandon` not found in reverse map",
+        },
+        {
+            "abandon ability able about above absent absorb abstract absurd abuse access accident",
+            "Checksum incorrect",
+        },
+        {
+            "abandon ability able about above absent absorb abstract absurd abuse access ability",
+            "",
+        },
+    }
+    for i, test := range tests {
+        err := CheckMnemonic(test.mnenomic)
+        if err != nil {
+            assert.Equal(t, err.Error(), test.errStr, "test %v failed", i)
+        }
+    }
 }

--- a/wallet/vault/vault_test.go
+++ b/wallet/vault/vault_test.go
@@ -307,35 +307,35 @@ func TestNeuter(t *testing.T) {
 }
 
 func TestValidateMnemonic(t *testing.T) {
-    tests := []struct {
-        mnenomic string
-        errStr   string
-    }{
-        {
-            "",
-            "Invalid mnenomic",
-        },
-        {
-            "abandon ability able about above absent absorb abstract absurd abuse access",
-            "Invalid mnenomic",
-        },
-        {
-            "bandon ability able about above absent absorb abstract absurd abuse access ability",
-            "word `bandon` not found in reverse map",
-        },
-        {
-            "abandon ability able about above absent absorb abstract absurd abuse access accident",
-            "Checksum incorrect",
-        },
-        {
-            "abandon ability able about above absent absorb abstract absurd abuse access ability",
-            "",
-        },
-    }
-    for i, test := range tests {
-        err := CheckMnemonic(test.mnenomic)
-        if err != nil {
-            assert.Equal(t, err.Error(), test.errStr, "test %v failed", i)
-        }
-    }
+	tests := []struct {
+		mnenomic string
+		errStr   string
+	}{
+		{
+			"",
+			"Invalid mnenomic",
+		},
+		{
+			"abandon ability able about above absent absorb abstract absurd abuse access",
+			"Invalid mnenomic",
+		},
+		{
+			"bandon ability able about above absent absorb abstract absurd abuse access ability",
+			"word `bandon` not found in reverse map",
+		},
+		{
+			"abandon ability able about above absent absorb abstract absurd abuse access accident",
+			"Checksum incorrect",
+		},
+		{
+			"abandon ability able about above absent absorb abstract absurd abuse access ability",
+			"",
+		},
+	}
+	for i, test := range tests {
+		err := CheckMnemonic(test.mnenomic)
+		if err != nil {
+			assert.Equal(t, err.Error(), test.errStr, "test %v failed", i)
+		}
+	}
 }


### PR DESCRIPTION
## Description
I enabled `dupword` linter

## Related issue(s)
- Fixes #649 