### PR TITLE
fix: fixing a crash on consensus

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -276,27 +276,6 @@ func (cs *consensus) AddVote(v *vote.Vote) {
 			cs.logger.Error("error on adding a cp vote", "vote", v, "error", err)
 			return
 		}
-
-		if v.Round() == cs.round && cs.cpWeakValidity == nil {
-			if v.CPValue() == vote.CPValueZero ||
-				v.CPValue() == vote.CPValueAbstain {
-				// TODO: Should we check the vote signature first before proceeding with this?"
-				bh := v.BlockHash()
-				cs.cpWeakValidity = &bh
-
-				roundProposal := cs.log.RoundProposal(cs.round)
-
-				if roundProposal != nil &&
-					roundProposal.Block().Hash() != bh {
-					cs.logger.Warn("double proposal detected",
-						"prepared", bh.ShortString(),
-						"roundProposal", roundProposal.Block().Hash().ShortString())
-
-					cs.log.SetRoundProposal(cs.round, nil)
-					cs.queryProposal()
-				}
-			}
-		}
 	}
 
 	added, err := cs.log.AddVote(v)

--- a/consensus/cp_decide.go
+++ b/consensus/cp_decide.go
@@ -38,7 +38,7 @@ func (s *cpDecideState) decide() {
 				s.cpDecided = 0
 			} else {
 				// conflicting votes
-				s.logger.Info("conflicting main votes", "round", s.cpRound)
+				s.logger.Debug("conflicting main votes", "round", s.cpRound)
 			}
 
 			s.cpRound++

--- a/consensus/cp_prevote.go
+++ b/consensus/cp_prevote.go
@@ -33,7 +33,7 @@ func (s *cpPreVoteState) decide() {
 	} else {
 		cpMainVotes := s.log.CPMainVoteVoteSet(s.round)
 		if cpMainVotes.HasAnyVoteFor(s.cpRound-1, vote.CPValueOne) {
-			s.logger.Info("cp: one main-vote for one", "b", "1")
+			s.logger.Debug("cp: one main-vote for one", "b", "1")
 
 			vote1 := cpMainVotes.GetRandomVote(s.cpRound-1, vote.CPValueOne)
 			just1 := &vote.JustPreVoteHard{
@@ -41,7 +41,7 @@ func (s *cpPreVoteState) decide() {
 			}
 			s.signAddCPPreVote(hash.UndefHash, s.cpRound, vote.CPValueOne, just1)
 		} else if cpMainVotes.HasAnyVoteFor(s.cpRound-1, vote.CPValueZero) {
-			s.logger.Info("cp: one main-vote for zero", "b", "0")
+			s.logger.Debug("cp: one main-vote for zero", "b", "0")
 
 			vote0 := cpMainVotes.GetRandomVote(s.cpRound-1, vote.CPValueZero)
 			just0 := &vote.JustPreVoteHard{
@@ -49,7 +49,7 @@ func (s *cpPreVoteState) decide() {
 			}
 			s.signAddCPPreVote(*s.cpWeakValidity, s.cpRound, vote.CPValueZero, just0)
 		} else if cpMainVotes.HasAllVotesFor(s.cpRound-1, vote.CPValueAbstain) {
-			s.logger.Info("cp: all main-votes are abstain", "b", "0 (biased)")
+			s.logger.Debug("cp: all main-votes are abstain", "b", "0 (biased)")
 
 			votes := cpMainVotes.BinaryVotes(s.cpRound-1, vote.CPValueAbstain)
 			cert := s.makeCertificate(votes)

--- a/consensus/manager.go
+++ b/consensus/manager.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pactus-project/pactus/sync/bundle/message"
 	"github.com/pactus-project/pactus/types/proposal"
 	"github.com/pactus-project/pactus/types/vote"
-	"github.com/pactus-project/pactus/util/logger"
 	"golang.org/x/exp/slices"
 )
 
@@ -114,7 +113,6 @@ func (mgr *manager) MoveToNewHeight() {
 			continue
 
 		case p.Height() == curHeight:
-			logger.Warn("p.Height() == curHeight", "height", p.Height())
 			for _, cons := range mgr.instances {
 				cons.SetProposal(p)
 			}
@@ -134,7 +132,6 @@ func (mgr *manager) MoveToNewHeight() {
 			continue
 
 		case v.Height() == curHeight:
-			logger.Warn("v.Height() == curHeight", "height", v.Height())
 			for _, cons := range mgr.instances {
 				cons.AddVote(v)
 			}

--- a/consensus/manager.go
+++ b/consensus/manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pactus-project/pactus/sync/bundle/message"
 	"github.com/pactus-project/pactus/types/proposal"
 	"github.com/pactus-project/pactus/types/vote"
+	"github.com/pactus-project/pactus/util/logger"
 	"golang.org/x/exp/slices"
 )
 
@@ -113,6 +114,7 @@ func (mgr *manager) MoveToNewHeight() {
 			continue
 
 		case p.Height() == curHeight:
+			logger.Warn("p.Height() == curHeight", "height", p.Height())
 			for _, cons := range mgr.instances {
 				cons.SetProposal(p)
 			}
@@ -132,6 +134,7 @@ func (mgr *manager) MoveToNewHeight() {
 			continue
 
 		case v.Height() == curHeight:
+			logger.Warn("v.Height() == curHeight", "height", v.Height())
 			for _, cons := range mgr.instances {
 				cons.AddVote(v)
 			}


### PR DESCRIPTION
## Description

A crash could occur in the consensus if a validator receives all pre-votes for zero before receiving a proposal. In this case, the node crashed because the prepared block hash was nil.

A test is written to reproduce the crash.