### PR TITLE
fix: ensure log rotation using tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -129,7 +129,7 @@ func SaveTestnetConfig(path string, numValidators int) error {
 	conf.GRPC.Listen = "[::]:50052"
 	conf.GRPC.Gateway.Enable = true
 	conf.GRPC.Gateway.Listen = "[::]:8080"
-	conf.HTTP.Enable = true
+	conf.HTTP.Enable = false
 	conf.HTTP.Listen = "[::]:80"
 	conf.Nanomsg.Enable = true
 	conf.Nanomsg.Listen = "tcp://127.0.0.1:40799"
@@ -149,7 +149,7 @@ func SaveLocalnetConfig(path string, numValidators int) error {
 	conf.GRPC.Listen = "[::]:0"
 	conf.GRPC.Gateway.Enable = true
 	conf.GRPC.Gateway.Listen = "[::]:0"
-	conf.HTTP.Enable = true
+	conf.HTTP.Enable = false
 	conf.HTTP.Listen = "[::]:0"
 	conf.Nanomsg.Enable = true
 	conf.Nanomsg.Listen = "tcp://127.0.0.1:0"

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pactus-project/pactus/types/param"
 	"github.com/pactus-project/pactus/types/validator"
 	"github.com/pactus-project/pactus/util"
+	"github.com/pactus-project/pactus/util/logger"
 	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,8 @@ import (
 func TestRunningNode(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
+	// Prevent log from messing the workspace
+	logger.LogFilename = util.TempFilePath()
 	pub, _ := ts.RandBLSKeyPair()
 	acc := account.NewAccount(0)
 	acc.AddToBalance(21 * 1e14)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pactus-project/pactus/types/param"
 	"github.com/pactus-project/pactus/types/validator"
 	"github.com/pactus-project/pactus/util"
+	"github.com/pactus-project/pactus/util/logger"
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -56,6 +57,9 @@ func getSequence(addr crypto.Address) int32 {
 }
 
 func TestMain(m *testing.M) {
+	// Prevent log from messing the workspace
+	logger.LogFilename = util.TempFilePath()
+
 	tSigners = make([][]crypto.Signer, tTotalNodes)
 	tConfigs = make([]*config.Config, tTotalNodes)
 	tNodes = make([]*node.Node, tTotalNodes)

--- a/util/logger/config.go
+++ b/util/logger/config.go
@@ -1,10 +1,5 @@
 package logger
 
-const (
-	LogDirectory = "logs"
-	LogFilename  = "pactus.log"
-)
-
 type Config struct {
 	Colorful bool              `toml:"colorful"`
 	Levels   map[string]string `toml:"levels"`

--- a/util/logger/logger_test.go
+++ b/util/logger/logger_test.go
@@ -3,8 +3,12 @@ package logger
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/pactus-project/pactus/util"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 )
@@ -80,4 +84,35 @@ func TestLogger(t *testing.T) {
 	assert.Contains(t, out, "info")
 	assert.Contains(t, out, "warn")
 	assert.Contains(t, out, "error")
+}
+
+func TestRotating(t *testing.T) {
+	tempDir := util.TempDirPath()
+	fmt.Println(tempDir)
+	MaxLogSize = 1
+	LogFilename = filepath.Join(tempDir, "pactus.log")
+	c := DefaultConfig()
+	InitGlobalLogger(c)
+	logger := NewSubLogger("test", nil)
+
+	for i := 0; i < 1000; i++ {
+		logger.Info(strings.Repeat("l", 1024))
+	}
+
+	assert.True(t, hasGzFile(tempDir), "log didn't rotate")
+}
+
+func hasGzFile(dir string) bool {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+
+	for _, file := range files {
+		if !file.IsDir() && strings.HasSuffix(file.Name(), ".gz") {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
## Description

This PR:
- Enables writing to `os.Stderr` and to files for both global and sub-loggers.
- Ensures the working space remains unaffected during project testing.
- Introduces a test for log rotation.

## Related issue(s)

This PR also fixes #666 