### PR TITLE
chore: better logging by renaming err to error

### DIFF
--- a/consensus/commit.go
+++ b/consensus/commit.go
@@ -21,7 +21,7 @@ func (s *commitState) decide() {
 	cert := s.makeCertificate(votes)
 	err := s.state.CommitBlock(s.height, certBlock, cert)
 	if err != nil {
-		s.logger.Error("committing block failed", "block", certBlock, "err", err)
+		s.logger.Error("committing block failed", "block", certBlock, "error", err)
 	} else {
 		s.logger.Info("block committed, schedule new height", "hash", certBlock.Hash().ShortString())
 	}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -226,12 +226,12 @@ func (cs *consensus) SetProposal(p *proposal.Proposal) {
 	} else {
 		proposer := cs.proposer(p.Round())
 		if err := p.Verify(proposer.PublicKey()); err != nil {
-			cs.logger.Warn("proposal has invalid signature", "proposal", p, "err", err)
+			cs.logger.Warn("proposal has invalid signature", "proposal", p, "error", err)
 			return
 		}
 
 		if err := cs.state.ValidateBlock(p.Block()); err != nil {
-			cs.logger.Warn("invalid block", "proposal", p, "err", err)
+			cs.logger.Warn("invalid block", "proposal", p, "error", err)
 			return
 		}
 	}
@@ -280,7 +280,7 @@ func (cs *consensus) AddVote(v *vote.Vote) {
 		v.Type() == vote.VoteTypeCPMainVote {
 		err := cs.checkJust(v)
 		if err != nil {
-			cs.logger.Error("error on adding a cp vote", "vote", v, "err", err)
+			cs.logger.Error("error on adding a cp vote", "vote", v, "error", err)
 			return
 		}
 
@@ -307,7 +307,7 @@ func (cs *consensus) AddVote(v *vote.Vote) {
 
 	added, err := cs.log.AddVote(v)
 	if err != nil {
-		cs.logger.Error("error on adding a vote", "vote", v, "err", err)
+		cs.logger.Error("error on adding a vote", "vote", v, "error", err)
 	}
 	if added {
 		cs.logger.Debug("new vote added", "vote", v)
@@ -650,7 +650,7 @@ func (cs *consensus) signAddVote(v *vote.Vote) {
 
 	_, err := cs.log.AddVote(v)
 	if err != nil {
-		cs.logger.Error("error on adding our vote", "err", err, "vote", v)
+		cs.logger.Error("error on adding our vote", "error", err, "vote", v)
 	}
 	cs.broadcastVote(v)
 }

--- a/consensus/height.go
+++ b/consensus/height.go
@@ -30,7 +30,7 @@ func (s *newHeightState) decide() {
 				lastCert := s.makeCertificate(votes)
 				if lastCert != nil {
 					if err := s.state.UpdateLastCertificate(lastCert); err != nil {
-						s.logger.Warn("updating last certificate failed", "err", err)
+						s.logger.Warn("updating last certificate failed", "error", err)
 					}
 				}
 			}

--- a/consensus/propose.go
+++ b/consensus/propose.go
@@ -31,11 +31,11 @@ func (s *proposeState) decide() {
 func (s *proposeState) createProposal(height uint32, round int16) {
 	block, err := s.state.ProposeBlock(s.signer, s.rewardAddr, round)
 	if err != nil {
-		s.logger.Error("unable to propose a block!", "err", err)
+		s.logger.Error("unable to propose a block!", "error", err)
 		return
 	}
 	if err := s.state.ValidateBlock(block); err != nil {
-		s.logger.Error("proposed block is invalid!", "err", err)
+		s.logger.Error("proposed block is invalid!", "error", err)
 		return
 	}
 

--- a/network/bootstrap.go
+++ b/network/bootstrap.go
@@ -47,7 +47,7 @@ func newBootstrap(ctx context.Context, h lp2phost.Host, d lp2pnet.Dialer, r lp2p
 
 	addresses, err := PeerAddrsToAddrInfo(conf.Addresses)
 	if err != nil {
-		b.logger.Panic("couldn't parse bootstrap addresses", "err", err, "addresses", conf.Addresses)
+		b.logger.Panic("couldn't parse bootstrap addresses", "error", err, "addresses", conf.Addresses)
 	}
 	b.bootstrapPeers = addresses
 
@@ -122,7 +122,7 @@ func (b *bootstrap) checkConnectivity() {
 			}
 
 			if err := b.host.Connect(b.ctx, pi); err != nil {
-				b.logger.Error("error trying to connect to bootstrap node", "info", pi, "err", err)
+				b.logger.Error("error trying to connect to bootstrap node", "info", pi, "error", err)
 			}
 		}
 
@@ -149,6 +149,6 @@ func (b *bootstrap) expand() {
 
 	err := dht.Bootstrap(b.ctx)
 	if err != nil {
-		b.logger.Warn("peer discovery may suffer", "err", err)
+		b.logger.Warn("peer discovery may suffer", "error", err)
 	}
 }

--- a/network/dht.go
+++ b/network/dht.go
@@ -27,7 +27,7 @@ func newDHTService(ctx context.Context, host lp2phost.Host, protocolID lp2pcore.
 
 	kademlia, err := lp2pdht.New(ctx, host, opts...)
 	if err != nil {
-		logger.Panic("unable to start DHT service", "err", err)
+		logger.Panic("unable to start DHT service", "error", err)
 		return nil
 	}
 
@@ -51,7 +51,7 @@ func (dht *dhtService) Start() error {
 
 func (dht *dhtService) Stop() {
 	if err := dht.kademlia.Close(); err != nil {
-		dht.logger.Error("unable to close Kademlia", "err", err)
+		dht.logger.Error("unable to close Kademlia", "error", err)
 	}
 
 	dht.bootstrap.Stop()

--- a/network/gossip.go
+++ b/network/gossip.go
@@ -25,7 +25,7 @@ func newGossipService(ctx context.Context, host lp2phost.Host, eventCh chan Even
 ) *gossipService {
 	pubsub, err := lp2pps.NewGossipSub(ctx, host)
 	if err != nil {
-		logger.Panic("unable to start Gossip service", "err", err)
+		logger.Panic("unable to start Gossip service", "error", err)
 		return nil
 	}
 
@@ -66,7 +66,7 @@ func (g *gossipService) JoinTopic(name string) (*lp2pps.Topic, error) {
 		for {
 			m, err := sub.Next(g.ctx)
 			if err != nil {
-				g.logger.Debug("readLoop error", "err", err)
+				g.logger.Debug("readLoop error", "error", err)
 				return
 			}
 

--- a/network/mdns.go
+++ b/network/mdns.go
@@ -41,7 +41,7 @@ func (mdns *mdnsService) HandlePeerFound(pi lp2ppeer.AddrInfo) {
 	if pi.ID != mdns.host.ID() {
 		mdns.logger.Debug("connecting to new peer", "addr", pi.Addrs, "id", pi.ID.Pretty())
 		if err := mdns.host.Connect(ctx, pi); err != nil {
-			mdns.logger.Error("error on connecting to peer", "id", pi.ID.Pretty(), "err", err)
+			mdns.logger.Error("error on connecting to peer", "id", pi.ID.Pretty(), "error", err)
 		}
 	}
 }
@@ -58,6 +58,6 @@ func (mdns *mdnsService) Start() error {
 func (mdns *mdnsService) Stop() {
 	err := mdns.service.Close()
 	if err != nil {
-		mdns.logger.Error("unable to close the network", "err", err)
+		mdns.logger.Error("unable to close the network", "error", err)
 	}
 }

--- a/network/network.go
+++ b/network/network.go
@@ -219,7 +219,7 @@ func (n *network) Stop() {
 	n.stream.Stop()
 
 	if err := n.host.Close(); err != nil {
-		n.logger.Error("unable to close the network", "err", err)
+		n.logger.Error("unable to close the network", "error", err)
 	}
 }
 

--- a/network/stream.go
+++ b/network/stream.go
@@ -70,7 +70,7 @@ func (s *streamService) SendRequest(msg []byte, pid lp2peer.ID) error {
 	stream, err := s.host.NewStream(
 		lp2pnetwork.WithNoDial(s.ctx, "should already have connection"), pid, s.protocolID)
 	if err != nil {
-		s.logger.Debug("unable to open direct stream", "pid", pid, "err", err)
+		s.logger.Debug("unable to open direct stream", "pid", pid, "error", err)
 		if len(s.relayAddrs) == 0 {
 			return err
 		}
@@ -100,7 +100,7 @@ func (s *streamService) SendRequest(msg []byte, pid lp2peer.ID) error {
 
 		if err := s.host.Connect(s.ctx, unreachableRelayInfo); err != nil {
 			// There is no relay connection to peer as well
-			s.logger.Warn("unable to connect to peer using relay", "pid", pid, "err", err)
+			s.logger.Warn("unable to connect to peer using relay", "pid", pid, "error", err)
 			return LibP2PError{Err: err}
 		}
 		s.logger.Debug("connected to peer using relay", "pid", pid)
@@ -110,7 +110,7 @@ func (s *streamService) SendRequest(msg []byte, pid lp2peer.ID) error {
 		stream, err = s.host.NewStream(
 			lp2pnetwork.WithUseTransient(s.ctx, string(s.protocolID)), pid, s.protocolID)
 		if err != nil {
-			s.logger.Warn("unable to open relay stream", "pid", pid, "err", err)
+			s.logger.Warn("unable to open relay stream", "pid", pid, "error", err)
 			return LibP2PError{Err: err}
 		}
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -269,7 +269,7 @@ func (st *state) UpdateLastCertificate(cert *certificate.Certificate) error {
 	// Check if certificate has more signers ...
 	if len(cert.Absentees()) < len(st.lastInfo.Certificate().Absentees()) {
 		if err := st.validatePrevCertificate(cert, st.lastInfo.BlockHash()); err != nil {
-			st.logger.Warn("try to update last certificate, but it's invalid", "err", err)
+			st.logger.Warn("try to update last certificate, but it's invalid", "error", err)
 			return err
 		}
 		st.lastInfo.UpdateCertificate(cert)
@@ -317,7 +317,7 @@ func (st *state) ProposeBlock(signer crypto.Signer, rewardAddr crypto.Address, r
 		}
 
 		if err := exe.Execute(txs[i], sb); err != nil {
-			st.logger.Debug("found invalid transaction", "tx", txs[i], "err", err)
+			st.logger.Debug("found invalid transaction", "tx", txs[i], "error", err)
 			txs.Remove(i)
 			i--
 		}
@@ -440,7 +440,7 @@ func (st *state) CommitBlock(height uint32, block *block.Block, cert *certificat
 	}
 
 	if err := st.store.WriteBatch(); err != nil {
-		st.logger.Panic("unable to update state", "err", err)
+		st.logger.Panic("unable to update state", "error", err)
 	}
 
 	st.logger.Info("new block committed", "block", block, "round", cert.Round())
@@ -490,7 +490,7 @@ func (st *state) evaluateSortition() bool {
 				evaluated = true
 			} else {
 				st.logger.Error("our sortition transaction is invalid!",
-					"address", signer.Address(), "power", val.Power(), "tx", trx, "err", err)
+					"address", signer.Address(), "power", val.Power(), "tx", trx, "error", err)
 			}
 		}
 	}
@@ -630,7 +630,7 @@ func (st *state) MakeCommittedBlock(data []byte, height uint32, blockHash hash.H
 func (st *state) CommittedBlock(height uint32) *store.CommittedBlock {
 	b, err := st.store.Block(height)
 	if err != nil {
-		st.logger.Trace("error on retrieving block", "err", err)
+		st.logger.Trace("error on retrieving block", "error", err)
 		return nil
 	}
 	return b
@@ -639,7 +639,7 @@ func (st *state) CommittedBlock(height uint32) *store.CommittedBlock {
 func (st *state) CommittedTx(id tx.ID) *store.CommittedTx {
 	tx, err := st.store.Transaction(id)
 	if err != nil {
-		st.logger.Trace("searching transaction in local store failed", "id", id, "err", err)
+		st.logger.Trace("searching transaction in local store failed", "id", id, "error", err)
 	}
 	return tx
 }
@@ -655,7 +655,7 @@ func (st *state) BlockHeight(hash hash.Hash) uint32 {
 func (st *state) AccountByAddress(addr crypto.Address) *account.Account {
 	acc, err := st.store.Account(addr)
 	if err != nil {
-		st.logger.Trace("error on retrieving account", "err", err)
+		st.logger.Trace("error on retrieving account", "error", err)
 	}
 	return acc
 }
@@ -663,7 +663,7 @@ func (st *state) AccountByAddress(addr crypto.Address) *account.Account {
 func (st *state) AccountByNumber(number int32) *account.Account {
 	acc, err := st.store.AccountByNumber(number)
 	if err != nil {
-		st.logger.Trace("error on retrieving account", "err", err)
+		st.logger.Trace("error on retrieving account", "error", err)
 	}
 	return acc
 }
@@ -675,7 +675,7 @@ func (st *state) ValidatorAddresses() []crypto.Address {
 func (st *state) ValidatorByAddress(addr crypto.Address) *validator.Validator {
 	val, err := st.store.Validator(addr)
 	if err != nil {
-		st.logger.Trace("error on retrieving validator", "err", err)
+		st.logger.Trace("error on retrieving validator", "error", err)
 	}
 	return val
 }
@@ -684,7 +684,7 @@ func (st *state) ValidatorByAddress(addr crypto.Address) *validator.Validator {
 func (st *state) ValidatorByNumber(n int32) *validator.Validator {
 	val, err := st.store.ValidatorByNumber(n)
 	if err != nil {
-		st.logger.Trace("error on retrieving validator", "err", err)
+		st.logger.Trace("error on retrieving validator", "error", err)
 	}
 	return val
 }

--- a/store/account.go
+++ b/store/account.go
@@ -29,7 +29,7 @@ func newAccountStore(db *leveldb.DB) *accountStore {
 
 		acc, err := account.FromBytes(value)
 		if err != nil {
-			logger.Panic("unable to decode account", "err", err)
+			logger.Panic("unable to decode account", "error", err)
 		}
 
 		var addr crypto.Address
@@ -87,7 +87,7 @@ func (as *accountStore) iterateAccounts(consumer func(crypto.Address, *account.A
 func (as *accountStore) updateAccount(batch *leveldb.Batch, addr crypto.Address, acc *account.Account) {
 	data, err := acc.Bytes()
 	if err != nil {
-		logger.Panic("unable to encode account", "err", err)
+		logger.Panic("unable to encode account", "error", err)
 	}
 	if !as.hasAccount(addr) {
 		as.total++

--- a/store/store.go
+++ b/store/store.go
@@ -44,7 +44,7 @@ func tryGet(db *leveldb.DB, key []byte) ([]byte, error) {
 	data, err := db.Get(key, nil)
 	if err != nil {
 		// Probably key doesn't exist in database
-		logger.Trace("database error", "err", err, "key", key)
+		logger.Trace("database error", "error", err, "key", key)
 		return nil, err
 	}
 	return data, nil

--- a/store/validator.go
+++ b/store/validator.go
@@ -29,7 +29,7 @@ func newValidatorStore(db *leveldb.DB) *validatorStore {
 
 		val, err := validator.FromBytes(value)
 		if err != nil {
-			logger.Panic("unable to decode validator", "err", err)
+			logger.Panic("unable to decode validator", "error", err)
 		}
 
 		numberMap[val.Number()] = val
@@ -92,7 +92,7 @@ func (vs *validatorStore) iterateValidators(consumer func(*validator.Validator) 
 func (vs *validatorStore) updateValidator(batch *leveldb.Batch, val *validator.Validator) {
 	data, err := val.Bytes()
 	if err != nil {
-		logger.Panic("unable to encode validator", "err", err)
+		logger.Panic("unable to encode validator", "error", err)
 	}
 	if !vs.hasValidator(val.Address()) {
 		vs.total++

--- a/sync/firewall/firewall.go
+++ b/sync/firewall/firewall.go
@@ -48,7 +48,7 @@ func (f *Firewall) OpenGossipBundle(data []byte, source peer.ID, from peer.ID) *
 
 	bdl, err := f.openBundle(bytes.NewReader(data), source)
 	if err != nil {
-		f.logger.Warn("firewall: unable to open a gossip bundle", "err", err)
+		f.logger.Warn("firewall: unable to open a gossip bundle", "error", err)
 		f.closeConnection(from)
 		return nil
 	}
@@ -62,7 +62,7 @@ func (f *Firewall) OpenGossipBundle(data []byte, source peer.ID, from peer.ID) *
 func (f *Firewall) OpenStreamBundle(r io.Reader, from peer.ID) *bundle.Bundle {
 	bdl, err := f.openBundle(r, from)
 	if err != nil {
-		f.logger.Warn("firewall: unable to open a stream bundle", "err", err)
+		f.logger.Warn("firewall: unable to open a stream bundle", "error", err)
 		f.closeConnection(from)
 		return nil
 	}

--- a/sync/handler_transactions.go
+++ b/sync/handler_transactions.go
@@ -22,7 +22,7 @@ func (handler *transactionsHandler) ParseMessage(m message.Message, _ peer.ID) e
 
 	for _, trx := range msg.Transactions {
 		if err := handler.state.AddPendingTx(trx); err != nil {
-			handler.logger.Debug("cannot append transaction", "tx", trx, "err", err)
+			handler.logger.Debug("cannot append transaction", "tx", trx, "error", err)
 
 			// TODO: set peer as bad peer?
 		}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -173,7 +173,7 @@ func (sync *synchronizer) receiveLoop() {
 				bdl := sync.firewall.OpenGossipBundle(ge.Data, ge.Source, ge.From)
 				err := sync.processIncomingBundle(bdl)
 				if err != nil {
-					sync.logger.Warn("error on parsing a Gossip bundle", "initiator", bdl.Initiator, "bundle", bdl, "err", err)
+					sync.logger.Warn("error on parsing a Gossip bundle", "initiator", bdl.Initiator, "bundle", bdl, "error", err)
 					sync.peerSet.IncreaseInvalidBundlesCounter(bdl.Initiator)
 				}
 
@@ -182,11 +182,11 @@ func (sync *synchronizer) receiveLoop() {
 				bdl := sync.firewall.OpenStreamBundle(se.Reader, se.Source)
 				if err := se.Reader.Close(); err != nil {
 					// TODO: write test for me
-					sync.logger.Warn("error on closing stream", "err", err)
+					sync.logger.Warn("error on closing stream", "error", err)
 				}
 				err := sync.processIncomingBundle(bdl)
 				if err != nil {
-					sync.logger.Warn("error on parsing a Stream bundle", "initiator", bdl.Initiator, "bundle", bdl, "err", err)
+					sync.logger.Warn("error on parsing a Stream bundle", "initiator", bdl.Initiator, "bundle", bdl, "error", err)
 					sync.peerSet.IncreaseInvalidBundlesCounter(bdl.Initiator)
 				}
 			case network.EventTypeConnect:
@@ -296,7 +296,7 @@ func (sync *synchronizer) sendTo(msg message.Message, to peer.ID) error {
 
 		err := sync.network.SendTo(data, to)
 		if err != nil {
-			sync.logger.Warn("error on sending bundle", "bundle", bdl, "err", err, "to", to)
+			sync.logger.Warn("error on sending bundle", "bundle", bdl, "error", err, "to", to)
 
 			return err
 		}
@@ -313,7 +313,7 @@ func (sync *synchronizer) broadcast(msg message.Message) {
 		data, _ := bdl.Encode()
 		err := sync.network.Broadcast(data, msg.Type().TopicID())
 		if err != nil {
-			sync.logger.Error("error on broadcasting bundle", "bundle", bdl, "err", err)
+			sync.logger.Error("error on broadcasting bundle", "bundle", bdl, "error", err)
 		} else {
 			sync.logger.Info("broadcasting new bundle", "bundle", bdl)
 		}
@@ -405,7 +405,7 @@ func (sync *synchronizer) tryCommitBlocks() {
 		}
 		sync.logger.Trace("committing block", "height", height, "block", b)
 		if err := sync.state.CommitBlock(height, b, c); err != nil {
-			sync.logger.Warn("committing block failed", "block", b, "err", err, "height", height)
+			sync.logger.Warn("committing block failed", "block", b, "error", err, "height", height)
 			// We will ask network to re-send this block again ...
 			break
 		}

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -112,7 +112,7 @@ func (p *txPool) appendTx(trx *tx.Tx) error {
 
 func (p *txPool) checkTx(trx *tx.Tx) error {
 	if err := p.checker.Execute(trx, p.sandbox); err != nil {
-		p.logger.Debug("invalid transaction", "tx", trx, "err", err)
+		p.logger.Debug("invalid transaction", "tx", trx, "error", err)
 		return err
 	}
 	return nil

--- a/util/logger/logger_test.go
+++ b/util/logger/logger_test.go
@@ -20,7 +20,7 @@ func TestNilObjLogger(t *testing.T) {
 	var buf bytes.Buffer
 	l.logger = l.logger.Output(&buf)
 
-	l.Info("hello", "err", fmt.Errorf("error"))
+	l.Info("hello", "error", fmt.Errorf("error"))
 	assert.Contains(t, buf.String(), "hello")
 	assert.Contains(t, buf.String(), "error")
 }
@@ -48,7 +48,7 @@ func TestObjLogger(t *testing.T) {
 	assert.NotContains(t, out, "debug")
 	assert.Contains(t, out, "info")
 	assert.Contains(t, out, "warn")
-	assert.Contains(t, out, "err")
+	assert.Contains(t, out, "error")
 }
 
 func TestLogger(t *testing.T) {

--- a/www/grpc/network.go
+++ b/www/grpc/network.go
@@ -28,7 +28,7 @@ func (s *networkServer) GetNetworkInfo(_ context.Context,
 
 		bs, err := cbor.Marshal(peer.Agent)
 		if err != nil {
-			s.logger.Error("couldn't marshal agent", "err", err)
+			s.logger.Error("couldn't marshal agent", "error", err)
 			continue
 		}
 		p.Agent = string(bs)

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -81,13 +81,13 @@ func (s *Server) StartServer() error {
 	s.grpc = grpc
 	go func() {
 		if err := s.grpc.Serve(listener); err != nil {
-			s.logger.Error("error on grpc serve", "err", err)
+			s.logger.Error("error on grpc serve", "error", err)
 		}
 	}()
 
 	go func() {
 		if err := s.startGateway(); err != nil {
-			s.logger.Error("error on grpc-gateway serve", "err", err)
+			s.logger.Error("error on grpc-gateway serve", "error", err)
 		}
 	}()
 

--- a/www/http/server.go
+++ b/www/http/server.go
@@ -94,7 +94,7 @@ func (s *Server) StartServer(grpcServer string) error {
 		for {
 			err := server.Serve(l)
 			if err != nil {
-				s.logger.Error("error on a connection", "err", err)
+				s.logger.Error("error on a connection", "error", err)
 			}
 		}
 	}()
@@ -128,7 +128,7 @@ func (s *Server) RootHandler(w http.ResponseWriter, _ *http.Request) {
 		return nil
 	})
 	if err != nil {
-		s.logger.Error("unable to walk through methods", "err", err)
+		s.logger.Error("unable to walk through methods", "error", err)
 		return
 	}
 
@@ -138,7 +138,7 @@ func (s *Server) RootHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) writeError(w http.ResponseWriter, err error) int {
-	s.logger.Error("an error occurred", "err", err)
+	s.logger.Error("an error occurred", "error", err)
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusBadRequest)

--- a/www/nanomsg/event/event.go
+++ b/www/nanomsg/event/event.go
@@ -24,7 +24,7 @@ func CreateBlockEvent(blockHash hash.Hash, height uint32) Event {
 	w := bytes.NewBuffer(buf)
 	err := encoding.WriteElements(w, TopicNewBlock, blockHash, height)
 	if err != nil {
-		logger.Error("error on encoding event", "err", err)
+		logger.Error("error on encoding event", "error", err)
 	}
 	return w.Bytes()
 }
@@ -37,7 +37,7 @@ func CreateNewTransactionEvent(txHash tx.ID, height uint32) Event {
 	w := bytes.NewBuffer(buf)
 	err := encoding.WriteElements(w, TopicNewTransaction, txHash, height)
 	if err != nil {
-		logger.Error("error on encoding event in transaction event", "err", err)
+		logger.Error("error on encoding event in transaction event", "error", err)
 	}
 	return w.Bytes()
 }

--- a/www/nanomsg/server.go
+++ b/www/nanomsg/server.go
@@ -43,10 +43,10 @@ func (s *Server) StartServer() error {
 		var publisher mangos.Socket
 		var err error
 		if publisher, err = pub.NewSocket(); err != nil {
-			s.logger.Error("error on nanomsg creating new socket", "err", err)
+			s.logger.Error("error on nanomsg creating new socket", "error", err)
 		}
 		if err = publisher.Listen(s.config.Listen); err != nil {
-			s.logger.Error("error on nanomsg publisher binding", "err", err)
+			s.logger.Error("error on nanomsg publisher binding", "error", err)
 		}
 		s.publisher = publisher
 		go s.eventLoop()
@@ -71,12 +71,12 @@ func (s *Server) eventLoop() {
 			w := bytes.NewBuffer(e)
 			err := encoding.WriteElement(w, s.seqNum)
 			if err != nil {
-				s.logger.Error("error on encoding event", "err", err)
+				s.logger.Error("error on encoding event", "error", err)
 				return
 			}
 			err = s.publisher.Send(w.Bytes())
 			if err != nil {
-				s.logger.Error("error on emitting event", "err", err)
+				s.logger.Error("error on emitting event", "error", err)
 				return
 			}
 			s.seqNum++


### PR DESCRIPTION
## Description

Renaming `err` to `error` improves logging in colorful logs.