### PR TITLE
fix: restoring at the first block

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -26,6 +26,7 @@ type sandbox struct {
 	accounts        map[crypto.Address]*sandboxAccount
 	validators      map[crypto.Address]*sandboxValidator
 	params          param.Params
+	height          uint32
 	totalAccounts   int32
 	totalValidators int32
 	totalPower      int64
@@ -43,10 +44,11 @@ type sandboxAccount struct {
 	updated bool
 }
 
-func NewSandbox(store store.Reader, params param.Params,
+func NewSandbox(height uint32, store store.Reader, params param.Params,
 	committee committee.Reader, totalPower int64,
 ) Sandbox {
 	sb := &sandbox{
+		height:     height,
 		store:      store,
 		committee:  committee,
 		totalPower: totalPower,
@@ -218,13 +220,7 @@ func (sb *sandbox) CurrentHeight() uint32 {
 	sb.lk.RLock()
 	defer sb.lk.RUnlock()
 
-	return sb.currentHeight()
-}
-
-func (sb *sandbox) currentHeight() uint32 {
-	h, _ := sb.store.LastCertificate()
-
-	return h + 1
+	return sb.height + 1
 }
 
 func (sb *sandbox) IterateAccounts(

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -48,15 +48,14 @@ func setup(t *testing.T) *testData {
 		totalPower += val.Power()
 	}
 
-	sandbox := NewSandbox(store, params, committee, totalPower).(*sandbox)
-
-	assert.Equal(t, sandbox.CurrentHeight(), uint32(1))
 	lastHeight := uint32(21)
 	for i := uint32(1); i < lastHeight; i++ {
 		b := ts.GenerateTestBlock(nil)
 		c := ts.GenerateTestCertificate()
 		store.SaveBlock(i, b, c)
 	}
+	sandbox := NewSandbox(store.LastHeight,
+		store, params, committee, totalPower).(*sandbox)
 	assert.Equal(t, sandbox.CurrentHeight(), lastHeight)
 	assert.Equal(t, sandbox.Params(), params)
 

--- a/state/state.go
+++ b/state/state.go
@@ -67,15 +67,15 @@ func LoadOrNewState(
 	st.logger = logger.NewSubLogger("_state", st)
 	st.store = store
 
-	// The first account is Treasury Account at the genesis time.
-	// So if we have more account, we are not in the genesis height anymore.
-	if store.TotalAccounts() > 1 {
+	// Check if the number of accounts is greater than the genesis time;
+	// this indicates we are not at the genesis height anymore.
+	if store.TotalAccounts() > int32(len(genDoc.Accounts())) {
 		err := st.tryLoadLastInfo()
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		// We are at the genesis height
+		// We are at the genesis height.
 		err := st.makeGenesisState(genDoc)
 		if err != nil {
 			return nil, err
@@ -94,7 +94,8 @@ func LoadOrNewState(
 }
 
 func (st *state) concreteSandbox() sandbox.Sandbox {
-	return sandbox.NewSandbox(st.store, st.params, st.committee, st.totalPower)
+	return sandbox.NewSandbox(st.lastInfo.BlockHeight(),
+		st.store, st.params, st.committee, st.totalPower)
 }
 
 func (st *state) tryLoadLastInfo() error {


### PR DESCRIPTION
## Description

The genesis can have more than one account. This PR checks if the number of accounts in the store exceeds the number of accounts in the genesis. If it does, it's considered that the blockchain is no longer at the genesis height.