### PR TITLE
chore: remove gofmt and fix golang-ci version

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -30,7 +30,7 @@ jobs:
       run: make build_gui
 
     - name: Installing golangci-lint
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@1.54.1
 
     - name: Lint check
       run: BUILD_TAG=gtk make check

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -30,7 +30,7 @@ jobs:
       run: make build_gui
 
     - name: Installing golangci-lint
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@1.54.1
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
 
     - name: Lint check
       run: BUILD_TAG=gtk make check

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Installing golangci-lint
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@1.54.1
 
     - name: Formatting and linting the project
       run: make check

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Installing golangci-lint
-      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@1.54.1
+      run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
 
     - name: Formatting and linting the project
       run: make check

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: build test
 ### Tools needed for development
 devtools:
 	@echo "Installing devtools"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@1.54.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
 	go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.12
 	go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.12
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ proto:
 ########################################
 ### Formatting, linting, and vetting
 fmt:
-	gofmt -s -w .
 	gofumpt -l -w .
 
 check:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ proto:
 	cd www/grpc/ && statik -m -f -src swagger-ui/
 
 ########################################
-### Formatting, linting, and vetting
+### Formatting the code
 fmt:
 	gofumpt -l -w .
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: build test
 ### Tools needed for development
 devtools:
 	@echo "Installing devtools"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@1.54.1
 	go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.12
 	go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.12
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28


### PR DESCRIPTION
## Description

from the  `gofumpt` [documents](https://github.com/mvdan/gofumpt/blob/9a108c1953290163d2104befba4a340b5f553001/README.md?plain=1#L10) `gofumpt` is a superset of `gofmt` and using `gofmt` after `gofumpt` doesn't make any changes.
so, we can remove it.