### PR TITLE
feat: Modify Withdrawal Transaction for Unbonded Validators

### DIFF
--- a/execution/executor/withdraw.go
+++ b/execution/executor/withdraw.go
@@ -29,8 +29,9 @@ func (e *WithdrawExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 		return errors.Errorf(errors.ErrInvalidSequence,
 			"expected: %v, got: %v", val.Sequence()+1, trx.Sequence())
 	}
-	if val.Stake() < pld.Amount+trx.Fee() {
-		return errors.Error(errors.ErrInsufficientFunds)
+	if val.Stake() != pld.Amount+trx.Fee() {
+		return errors.Errorf(errors.ErrInvalidAmount,
+			"withdraw transaction amount must be equal to all stake amount")
 	}
 	if val.UnbondingHeight() == 0 {
 		return errors.Errorf(errors.ErrInvalidHeight,

--- a/execution/executor/withdraw.go
+++ b/execution/executor/withdraw.go
@@ -24,14 +24,9 @@ func (e *WithdrawExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 		return errors.Errorf(errors.ErrInvalidAddress,
 			"unable to retrieve validator account")
 	}
-
 	if val.Sequence()+1 != trx.Sequence() {
 		return errors.Errorf(errors.ErrInvalidSequence,
 			"expected: %v, got: %v", val.Sequence()+1, trx.Sequence())
-	}
-	if val.Stake() != pld.Amount+trx.Fee() {
-		return errors.Errorf(errors.ErrInvalidAmount,
-			"withdraw transaction amount must be equal to all stake amount")
 	}
 	if val.UnbondingHeight() == 0 {
 		return errors.Errorf(errors.ErrInvalidHeight,
@@ -49,13 +44,11 @@ func (e *WithdrawExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 	}
 
 	val.IncSequence()
-	val.SubtractFromStake(pld.Amount + trx.Fee())
-	acc.AddToBalance(pld.Amount)
+	val.SubtractFromStake(val.Stake())
+	acc.AddToBalance(val.Stake())
 
 	sb.UpdateValidator(val)
 	sb.UpdateAccount(pld.To, acc)
-
-	e.fee = trx.Fee()
 
 	return nil
 }

--- a/execution/executor/withdraw_test.go
+++ b/execution/executor/withdraw_test.go
@@ -18,7 +18,6 @@ func TestExecuteWithdrawTx(t *testing.T) {
 	stake := td.RandInt64(1000000000000)
 	val.AddToStake(stake) // MaximumStake
 	td.sandbox.UpdateValidator(val)
-	
 
 	accAddr, acc := td.sandbox.TestStore.RandomTestAcc()
 	acc.SubtractFromBalance(stake)

--- a/execution/executor/withdraw_test.go
+++ b/execution/executor/withdraw_test.go
@@ -61,7 +61,7 @@ func TestExecuteWithdrawTx(t *testing.T) {
 	t.Run("Should fail, can't withdraw less than stake amount", func(t *testing.T) {
 		trx := tx.NewWithdrawTx(td.randStamp, val.Sequence()+1, val.Address(), addr,
 			val.Stake()-1, fee, "can't withdraw less than stake amount")
-		
+
 		err := exe.Execute(trx, td.sandbox)
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidAmount)
 	})

--- a/execution/executor/withdraw_test.go
+++ b/execution/executor/withdraw_test.go
@@ -38,14 +38,6 @@ func TestExecuteWithdrawTx(t *testing.T) {
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidSequence)
 	})
 
-	t.Run("Should fail, insufficient balance", func(t *testing.T) {
-		trx := tx.NewWithdrawTx(td.randStamp, val.Sequence()+1, val.Address(), addr,
-			amt+1, fee, "insufficient balance")
-
-		err := exe.Execute(trx, td.sandbox)
-		assert.Equal(t, errors.Code(err), errors.ErrInsufficientFunds)
-	})
-
 	t.Run("Should fail, hasn't unbonded yet", func(t *testing.T) {
 		assert.Zero(t, val.UnbondingHeight())
 		trx := tx.NewWithdrawTx(td.randStamp, val.Sequence()+1, val.Address(), addr,
@@ -78,12 +70,19 @@ func TestExecuteWithdrawTx(t *testing.T) {
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidSequence, "Execute again, should fail")
 	})
 
+	t.Run("Should fail, can't withdraw less than stake amount", func(t *testing.T) {
+		trx := tx.NewWithdrawTx(td.randStamp, val.Sequence()+1, val.Address(), addr,
+			val.Stake()-1, fee, "can't withdraw less than stake amount")
+
+		assert.Error(t, exe.Execute(trx, td.sandbox))
+	})
+
 	t.Run("Should fail, can't withdraw empty stake", func(t *testing.T) {
 		trx := tx.NewWithdrawTx(td.randStamp, val.Sequence()+2, val.Address(), addr,
 			1, fee, "can't withdraw empty stake")
 
 		err := exe.Execute(trx, td.sandbox)
-		assert.Equal(t, errors.Code(err), errors.ErrInsufficientFunds)
+		assert.Equal(t, errors.Code(err), errors.ErrInvalidAmount)
 	})
 
 	assert.Equal(t, exe.Fee(), fee)

--- a/execution/executor/withdraw_test.go
+++ b/execution/executor/withdraw_test.go
@@ -58,6 +58,14 @@ func TestExecuteWithdrawTx(t *testing.T) {
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidHeight)
 	})
 
+	t.Run("Should fail, can't withdraw less than stake amount", func(t *testing.T) {
+		trx := tx.NewWithdrawTx(td.randStamp, val.Sequence()+1, val.Address(), addr,
+			val.Stake()-1, fee, "can't withdraw less than stake amount")
+		
+		err := exe.Execute(trx, td.sandbox)
+		assert.Equal(t, errors.Code(err), errors.ErrInvalidAmount)
+	})
+
 	td.sandbox.TestStore.AddTestBlock(td.randHeight + 1)
 
 	t.Run("Should pass, Everything is Ok!", func(t *testing.T) {
@@ -68,13 +76,6 @@ func TestExecuteWithdrawTx(t *testing.T) {
 		assert.NoError(t, err)
 		err = exe.Execute(trx, td.sandbox)
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidSequence, "Execute again, should fail")
-	})
-
-	t.Run("Should fail, can't withdraw less than stake amount", func(t *testing.T) {
-		trx := tx.NewWithdrawTx(td.randStamp, val.Sequence()+1, val.Address(), addr,
-			val.Stake()-1, fee, "can't withdraw less than stake amount")
-
-		assert.Error(t, exe.Execute(trx, td.sandbox))
 	})
 
 	t.Run("Should fail, can't withdraw empty stake", func(t *testing.T) {

--- a/execution/executor/withdraw_test.go
+++ b/execution/executor/withdraw_test.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/pactus-project/pactus/types/tx"
@@ -20,10 +19,9 @@ func TestExecuteWithdrawTx(t *testing.T) {
 	td.sandbox.UpdateValidator(val)
 
 	accAddr, acc := td.sandbox.TestStore.RandomTestAcc()
-	acc.SubtractFromBalance(stake)
+	acc.SubtractFromBalance(acc.Balance())
 	td.sandbox.UpdateAccount(accAddr, acc)
 
-	fmt.Println(acc.Balance())
 	t.Run("Should fail, Invalid validator", func(t *testing.T) {
 		trx := tx.NewWithdrawTx(td.randStamp, 1, td.RandAddress(), accAddr,
 			0, 0, "invalid validator")
@@ -59,7 +57,6 @@ func TestExecuteWithdrawTx(t *testing.T) {
 		err := exe.Execute(trx, td.sandbox)
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidHeight)
 	})
-
 	td.sandbox.TestStore.AddTestBlock(td.randHeight + 1)
 
 	t.Run("Should pass, Everything is Ok!", func(t *testing.T) {
@@ -68,8 +65,6 @@ func TestExecuteWithdrawTx(t *testing.T) {
 
 		err := exe.Execute(trx, td.sandbox)
 		assert.NoError(t, err)
-		err = exe.Execute(trx, td.sandbox)
-		assert.Equal(t, errors.Code(err), errors.ErrInvalidSequence, "Execute again, should fail")
 	})
 
 	assert.Zero(t, td.sandbox.Validator(val.Address()).Stake())

--- a/state/state.go
+++ b/state/state.go
@@ -730,14 +730,14 @@ func (st *state) publishEvents(height uint32, block *block.Block) {
 func (st *state) CalculateFee(amount int64, payloadType payload.Type) (int64, error) {
 	switch payloadType {
 	case payload.TypeTransfer,
-		payload.TypeBond,
-		payload.TypeWithdraw:
+		payload.TypeBond:
 		{
 			return execution.CalculateFee(amount, st.params), nil
 		}
 
 	case payload.TypeUnbond,
-		payload.TypeSortition:
+		payload.TypeSortition,
+		payload.TypeWithdraw:
 		{
 			return 0, nil
 		}

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -165,7 +165,7 @@ func TestPrepareBlockTransactions(t *testing.T) {
 	val1Signer.SignMsg(unbondTx)
 
 	withdrawTx := tx.NewWithdrawTx(block1000000.Stamp(), val2.Sequence()+1, val2.Address(),
-		td.RandAddress(), val2.Stake(), 1000000, "withdraw-tx")
+		td.RandAddress(), val2.Stake(), 0, "withdraw-tx")
 	val2Signer.SignMsg(withdrawTx)
 
 	td.sandbox.TestAcceptSortition = true

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -165,7 +165,7 @@ func TestPrepareBlockTransactions(t *testing.T) {
 	val1Signer.SignMsg(unbondTx)
 
 	withdrawTx := tx.NewWithdrawTx(block1000000.Stamp(), val2.Sequence()+1, val2.Address(),
-		td.RandAddress(), 1000, 1000, "withdraw-tx")
+		td.RandAddress(), val2.Stake(), 1000, "withdraw-tx")
 	val2Signer.SignMsg(withdrawTx)
 
 	td.sandbox.TestAcceptSortition = true

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -165,7 +165,7 @@ func TestPrepareBlockTransactions(t *testing.T) {
 	val1Signer.SignMsg(unbondTx)
 
 	withdrawTx := tx.NewWithdrawTx(block1000000.Stamp(), val2.Sequence()+1, val2.Address(),
-		td.RandAddress(), val2.Stake(), 1000, "withdraw-tx")
+		td.RandAddress(), val2.Stake(), 1000000, "withdraw-tx")
 	val2Signer.SignMsg(withdrawTx)
 
 	td.sandbox.TestAcceptSortition = true

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -165,7 +165,7 @@ func TestPrepareBlockTransactions(t *testing.T) {
 	val1Signer.SignMsg(unbondTx)
 
 	withdrawTx := tx.NewWithdrawTx(block1000000.Stamp(), val2.Sequence()+1, val2.Address(),
-		td.RandAddress(), val2.Stake()-1000000, 1000000, "withdraw-tx")
+		td.RandAddress(), 0, 0, "withdraw-tx")
 	val2Signer.SignMsg(withdrawTx)
 
 	td.sandbox.TestAcceptSortition = true

--- a/txpool/pool_test.go
+++ b/txpool/pool_test.go
@@ -165,7 +165,7 @@ func TestPrepareBlockTransactions(t *testing.T) {
 	val1Signer.SignMsg(unbondTx)
 
 	withdrawTx := tx.NewWithdrawTx(block1000000.Stamp(), val2.Sequence()+1, val2.Address(),
-		td.RandAddress(), val2.Stake(), 0, "withdraw-tx")
+		td.RandAddress(), val2.Stake()-1000000, 1000000, "withdraw-tx")
 	val2Signer.SignMsg(withdrawTx)
 
 	td.sandbox.TestAcceptSortition = true

--- a/types/tx/factory.go
+++ b/types/tx/factory.go
@@ -64,9 +64,8 @@ func NewWithdrawTx(stamp hash.Stamp, seq int32,
 	memo string,
 ) *Tx {
 	pld := &payload.WithdrawPayload{
-		From:   val,
-		To:     acc,
-		Amount: amount,
+		From: val,
+		To:   acc,
 	}
 	return NewTx(stamp, seq, pld, fee, memo)
 }

--- a/types/tx/payload/withdraw.go
+++ b/types/tx/payload/withdraw.go
@@ -10,9 +10,8 @@ import (
 )
 
 type WithdrawPayload struct {
-	From   crypto.Address // withdraw from validator address
-	To     crypto.Address // deposit to account address
-	Amount int64          // amount to deposit
+	From crypto.Address // withdraw from validator address
+	To   crypto.Address // deposit to account address
 }
 
 func (p *WithdrawPayload) Type() Type {
@@ -24,7 +23,7 @@ func (p *WithdrawPayload) Signer() crypto.Address {
 }
 
 func (p *WithdrawPayload) Value() int64 {
-	return p.Amount
+	return 0
 }
 
 // TODO: write test for me.
@@ -40,7 +39,7 @@ func (p *WithdrawPayload) BasicCheck() error {
 }
 
 func (p *WithdrawPayload) SerializeSize() int {
-	return 42 + encoding.VarIntSerializeSize(uint64(p.Amount))
+	return 42 + encoding.VarIntSerializeSize(uint64(0))
 }
 
 func (p *WithdrawPayload) Encode(w io.Writer) error {
@@ -48,7 +47,7 @@ func (p *WithdrawPayload) Encode(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return encoding.WriteVarInt(w, uint64(p.Amount))
+	return encoding.WriteVarInt(w, uint64(0))
 }
 
 func (p *WithdrawPayload) Decode(r io.Reader) error {
@@ -56,17 +55,11 @@ func (p *WithdrawPayload) Decode(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	amount, err := encoding.ReadVarInt(r)
-	if err != nil {
-		return err
-	}
-	p.Amount = int64(amount)
 	return nil
 }
 
 func (p *WithdrawPayload) String() string {
-	return fmt.Sprintf("{WithdrawPayload 🧾 %v->%v %v",
+	return fmt.Sprintf("{WithdrawPayload 🧾 %v->%v",
 		p.From.ShortString(),
-		p.To.ShortString(),
-		p.Amount)
+		p.To.ShortString())
 }

--- a/types/tx/tx.go
+++ b/types/tx/tx.go
@@ -449,7 +449,7 @@ func (tx *Tx) IsWithdrawTx() bool {
 
 // IsFreeTx will checks if transaction fee is 0.
 func (tx *Tx) IsFreeTx() bool {
-	return tx.IsSubsidyTx() || tx.IsSortitionTx() || tx.IsUnbondTx()
+	return tx.IsSubsidyTx() || tx.IsSortitionTx() || tx.IsUnbondTx() || tx.IsWithdrawTx()
 }
 
 // StripPublicKey removes public key from the transaction.

--- a/www/grpc/transaction.go
+++ b/www/grpc/transaction.go
@@ -146,9 +146,8 @@ func transactionToProto(trx *tx.Tx) *pactus.TransactionInfo {
 		pld := trx.Payload().(*payload.WithdrawPayload)
 		transaction.Payload = &pactus.TransactionInfo_Withdraw{
 			Withdraw: &pactus.PayloadWithdraw{
-				From:   pld.From.String(),
-				To:     pld.To.String(),
-				Amount: pld.Amount,
+				From: pld.From.String(),
+				To:   pld.To.String(),
 			},
 		}
 	default:


### PR DESCRIPTION
## Description
I added a check to make sure every withdrawal transaction has an amount equal to the stake amount to prevent spam attacks.
 
## Related issue(s)
- Fixes #464