### PR TITLE
chore: fix unbond typo

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -25,7 +25,7 @@ func newExecution(strict bool) *Execution {
 	execs[payload.TypeTransfer] = executor.NewTransferExecutor(strict)
 	execs[payload.TypeBond] = executor.NewBondExecutor(strict)
 	execs[payload.TypeSortition] = executor.NewSortitionExecutor(strict)
-	execs[payload.TypeUnbound] = executor.NewUnbondExecutor(strict)
+	execs[payload.TypeUnbond] = executor.NewUnbondExecutor(strict)
 	execs[payload.TypeWithdraw] = executor.NewWithdrawExecutor(strict)
 
 	return &Execution{

--- a/state/mock.go
+++ b/state/mock.go
@@ -247,7 +247,7 @@ func (m *MockState) CalculateFee(_ int64, payloadType payload.Type) (int64, erro
 			return m.ts.RandInt64(1e9), nil
 		}
 
-	case payload.TypeUnbound,
+	case payload.TypeUnbond,
 		payload.TypeSortition:
 		{
 			return 0, nil

--- a/state/state.go
+++ b/state/state.go
@@ -722,7 +722,7 @@ func (st *state) CalculateFee(amount int64, payloadType payload.Type) (int64, er
 			return execution.CalculateFee(amount, st.params), nil
 		}
 
-	case payload.TypeUnbound,
+	case payload.TypeUnbond,
 		payload.TypeSortition:
 		{
 			return 0, nil

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -768,7 +768,7 @@ func TestCalcFee(t *testing.T) {
 		{1 * 1e12, payload.TypeBond, 1000000, 1000000, errors.ErrNone},
 
 		{1 * 1e12, payload.TypeSortition, 0, 0, errors.ErrInvalidFee},
-		{1 * 1e12, payload.TypeUnbound, 0, 0, errors.ErrNone},
+		{1 * 1e12, payload.TypeUnbond, 0, 0, errors.ErrNone},
 	}
 	for _, test := range tests {
 		fee, err := td.state2.CalculateFee(test.amount, test.pldType)

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -31,7 +31,7 @@ func NewTxPool(conf *Config, broadcastCh chan message.Message) TxPool {
 
 	pending[payload.TypeTransfer] = linkedmap.NewLinkedMap[tx.ID, *tx.Tx](conf.sendPoolSize())
 	pending[payload.TypeBond] = linkedmap.NewLinkedMap[tx.ID, *tx.Tx](conf.bondPoolSize())
-	pending[payload.TypeUnbound] = linkedmap.NewLinkedMap[tx.ID, *tx.Tx](conf.unbondPoolSize())
+	pending[payload.TypeUnbond] = linkedmap.NewLinkedMap[tx.ID, *tx.Tx](conf.unbondPoolSize())
 	pending[payload.TypeWithdraw] = linkedmap.NewLinkedMap[tx.ID, *tx.Tx](conf.withdrawPoolSize())
 	pending[payload.TypeSortition] = linkedmap.NewLinkedMap[tx.ID, *tx.Tx](conf.sortitionPoolSize())
 
@@ -164,7 +164,7 @@ func (p *txPool) PrepareBlockTransactions() block.Txs {
 	}
 
 	// Appending unbond transactions
-	poolUnbond := p.pools[payload.TypeUnbound]
+	poolUnbond := p.pools[payload.TypeUnbond]
 	for n := poolUnbond.HeadNode(); n != nil; n = n.Next {
 		trxs = append(trxs, n.Data.Value)
 	}
@@ -212,7 +212,7 @@ func (p *txPool) String() string {
 	return fmt.Sprintf("{💸 %v 🔐 %v 🔓 %v 🎯 %v 🧾 %v}",
 		p.pools[payload.TypeTransfer].Size(),
 		p.pools[payload.TypeBond].Size(),
-		p.pools[payload.TypeUnbound].Size(),
+		p.pools[payload.TypeUnbond].Size(),
 		p.pools[payload.TypeSortition].Size(),
 		p.pools[payload.TypeWithdraw].Size(),
 	)

--- a/types/tx/payload/payload.go
+++ b/types/tx/payload/payload.go
@@ -13,7 +13,7 @@ const (
 	TypeTransfer  = Type(1)
 	TypeBond      = Type(2)
 	TypeSortition = Type(3)
-	TypeUnbound   = Type(4)
+	TypeUnbond   = Type(4)
 	TypeWithdraw  = Type(5)
 )
 
@@ -23,8 +23,8 @@ func (t Type) String() string {
 		return "transfer"
 	case TypeBond:
 		return "bond"
-	case TypeUnbound:
-		return "unbound"
+	case TypeUnbond:
+		return "unbond"
 	case TypeWithdraw:
 		return "withdraw"
 	case TypeSortition:

--- a/types/tx/payload/payload.go
+++ b/types/tx/payload/payload.go
@@ -13,7 +13,7 @@ const (
 	TypeTransfer  = Type(1)
 	TypeBond      = Type(2)
 	TypeSortition = Type(3)
-	TypeUnbond   = Type(4)
+	TypeUnbond    = Type(4)
 	TypeWithdraw  = Type(5)
 )
 

--- a/types/tx/payload/unbond.go
+++ b/types/tx/payload/unbond.go
@@ -14,7 +14,7 @@ type UnbondPayload struct {
 }
 
 func (p *UnbondPayload) Type() Type {
-	return TypeUnbound
+	return TypeUnbond
 }
 
 func (p *UnbondPayload) Signer() crypto.Address {

--- a/types/tx/tx.go
+++ b/types/tx/tx.go
@@ -339,7 +339,7 @@ func (tx *Tx) DecodeWithNoSignatory(r io.Reader) error {
 		tx.data.Payload = &payload.TransferPayload{}
 	case payload.TypeBond:
 		tx.data.Payload = &payload.BondPayload{}
-	case payload.TypeUnbound:
+	case payload.TypeUnbond:
 		tx.data.Payload = &payload.UnbondPayload{}
 	case payload.TypeWithdraw:
 		tx.data.Payload = &payload.WithdrawPayload{}
@@ -430,7 +430,7 @@ func (tx *Tx) IsSortitionTx() bool {
 }
 
 func (tx *Tx) IsUnbondTx() bool {
-	return tx.Payload().Type() == payload.TypeUnbound
+	return tx.Payload().Type() == payload.TypeUnbond
 }
 
 func (tx *Tx) IsWithdrawTx() bool {

--- a/wallet/tx_builder.go
+++ b/wallet/tx_builder.go
@@ -118,7 +118,7 @@ func (m *txBuilder) build() (*tx.Tx, error) {
 			}
 			trx = tx.NewBondTx(*m.stamp, m.seq, *m.from, *m.to, pub, m.amount, m.fee, m.memo)
 		}
-	case payload.TypeUnbound:
+	case payload.TypeUnbond:
 		trx = tx.NewUnbondTx(*m.stamp, m.seq, *m.from, m.memo)
 	case payload.TypeWithdraw:
 		trx = tx.NewWithdrawTx(*m.stamp, m.seq, *m.from, *m.to, m.amount, m.fee, m.memo)
@@ -160,7 +160,7 @@ func (m *txBuilder) setSequence() error {
 				m.seq = acc.Sequence + 1
 			}
 
-		case payload.TypeUnbound,
+		case payload.TypeUnbond,
 			payload.TypeWithdraw:
 			{
 				val, err := m.client.getValidator(*m.from)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -349,7 +349,7 @@ func (w *Wallet) MakeUnbondTx(addr string, opts ...TxOption) (*tx.Tx, error) {
 	if err != nil {
 		return nil, err
 	}
-	maker.typ = payload.TypeUnbound
+	maker.typ = payload.TypeUnbond
 
 	return maker.build()
 }

--- a/www/grpc/transaction.go
+++ b/www/grpc/transaction.go
@@ -126,7 +126,7 @@ func transactionToProto(trx *tx.Tx) *pactus.TransactionInfo {
 				Proof:   pld.Proof[:],
 			},
 		}
-	case payload.TypeUnbound:
+	case payload.TypeUnbond:
 		pld := trx.Payload().(*payload.UnbondPayload)
 		transaction.Payload = &pactus.TransactionInfo_Unbond{
 			Unbond: &pactus.PayloadUnbond{


### PR DESCRIPTION
## Description

from the previous PR, we changed `Unbond` to `Unbound`, but the `Unbond` phrase is correct, and changing it to `Unbound` needs a heavy change, so we decided to revert this word.