### PR TITLE
fix: cache certificate by height

### DIFF
--- a/consensus/commit.go
+++ b/consensus/commit.go
@@ -19,7 +19,7 @@ func (s *commitState) decide() {
 	precommits := s.log.PrecommitVoteSet(s.round)
 	votes := precommits.BlockVotes(certBlock.Hash())
 	cert := s.makeCertificate(votes)
-	err := s.state.CommitBlock(s.height, certBlock, cert)
+	err := s.state.CommitBlock(certBlock, cert)
 	if err != nil {
 		s.logger.Error("committing block failed", "block", certBlock, "error", err)
 	} else {
@@ -27,7 +27,7 @@ func (s *commitState) decide() {
 	}
 
 	// Now we can announce the committed block and certificate
-	s.announceNewBlock(s.height, certBlock, cert)
+	s.announceNewBlock(certBlock, cert)
 
 	s.enterNewState(s.newHeightState)
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -651,10 +651,10 @@ func (cs *consensus) broadcastVote(v *vote.Vote) {
 		message.NewVoteMessage(v))
 }
 
-func (cs *consensus) announceNewBlock(h uint32, b *block.Block, c *certificate.Certificate) {
+func (cs *consensus) announceNewBlock(blk *block.Block, cert *certificate.Certificate) {
 	go cs.mediator.OnBlockAnnounce(cs)
 	cs.broadcaster(cs.valKey.Address(),
-		message.NewBlockAnnounceMessage(h, b, c))
+		message.NewBlockAnnounceMessage(blk, cert))
 }
 
 func (cs *consensus) makeCertificate(votes map[crypto.Address]*vote.Vote) *certificate.Certificate {

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -323,18 +323,18 @@ func (td *testData) commitBlockForAllStates(t *testing.T) (*block.Block, *certif
 
 	sig := bls.SignatureAggregate(sig1, sig2, sig4)
 	cert := certificate.NewCertificate(height+1, 0, []int32{0, 1, 2, 3}, []int32{2}, sig)
-	block := p.Block()
+	blk := p.Block()
 
-	err = td.consX.state.CommitBlock(block, cert)
+	err = td.consX.state.CommitBlock(blk, cert)
 	assert.NoError(t, err)
-	err = td.consY.state.CommitBlock(block, cert)
+	err = td.consY.state.CommitBlock(blk, cert)
 	assert.NoError(t, err)
-	err = td.consB.state.CommitBlock(block, cert)
+	err = td.consB.state.CommitBlock(blk, cert)
 	assert.NoError(t, err)
-	err = td.consP.state.CommitBlock(block, cert)
+	err = td.consP.state.CommitBlock(blk, cert)
 	assert.NoError(t, err)
 
-	return block, cert
+	return blk, cert
 }
 
 func (td *testData) makeProposal(t *testing.T, height uint32, round int16) *proposal.Proposal {

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -325,13 +325,13 @@ func (td *testData) commitBlockForAllStates(t *testing.T) (*block.Block, *certif
 	cert := certificate.NewCertificate(height+1, 0, []int32{0, 1, 2, 3}, []int32{2}, sig)
 	block := p.Block()
 
-	err = td.consX.state.CommitBlock(height+1, block, cert)
+	err = td.consX.state.CommitBlock(block, cert)
 	assert.NoError(t, err)
-	err = td.consY.state.CommitBlock(height+1, block, cert)
+	err = td.consY.state.CommitBlock(block, cert)
 	assert.NoError(t, err)
-	err = td.consB.state.CommitBlock(height+1, block, cert)
+	err = td.consB.state.CommitBlock(block, cert)
 	assert.NoError(t, err)
-	err = td.consP.state.CommitBlock(height+1, block, cert)
+	err = td.consP.state.CommitBlock(block, cert)
 	assert.NoError(t, err)
 
 	return block, cert
@@ -619,17 +619,15 @@ func TestNonActiveValidator(t *testing.T) {
 
 	t.Run("non-active instances should move to new height", func(t *testing.T) {
 		b1, cert1 := td.commitBlockForAllStates(t)
-		b2, cert2 := td.commitBlockForAllStates(t)
 
 		nonActiveCons.MoveToNewHeight()
 		td.checkHeightRound(t, nonActiveCons, 1, 0)
 
-		assert.NoError(t, nonActiveCons.state.CommitBlock(1, b1, cert1))
-		assert.NoError(t, nonActiveCons.state.CommitBlock(2, b2, cert2))
+		assert.NoError(t, nonActiveCons.state.CommitBlock(b1, cert1))
 
 		nonActiveCons.MoveToNewHeight()
 		td.newHeightTimeout(nonActiveCons)
-		td.checkHeightRound(t, nonActiveCons, 3, 0)
+		td.checkHeightRound(t, nonActiveCons, 2, 0)
 	})
 }
 

--- a/consensus/cp_test.go
+++ b/consensus/cp_test.go
@@ -201,7 +201,7 @@ func TestInvalidJustInitZero(t *testing.T) {
 	h := uint32(1)
 	r := int16(0)
 	just := &vote.JustInitZero{
-		QCert: td.GenerateTestCertificate(),
+		QCert: td.GenerateTestCertificate(h),
 	}
 
 	t.Run("invalid value: one", func(t *testing.T) {
@@ -230,7 +230,7 @@ func TestInvalidJustInitZero(t *testing.T) {
 		err := td.consX.checkJust(v)
 		assert.ErrorIs(t, err, invalidJustificationError{
 			JustType: just.Type(),
-			Reason:   fmt.Sprintf("certificate height is invalid (expected 1 got %v)", just.QCert.Height()),
+			Reason:   fmt.Sprintf("certificate has an unexpected committers: %v", just.QCert.Committers()),
 		})
 	})
 }
@@ -242,7 +242,7 @@ func TestInvalidJustPreVoteHard(t *testing.T) {
 	h := uint32(1)
 	r := int16(0)
 	just := &vote.JustPreVoteHard{
-		QCert: td.GenerateTestCertificate(),
+		QCert: td.GenerateTestCertificate(h),
 	}
 
 	t.Run("invalid value: abstain", func(t *testing.T) {
@@ -271,7 +271,7 @@ func TestInvalidJustPreVoteHard(t *testing.T) {
 		err := td.consX.checkJust(v)
 		assert.ErrorIs(t, err, invalidJustificationError{
 			JustType: just.Type(),
-			Reason:   fmt.Sprintf("certificate height is invalid (expected 1 got %v)", just.QCert.Height()),
+			Reason:   fmt.Sprintf("certificate has an unexpected committers: %v", just.QCert.Committers()),
 		})
 	})
 }
@@ -283,7 +283,7 @@ func TestInvalidJustPreVoteSoft(t *testing.T) {
 	h := uint32(1)
 	r := int16(0)
 	just := &vote.JustPreVoteSoft{
-		QCert: td.GenerateTestCertificate(),
+		QCert: td.GenerateTestCertificate(h),
 	}
 
 	t.Run("invalid value: abstain", func(t *testing.T) {
@@ -312,7 +312,7 @@ func TestInvalidJustPreVoteSoft(t *testing.T) {
 		err := td.consX.checkJust(v)
 		assert.ErrorIs(t, err, invalidJustificationError{
 			JustType: just.Type(),
-			Reason:   fmt.Sprintf("certificate height is invalid (expected 1 got %v)", just.QCert.Height()),
+			Reason:   fmt.Sprintf("certificate has an unexpected committers: %v", just.QCert.Committers()),
 		})
 	})
 }
@@ -324,7 +324,7 @@ func TestInvalidJustMainVoteNoConflict(t *testing.T) {
 	h := uint32(1)
 	r := int16(0)
 	just := &vote.JustMainVoteNoConflict{
-		QCert: td.GenerateTestCertificate(),
+		QCert: td.GenerateTestCertificate(h),
 	}
 
 	t.Run("invalid value: abstain", func(t *testing.T) {
@@ -343,7 +343,7 @@ func TestInvalidJustMainVoteNoConflict(t *testing.T) {
 		err := td.consX.checkJust(v)
 		assert.ErrorIs(t, err, invalidJustificationError{
 			JustType: just.Type(),
-			Reason:   fmt.Sprintf("certificate height is invalid (expected 1 got %v)", just.QCert.Height()),
+			Reason:   fmt.Sprintf("certificate has an unexpected committers: %v", just.QCert.Committers()),
 		})
 	})
 }
@@ -358,7 +358,7 @@ func TestInvalidJustMainVoteConflict(t *testing.T) {
 	t.Run("invalid value: zero", func(t *testing.T) {
 		just := &vote.JustMainVoteConflict{
 			Just0: &vote.JustInitZero{
-				QCert: td.GenerateTestCertificate(),
+				QCert: td.GenerateTestCertificate(h),
 			},
 			Just1: &vote.JustInitOne{},
 		}
@@ -374,7 +374,7 @@ func TestInvalidJustMainVoteConflict(t *testing.T) {
 	t.Run("invalid value: one", func(t *testing.T) {
 		just := &vote.JustMainVoteConflict{
 			Just0: &vote.JustInitZero{
-				QCert: td.GenerateTestCertificate(),
+				QCert: td.GenerateTestCertificate(h),
 			},
 			Just1: &vote.JustInitOne{},
 		}
@@ -390,7 +390,7 @@ func TestInvalidJustMainVoteConflict(t *testing.T) {
 	t.Run("invalid value: unexpected justification (just0)", func(t *testing.T) {
 		just := &vote.JustMainVoteConflict{
 			Just0: &vote.JustPreVoteSoft{
-				QCert: td.GenerateTestCertificate(),
+				QCert: td.GenerateTestCertificate(h),
 			},
 			Just1: &vote.JustInitOne{},
 		}
@@ -406,10 +406,10 @@ func TestInvalidJustMainVoteConflict(t *testing.T) {
 	t.Run("invalid value: unexpected justification", func(t *testing.T) {
 		just := &vote.JustMainVoteConflict{
 			Just0: &vote.JustInitZero{
-				QCert: td.GenerateTestCertificate(),
+				QCert: td.GenerateTestCertificate(h),
 			},
 			Just1: &vote.JustPreVoteSoft{
-				QCert: td.GenerateTestCertificate(),
+				QCert: td.GenerateTestCertificate(h),
 			},
 		}
 		v := vote.NewCPMainVote(td.RandHash(), h, r, 1, vote.CPValueAbstain, just, td.valKeys[tIndexB].Address())
@@ -423,7 +423,7 @@ func TestInvalidJustMainVoteConflict(t *testing.T) {
 
 	t.Run("invalid certificate", func(t *testing.T) {
 		just0 := &vote.JustInitZero{
-			QCert: td.GenerateTestCertificate(),
+			QCert: td.GenerateTestCertificate(h),
 		}
 		just := &vote.JustMainVoteConflict{
 			Just0: just0,
@@ -434,18 +434,18 @@ func TestInvalidJustMainVoteConflict(t *testing.T) {
 		err := td.consX.checkJust(v)
 		assert.ErrorIs(t, err, invalidJustificationError{
 			JustType: just0.Type(),
-			Reason:   fmt.Sprintf("certificate height is invalid (expected 1 got %v)", just0.QCert.Height()),
+			Reason:   fmt.Sprintf("certificate has an unexpected committers: %v", just0.QCert.Committers()),
 		})
 	})
 
 	t.Run("invalid certificate", func(t *testing.T) {
 		just0 := &vote.JustPreVoteSoft{
-			QCert: td.GenerateTestCertificate(),
+			QCert: td.GenerateTestCertificate(h),
 		}
 		just := &vote.JustMainVoteConflict{
 			Just0: just0,
 			Just1: &vote.JustPreVoteSoft{
-				QCert: td.GenerateTestCertificate(),
+				QCert: td.GenerateTestCertificate(h),
 			},
 		}
 		v := vote.NewCPMainVote(td.RandHash(), h, r, 1, vote.CPValueAbstain, just, td.valKeys[tIndexB].Address())
@@ -453,7 +453,7 @@ func TestInvalidJustMainVoteConflict(t *testing.T) {
 		err := td.consX.checkJust(v)
 		assert.ErrorIs(t, err, invalidJustificationError{
 			JustType: just0.Type(),
-			Reason:   fmt.Sprintf("certificate height is invalid (expected 1 got %v)", just0.QCert.Height()),
+			Reason:   fmt.Sprintf("certificate has an unexpected committers: %v", just0.QCert.Committers()),
 		})
 	})
 }

--- a/consensus/manager_test.go
+++ b/consensus/manager_test.go
@@ -64,7 +64,9 @@ func TestManager(t *testing.T) {
 	valKeys[4] = ts.RandValKey()
 	broadcastCh := make(chan message.Message, 500)
 
-	state.TestStore.SaveBlock(ts.RandHeight(), ts.GenerateTestBlock(), ts.GenerateTestCertificate())
+	height := ts.RandHeight()
+	blk, cert := ts.GenerateTestBlock(height)
+	state.TestStore.SaveBlock(blk, cert)
 
 	Mgr := NewManager(testConfig(), state, valKeys, rewardAddrs, broadcastCh)
 	mgr := Mgr.(*manager)
@@ -77,7 +79,7 @@ func TestManager(t *testing.T) {
 
 	assert.False(t, mgr.HasActiveInstance())
 	mgr.MoveToNewHeight()
-	curHeight := state.TestStore.LastHeight + 1
+	curHeight, _ := mgr.HeightRound()
 
 	newHeightTimeout(consA)
 
@@ -165,13 +167,13 @@ func TestManager(t *testing.T) {
 
 		assert.Len(t, mgr.upcomingVotes, 3)
 
-		err := state.CommitBlock(curHeight,
-			ts.GenerateTestBlockWithTime(util.Now().Add(1*time.Hour)), ts.GenerateTestCertificate())
+		blk, cert := ts.GenerateTestBlockWithTime(curHeight, util.Now().Add(1*time.Hour))
+		err := state.CommitBlock(blk, cert)
 		assert.NoError(t, err)
 		curHeight++
 
-		err = state.CommitBlock(curHeight,
-			ts.GenerateTestBlockWithTime(util.Now().Add(1*time.Hour)), ts.GenerateTestCertificate())
+		blk, cert = ts.GenerateTestBlockWithTime(curHeight, util.Now().Add(2*time.Hour))
+		err = state.CommitBlock(blk, cert)
 		assert.NoError(t, err)
 		curHeight++
 
@@ -200,13 +202,13 @@ func TestManager(t *testing.T) {
 
 		assert.Len(t, mgr.upcomingProposals, 3)
 
-		err := state.CommitBlock(curHeight,
-			ts.GenerateTestBlockWithTime(util.Now().Add(1*time.Hour)), ts.GenerateTestCertificate())
+		blk, cert := ts.GenerateTestBlockWithTime(curHeight, util.Now().Add(1*time.Hour))
+		err := state.CommitBlock(blk, cert)
 		assert.NoError(t, err)
 		curHeight++
 
-		err = state.CommitBlock(curHeight,
-			ts.GenerateTestBlockWithTime(util.Now().Add(1*time.Hour)), ts.GenerateTestCertificate())
+		blk, cert = ts.GenerateTestBlockWithTime(curHeight, util.Now().Add(2*time.Hour))
+		err = state.CommitBlock(blk, cert)
 		assert.NoError(t, err)
 
 		mgr.MoveToNewHeight()

--- a/consensus/propose_test.go
+++ b/consensus/propose_test.go
@@ -23,14 +23,14 @@ func TestSetProposalInvalidProposer(t *testing.T) {
 	assert.Nil(t, td.consY.RoundProposal(0))
 
 	addr := td.valKeys[tIndexB].Address()
-	b := td.GenerateTestBlockWithProposer(addr)
-	p := proposal.NewProposal(1, 0, b)
+	blk, _ := td.GenerateTestBlockWithProposer(1, addr)
+	invalidProp := proposal.NewProposal(1, 0, blk)
 
-	td.consY.SetProposal(p)
+	td.consY.SetProposal(invalidProp)
 	assert.Nil(t, td.consY.RoundProposal(0))
 
-	td.HelperSignProposal(td.valKeys[tIndexB], p) // Invalid signature
-	td.consY.SetProposal(p)
+	td.HelperSignProposal(td.valKeys[tIndexB], invalidProp)
+	td.consY.SetProposal(invalidProp)
 	assert.Nil(t, td.consY.RoundProposal(0))
 }
 
@@ -38,15 +38,15 @@ func TestSetProposalInvalidBlock(t *testing.T) {
 	td := setup(t)
 
 	addr := td.valKeys[tIndexB].Address()
-	invBlock := td.GenerateTestBlockWithProposer(addr)
-	p := proposal.NewProposal(1, 2, invBlock)
-	td.HelperSignProposal(td.valKeys[tIndexB], p)
+	blk, _ := td.GenerateTestBlockWithProposer(1, addr)
+	invProp := proposal.NewProposal(1, 2, blk)
+	td.HelperSignProposal(td.valKeys[tIndexB], invProp)
 
 	td.enterNewHeight(td.consP)
 	td.enterNextRound(td.consP)
 	td.enterNextRound(td.consP)
 
-	td.consP.SetProposal(p)
+	td.consP.SetProposal(invProp)
 	assert.Nil(t, td.consP.RoundProposal(2))
 }
 
@@ -54,12 +54,12 @@ func TestSetProposalInvalidHeight(t *testing.T) {
 	td := setup(t)
 
 	addr := td.valKeys[tIndexB].Address()
-	invBlock := td.GenerateTestBlockWithProposer(addr)
-	p := proposal.NewProposal(2, 0, invBlock)
-	td.HelperSignProposal(td.valKeys[tIndexB], p)
+	blk, _ := td.GenerateTestBlockWithProposer(2, addr)
+	invProp := proposal.NewProposal(2, 0, blk)
+	td.HelperSignProposal(td.valKeys[tIndexB], invProp)
 
 	td.enterNewHeight(td.consY)
-	td.consY.SetProposal(p)
+	td.consY.SetProposal(invProp)
 	assert.Nil(t, td.consY.RoundProposal(2))
 }
 

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -48,10 +48,9 @@ func setup(t *testing.T) *testData {
 	}
 
 	lastHeight := uint32(21)
-	for i := uint32(1); i < lastHeight; i++ {
-		b := ts.GenerateTestBlock()
-		c := ts.GenerateTestCertificate()
-		mockStore.SaveBlock(i, b, c)
+	for height := uint32(1); height < lastHeight; height++ {
+		blk, cert := ts.GenerateTestBlock(height)
+		mockStore.SaveBlock(blk, cert)
 	}
 	sandbox := NewSandbox(mockStore.LastHeight,
 		mockStore, params, committee, totalPower).(*sandbox)
@@ -375,7 +374,8 @@ func TestPowerDelta(t *testing.T) {
 func TestVerifyProof(t *testing.T) {
 	td := setup(t)
 
-	lastHeight, _ := td.store.LastCertificate()
+	lastCert := td.store.LastCertificate()
+	lastHeight := lastCert.Height()
 	vals := td.sandbox.committee.Validators()
 
 	// Try to evaluate a valid sortition

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -18,8 +18,8 @@ func TestProposeBlock(t *testing.T) {
 		td.moveToNextHeightForAllStates(t)
 	}
 	b1, c1 := td.makeBlockAndCertificate(t, 0, td.valKey1, td.valKey2, td.valKey3)
-	assert.NoError(t, td.state1.CommitBlock(curHeight+1, b1, c1))
-	assert.NoError(t, td.state2.CommitBlock(curHeight+1, b1, c1))
+	assert.NoError(t, td.state1.CommitBlock(b1, c1))
+	assert.NoError(t, td.state2.CommitBlock(b1, c1))
 	assert.Equal(t, td.state1.LastBlockHeight(), curHeight+1)
 
 	invSubsidyTx := tx.NewSubsidyTx(1, td.valKey2.Address(),
@@ -46,7 +46,7 @@ func TestProposeBlock(t *testing.T) {
 	assert.Equal(t, b2.Header().PrevBlockHash(), b1.Hash())
 	assert.Equal(t, b2.Transactions()[1:], block.Txs{trx1, trx2})
 	assert.True(t, b2.Transactions()[0].IsSubsidyTx())
-	assert.NoError(t, td.state1.CommitBlock(curHeight+2, b2, c2))
+	assert.NoError(t, td.state1.CommitBlock(b2, c2))
 
 	assert.Equal(t, td.state1.TotalPower(), int64(1000000004))
 	assert.Equal(t, td.state1.committee.TotalPower(), int64(4))
@@ -56,7 +56,7 @@ func TestExecuteBlock(t *testing.T) {
 	td := setup(t)
 
 	b1, c1 := td.makeBlockAndCertificate(t, 0, td.valKey1, td.valKey2, td.valKey3)
-	assert.NoError(t, td.state1.CommitBlock(1, b1, c1))
+	assert.NoError(t, td.state1.CommitBlock(b1, c1))
 
 	proposerAddr := td.RandAccAddress()
 	rewardAddr := td.RandAccAddress()

--- a/state/facade.go
+++ b/state/facade.go
@@ -26,8 +26,8 @@ type Facade interface {
 	LastCertificate() *certificate.Certificate
 	UpdateLastCertificate(v *vote.Vote) error
 	ProposeBlock(valKey *bls.ValidatorKey, rewardAddr crypto.Address, round int16) (*block.Block, error)
-	ValidateBlock(block *block.Block) error
-	CommitBlock(block *block.Block, cert *certificate.Certificate) error
+	ValidateBlock(blk *block.Block) error
+	CommitBlock(blk *block.Block, cert *certificate.Certificate) error
 	CommitteeValidators() []*validator.Validator
 	IsInCommittee(addr crypto.Address) bool
 	Proposer(round int16) *validator.Validator

--- a/state/facade.go
+++ b/state/facade.go
@@ -27,7 +27,7 @@ type Facade interface {
 	UpdateLastCertificate(v *vote.Vote) error
 	ProposeBlock(valKey *bls.ValidatorKey, rewardAddr crypto.Address, round int16) (*block.Block, error)
 	ValidateBlock(block *block.Block) error
-	CommitBlock(height uint32, block *block.Block, cert *certificate.Certificate) error
+	CommitBlock(block *block.Block, cert *certificate.Certificate) error
 	CommitteeValidators() []*validator.Validator
 	IsInCommittee(addr crypto.Address) bool
 	Proposer(round int16) *validator.Validator

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -172,13 +172,15 @@ func (td *testData) makeCertificateAndSign(t *testing.T, blockHash hash.Hash, ro
 	return certificate.NewCertificate(height+1, round, committers, absentees, bls.SignatureAggregate(sigs...))
 }
 
-func (td *testData) commitBlockForAllStates(t *testing.T, b *block.Block, c *certificate.Certificate) {
+func (td *testData) commitBlockForAllStates(t *testing.T,
+	blk *block.Block, cert *certificate.Certificate,
+) {
 	t.Helper()
 
-	assert.NoError(t, td.state1.CommitBlock(td.state1.lastInfo.BlockHeight()+1, b, c))
-	assert.NoError(t, td.state2.CommitBlock(td.state2.lastInfo.BlockHeight()+1, b, c))
-	assert.NoError(t, td.state3.CommitBlock(td.state3.lastInfo.BlockHeight()+1, b, c))
-	assert.NoError(t, td.state4.CommitBlock(td.state4.lastInfo.BlockHeight()+1, b, c))
+	assert.NoError(t, td.state1.CommitBlock(blk, cert))
+	assert.NoError(t, td.state2.CommitBlock(blk, cert))
+	assert.NoError(t, td.state3.CommitBlock(blk, cert))
+	assert.NoError(t, td.state4.CommitBlock(blk, cert))
 }
 
 func (td *testData) moveToNextHeightForAllStates(t *testing.T) {
@@ -236,11 +238,11 @@ func TestBlockTime(t *testing.T) {
 	})
 
 	t.Run("Commit one block: LastBlockTime is the time of the first block", func(t *testing.T) {
-		b1, c1 := td.makeBlockAndCertificate(t, 1, td.valKey1, td.valKey2, td.valKey3)
-		assert.NoError(t, td.state1.CommitBlock(1, b1, c1))
+		blk, cert := td.makeBlockAndCertificate(t, 1, td.valKey1, td.valKey2, td.valKey3)
+		assert.NoError(t, td.state1.CommitBlock(blk, cert))
 
 		assert.NotEqual(t, td.state1.LastBlockTime(), td.state1.Genesis().GenesisTime())
-		assert.Equal(t, td.state1.LastBlockTime(), b1.Header().Time())
+		assert.Equal(t, td.state1.LastBlockTime(), blk.Header().Time())
 	})
 }
 
@@ -248,11 +250,12 @@ func TestCommitBlocks(t *testing.T) {
 	td := setup(t)
 
 	b1, c1 := td.makeBlockAndCertificate(t, 1, td.valKey1, td.valKey2, td.valKey3)
-	invBlock := td.GenerateTestBlock()
-	assert.Error(t, td.state1.CommitBlock(1, invBlock, c1))
+	invBlock, invCert := td.GenerateTestBlock(1)
+	assert.Error(t, td.state1.CommitBlock(invBlock, c1))
+	assert.Error(t, td.state1.CommitBlock(b1, invCert))
 	// No error here but block is ignored, because the height is invalid
-	assert.NoError(t, td.state1.CommitBlock(2, b1, c1))
-	assert.NoError(t, td.state1.CommitBlock(1, b1, c1))
+	assert.NoError(t, td.state1.CommitBlock(b1, c1))
+	assert.NoError(t, td.state1.CommitBlock(b1, c1))
 
 	assert.Equal(t, td.state1.LastBlockHash(), b1.Hash())
 	assert.Equal(t, td.state1.LastBlockTime(), b1.Header().Time())
@@ -417,8 +420,8 @@ func TestBlockProposal(t *testing.T) {
 func TestInvalidBlock(t *testing.T) {
 	td := setup(t)
 
-	b := td.GenerateTestBlock()
-	assert.Error(t, td.state1.ValidateBlock(b))
+	invBlk, _ := td.GenerateTestBlock(td.RandHeight())
+	assert.Error(t, td.state1.ValidateBlock(invBlk))
 }
 
 func TestForkDetection(t *testing.T) {
@@ -426,25 +429,25 @@ func TestForkDetection(t *testing.T) {
 
 	td.moveToNextHeightForAllStates(t)
 
-	b5m, c5m := td.makeBlockAndCertificate(t, 0, td.valKey1, td.valKey2, td.valKey3)
-	b5f, c5f := td.makeBlockAndCertificate(t, 1, td.valKey1, td.valKey2, td.valKey3)
-	assert.NoError(t, td.state1.CommitBlock(2, b5m, c5m))
-	assert.NoError(t, td.state2.CommitBlock(2, b5m, c5m))
-	assert.NoError(t, td.state3.CommitBlock(2, b5m, c5m))
-	assert.NoError(t, td.state4.CommitBlock(2, b5f, c5f))
+	b2m, c2m := td.makeBlockAndCertificate(t, 0, td.valKey1, td.valKey2, td.valKey3)
+	b2f, c2f := td.makeBlockAndCertificate(t, 1, td.valKey1, td.valKey2, td.valKey3)
+	assert.NoError(t, td.state1.CommitBlock(b2m, c2m))
+	assert.NoError(t, td.state2.CommitBlock(b2m, c2m))
+	assert.NoError(t, td.state3.CommitBlock(b2m, c2m))
+	assert.NoError(t, td.state4.CommitBlock(b2f, c2f))
 
-	b6, c6 := td.makeBlockAndCertificate(t, 0, td.valKey1, td.valKey2, td.valKey3)
+	b3, c3 := td.makeBlockAndCertificate(t, 0, td.valKey1, td.valKey2, td.valKey3)
 
-	assert.NoError(t, td.state1.CommitBlock(3, b6, c6))
-	assert.NoError(t, td.state2.CommitBlock(3, b6, c6))
-	assert.NoError(t, td.state3.CommitBlock(3, b6, c6))
+	assert.NoError(t, td.state1.CommitBlock(b3, c3))
+	assert.NoError(t, td.state2.CommitBlock(b3, c3))
+	assert.NoError(t, td.state3.CommitBlock(b3, c3))
 	t.Run("Fork is detected, Should panic ", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r == nil {
 				t.Errorf("The code did not panic")
 			}
 		}()
-		assert.Error(t, td.state4.CommitBlock(3, b6, c6))
+		assert.Error(t, td.state4.CommitBlock(b3, c3))
 	})
 }
 
@@ -472,7 +475,7 @@ func TestSortition(t *testing.T) {
 
 		b, c := td.makeBlockAndCertificate(t, 0, td.valKey1, td.valKey2, td.valKey3, td.valKey4)
 		td.commitBlockForAllStates(t, b, c)
-		require.NoError(t, stNew.CommitBlock(height, b, c))
+		require.NoError(t, stNew.CommitBlock(b, c))
 	}
 
 	assert.False(t, stNew.evaluateSortition()) //  bonding period
@@ -480,7 +483,7 @@ func TestSortition(t *testing.T) {
 	// Certificate next block
 	b, c := td.makeBlockAndCertificate(t, 0, td.valKey1, td.valKey2, td.valKey3, td.valKey4)
 	td.commitBlockForAllStates(t, b, c)
-	require.NoError(t, stNew.CommitBlock(height, b, c))
+	require.NoError(t, stNew.CommitBlock(b, c))
 	height++
 
 	assert.True(t, stNew.evaluateSortition())                             //  ok
@@ -490,7 +493,7 @@ func TestSortition(t *testing.T) {
 	// Certificate next block, new validator should be in the committee now
 	b, c = td.makeBlockAndCertificate(t, 0, td.valKey1, td.valKey2, td.valKey3, td.valKey4)
 	td.commitBlockForAllStates(t, b, c)
-	require.NoError(t, stNew.CommitBlock(height, b, c))
+	require.NoError(t, stNew.CommitBlock(b, c))
 
 	assert.True(t, stNew.evaluateSortition()) // in the committee
 	assert.True(t, td.state1.committee.Contains(td.valKey1.Address()))
@@ -520,11 +523,11 @@ func TestSortition(t *testing.T) {
 
 	c14 := certificate.NewCertificate(height, 3, []int32{4, 0, 1, 2, 3}, []int32{0}, bls.SignatureAggregate(sigs...))
 
-	assert.NoError(t, st1.CommitBlock(height, b14, c14))
-	assert.NoError(t, td.state1.CommitBlock(height, b14, c14))
-	assert.NoError(t, td.state2.CommitBlock(height, b14, c14))
-	assert.NoError(t, td.state3.CommitBlock(height, b14, c14))
-	assert.NoError(t, td.state4.CommitBlock(height, b14, c14))
+	assert.NoError(t, st1.CommitBlock(b14, c14))
+	assert.NoError(t, td.state1.CommitBlock(b14, c14))
+	assert.NoError(t, td.state2.CommitBlock(b14, c14))
+	assert.NoError(t, td.state3.CommitBlock(b14, c14))
+	assert.NoError(t, td.state4.CommitBlock(b14, c14))
 
 	assert.Equal(t, td.state1.CommitteePower(), int64(1000000004))
 	assert.Equal(t, td.state1.TotalValidators(), int32(5))
@@ -686,8 +689,8 @@ func TestLoadState(t *testing.T) {
 	assert.Equal(t, td.state1.TotalPower(), st1Load.(*state).TotalPower())
 	assert.Equal(t, td.state1.store.TotalAccounts(), int32(6))
 
-	require.NoError(t, st1Load.CommitBlock(6, b6, c6))
-	require.NoError(t, td.state2.CommitBlock(6, b6, c6))
+	require.NoError(t, st1Load.CommitBlock(b6, c6))
+	require.NoError(t, td.state2.CommitBlock(b6, c6))
 }
 
 func TestLoadStateAfterChangingGenesis(t *testing.T) {
@@ -794,7 +797,7 @@ func TestCommittingInvalidBlock(t *testing.T) {
 
 	// td.state1 receives a block with version 2 and rejects it.
 	// It is possible that the same block would be considered valid by td.state2.
-	assert.Error(t, td.state1.CommitBlock(2, b, c))
+	assert.Error(t, td.state1.CommitBlock(b, c))
 }
 
 func TestCalcFee(t *testing.T) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -347,7 +347,8 @@ func TestUpdateLastCertificate(t *testing.T) {
 
 	invValKey := td.RandValKey()
 	notActiveValKey := td.RandValKey()
-	val := validator.NewValidator(notActiveValKey.PublicKey(), td.RandInt32(100))
+	valNum := int32(4) // [0..3] are in the committee now
+	val := validator.NewValidator(notActiveValKey.PublicKey(), valNum)
 	td.state1.store.UpdateValidator(val)
 
 	v1 := vote.NewPrepareVote(blk.Hash(), cert.Height(), cert.Round(), td.valKey3.Address())

--- a/state/validation.go
+++ b/state/validation.go
@@ -7,18 +7,18 @@ import (
 	"github.com/pactus-project/pactus/util/errors"
 )
 
-func (st *state) validateBlock(block *block.Block) error {
-	if block.Header().Version() != st.params.BlockVersion {
+func (st *state) validateBlock(blk *block.Block) error {
+	if blk.Header().Version() != st.params.BlockVersion {
 		return errors.Errorf(errors.ErrInvalidBlock,
 			"invalid version")
 	}
 
-	if block.Header().StateRoot() != st.stateRoot() {
+	if blk.Header().StateRoot() != st.stateRoot() {
 		return errors.Errorf(errors.ErrInvalidBlock,
-			"state root is not same as we expected, expected %v, got %v", st.stateRoot(), block.Header().StateRoot())
+			"state root is not same as we expected, expected %v, got %v", st.stateRoot(), blk.Header().StateRoot())
 	}
 
-	return st.validatePrevCertificate(block.PrevCertificate(), block.Header().PrevBlockHash())
+	return st.validatePrevCertificate(blk.PrevCertificate(), blk.Header().PrevBlockHash())
 }
 
 // validatePrevCertificate validates certificate for the previous block.

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -42,7 +42,7 @@ func TestCertificateValidation(t *testing.T) {
 		aggSig := valKey5.Sign(signBytes)
 		cert := certificate.NewCertificate(height, 0, committers, []int32{2}, aggSig)
 
-		assert.Error(t, td.state1.CommitBlock(height, nextBlock, cert))
+		assert.Error(t, td.state1.CommitBlock(nextBlock, cert))
 	})
 
 	t.Run("Invalid round, should return error", func(t *testing.T) {
@@ -54,19 +54,7 @@ func TestCertificateValidation(t *testing.T) {
 		aggSig := aggregate([]crypto.Signature{sig1, sig2, sig4})
 		cert := certificate.NewCertificate(height, 0, committers, []int32{2}, aggSig)
 
-		assert.Error(t, td.state1.CommitBlock(height, nextBlock, cert))
-	})
-
-	t.Run("Invalid height, should return error", func(t *testing.T) {
-		committers := td.state2.committee.Committers()
-		signBytes := certificate.BlockCertificateSignBytes(nextBlockHash, height+1, round)
-		sig1 := td.valKey1.Sign(signBytes)
-		sig2 := td.valKey2.Sign(signBytes)
-		sig4 := td.valKey4.Sign(signBytes)
-		aggSig := aggregate([]crypto.Signature{sig1, sig2, sig4})
-		cert := certificate.NewCertificate(height+1, 0, committers, []int32{2}, aggSig)
-
-		assert.Error(t, td.state1.CommitBlock(height, nextBlock, cert))
+		assert.Error(t, td.state1.CommitBlock(nextBlock, cert))
 	})
 
 	t.Run("Invalid block hash, should return error", func(t *testing.T) {
@@ -79,7 +67,7 @@ func TestCertificateValidation(t *testing.T) {
 		aggSig := aggregate([]crypto.Signature{sig1, sig2, sig4})
 		cert := certificate.NewCertificate(height, 0, committers, []int32{2}, aggSig)
 
-		assert.Error(t, td.state1.CommitBlock(height, nextBlock, cert))
+		assert.Error(t, td.state1.CommitBlock(nextBlock, cert))
 	})
 
 	t.Run("Invalid committer, should return error", func(t *testing.T) {
@@ -92,7 +80,7 @@ func TestCertificateValidation(t *testing.T) {
 		aggSig := aggregate([]crypto.Signature{sig1, sig2, sig4})
 		cert := certificate.NewCertificate(height, 0, committers, []int32{2}, aggSig)
 
-		assert.Error(t, td.state1.CommitBlock(height, nextBlock, cert))
+		assert.Error(t, td.state1.CommitBlock(nextBlock, cert))
 	})
 
 	t.Run("Invalid committers, should return error", func(t *testing.T) {
@@ -105,7 +93,7 @@ func TestCertificateValidation(t *testing.T) {
 		aggSig := aggregate([]crypto.Signature{sig1, sig2, sig4})
 		cert := certificate.NewCertificate(height, 0, committers, []int32{2}, aggSig)
 
-		assert.Error(t, td.state1.CommitBlock(height, nextBlock, cert))
+		assert.Error(t, td.state1.CommitBlock(nextBlock, cert))
 	})
 
 	t.Run("Doesn't have 2/3 majority", func(t *testing.T) {
@@ -116,7 +104,7 @@ func TestCertificateValidation(t *testing.T) {
 		aggSig := aggregate([]crypto.Signature{sig1, sig2})
 		cert := certificate.NewCertificate(height, 0, committers, []int32{2, 3}, aggSig)
 
-		assert.Error(t, td.state1.CommitBlock(height, nextBlock, cert))
+		assert.Error(t, td.state1.CommitBlock(nextBlock, cert))
 	})
 
 	t.Run("Ok, should return no error", func(t *testing.T) {
@@ -128,7 +116,7 @@ func TestCertificateValidation(t *testing.T) {
 		aggSig := aggregate([]crypto.Signature{sig1, sig2, sig4})
 		cert := certificate.NewCertificate(height, 0, committers, []int32{2}, aggSig)
 
-		assert.NoError(t, td.state1.CommitBlock(height, nextBlock, cert))
+		assert.NoError(t, td.state1.CommitBlock(nextBlock, cert))
 	})
 }
 
@@ -197,7 +185,7 @@ func TestBlockValidation(t *testing.T) {
 		c := td.makeCertificateAndSign(t, b.Hash(), 0, td.valKey1, td.valKey2, td.valKey3, td.valKey4)
 
 		assert.NoError(t, td.state1.validateBlock(b))
-		assert.Error(t, td.state1.CommitBlock(2, b, c), "Invalid ProposerAddress")
+		assert.Error(t, td.state1.CommitBlock(b, c), "Invalid ProposerAddress")
 	})
 
 	t.Run("Invalid SortitionSeed", func(t *testing.T) {
@@ -207,7 +195,7 @@ func TestBlockValidation(t *testing.T) {
 		c := td.makeCertificateAndSign(t, b.Hash(), 0, td.valKey1, td.valKey2, td.valKey3, td.valKey4)
 
 		assert.NoError(t, td.state1.validateBlock(b))
-		assert.Error(t, td.state1.CommitBlock(2, b, c), "Invalid SortitionSeed")
+		assert.Error(t, td.state1.CommitBlock(b, c), "Invalid SortitionSeed")
 	})
 
 	t.Run("Ok", func(t *testing.T) {
@@ -217,6 +205,6 @@ func TestBlockValidation(t *testing.T) {
 		c := td.makeCertificateAndSign(t, b.Hash(), 0, td.valKey1, td.valKey2, td.valKey3, td.valKey4)
 
 		assert.NoError(t, td.state1.validateBlock(b))
-		assert.NoError(t, td.state1.CommitBlock(2, b, c), "Looks Good")
+		assert.NoError(t, td.state1.CommitBlock(b, c), "Looks Good")
 	})
 }

--- a/store/interface.go
+++ b/store/interface.go
@@ -94,7 +94,7 @@ type Reader interface {
 	IterateValidators(consumer func(*validator.Validator) (stop bool))
 	IterateAccounts(consumer func(crypto.Address, *account.Account) (stop bool))
 	TotalValidators() int32
-	LastCertificate() (uint32, *certificate.Certificate)
+	LastCertificate() *certificate.Certificate
 }
 
 type Store interface {
@@ -102,7 +102,7 @@ type Store interface {
 
 	UpdateAccount(addr crypto.Address, acc *account.Account)
 	UpdateValidator(val *validator.Validator)
-	SaveBlock(height uint32, block *block.Block, cert *certificate.Certificate)
+	SaveBlock(block *block.Block, cert *certificate.Certificate)
 	WriteBatch() error
 	Close() error
 }

--- a/store/interface.go
+++ b/store/interface.go
@@ -102,7 +102,7 @@ type Store interface {
 
 	UpdateAccount(addr crypto.Address, acc *account.Account)
 	UpdateValidator(val *validator.Validator)
-	SaveBlock(block *block.Block, cert *certificate.Certificate)
+	SaveBlock(blk *block.Block, cert *certificate.Certificate)
 	WriteBatch() error
 	Close() error
 }

--- a/store/mock.go
+++ b/store/mock.go
@@ -203,17 +203,17 @@ func (m *MockStore) IterateValidators(consumer func(*validator.Validator) (stop 
 	}
 }
 
-func (m *MockStore) SaveBlock(height uint32, b *block.Block, cert *certificate.Certificate) {
-	m.Blocks[height] = b
-	m.LastHeight = height
+func (m *MockStore) SaveBlock(b *block.Block, cert *certificate.Certificate) {
+	m.Blocks[cert.Height()] = b
+	m.LastHeight = cert.Height()
 	m.LastCert = cert
 }
 
-func (m *MockStore) LastCertificate() (uint32, *certificate.Certificate) {
+func (m *MockStore) LastCertificate() *certificate.Certificate {
 	if m.LastHeight == 0 {
-		return 0, nil
+		return nil
 	}
-	return m.LastHeight, m.LastCert
+	return m.LastCert
 }
 
 func (m *MockStore) WriteBatch() error {
@@ -233,9 +233,8 @@ func (m *MockStore) AddTestAccount() (*account.Account, crypto.Address) {
 }
 
 func (m *MockStore) AddTestBlock(height uint32) *block.Block {
-	blk := m.ts.GenerateTestBlock()
-	cert := m.ts.GenerateTestCertificate()
-	m.SaveBlock(height, blk, cert)
+	blk, cert := m.ts.GenerateTestBlock(height)
+	m.SaveBlock(blk, cert)
 	return blk
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -89,17 +89,17 @@ func (s *store) Close() error {
 	return s.db.Close()
 }
 
-func (s *store) SaveBlock(block *block.Block, cert *certificate.Certificate) {
+func (s *store) SaveBlock(blk *block.Block, cert *certificate.Certificate) {
 	s.lk.Lock()
 	defer s.lk.Unlock()
 
 	height := cert.Height()
-	reg := s.blockStore.saveBlock(s.batch, height, block)
-	for i, trx := range block.Transactions() {
+	reg := s.blockStore.saveBlock(s.batch, height, blk)
+	for i, trx := range blk.Transactions() {
 		s.txStore.saveTx(s.batch, trx.ID(), &reg[i])
 	}
 
-	// Save last certificate
+	// Save last certificate: [version: 4 bytes]+[certificate: variant]
 	w := bytes.NewBuffer(make([]byte, 0, 4+cert.SerializeSize()))
 	err := encoding.WriteElements(w, lastStoreVersion)
 	if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -89,18 +89,19 @@ func (s *store) Close() error {
 	return s.db.Close()
 }
 
-func (s *store) SaveBlock(height uint32, block *block.Block, cert *certificate.Certificate) {
+func (s *store) SaveBlock(block *block.Block, cert *certificate.Certificate) {
 	s.lk.Lock()
 	defer s.lk.Unlock()
 
+	height := cert.Height()
 	reg := s.blockStore.saveBlock(s.batch, height, block)
 	for i, trx := range block.Transactions() {
 		s.txStore.saveTx(s.batch, trx.ID(), &reg[i])
 	}
 
 	// Save last certificate
-	w := bytes.NewBuffer(make([]byte, 0, 8+cert.SerializeSize()))
-	err := encoding.WriteElements(w, lastStoreVersion, height)
+	w := bytes.NewBuffer(make([]byte, 0, 4+cert.SerializeSize()))
+	err := encoding.WriteElements(w, lastStoreVersion)
 	if err != nil {
 		panic(err)
 	}
@@ -289,28 +290,27 @@ func (s *store) UpdateValidator(acc *validator.Validator) {
 	s.validatorStore.updateValidator(s.batch, acc)
 }
 
-func (s *store) LastCertificate() (uint32, *certificate.Certificate) {
+func (s *store) LastCertificate() *certificate.Certificate {
 	s.lk.Lock()
 	defer s.lk.Unlock()
 
 	data, _ := tryGet(s.db, lastInfoKey)
 	if data == nil {
 		// Genesis block
-		return 0, nil
+		return nil
 	}
 	r := bytes.NewReader(data)
 	version := int32(0)
-	height := uint32(0)
 	cert := new(certificate.Certificate)
-	err := encoding.ReadElements(r, &version, &height)
+	err := encoding.ReadElements(r, &version)
 	if err != nil {
-		return 0, nil
+		return nil
 	}
 	err = cert.Decode(r)
 	if err != nil {
-		return 0, nil
+		return nil
 	}
-	return height, cert
+	return cert
 }
 
 func (s *store) WriteBatch() error {

--- a/sync/bundle/bundle_test.go
+++ b/sync/bundle/bundle_test.go
@@ -37,8 +37,8 @@ func TestMessageCompress(t *testing.T) {
 
 	blocksData := [][]byte{}
 	for i := 0; i < 10; i++ {
-		b := ts.GenerateTestBlock()
-		d, _ := b.Bytes()
+		blk, _ := ts.GenerateTestBlock(ts.RandHeight())
+		d, _ := blk.Bytes()
 		blocksData = append(blocksData, d)
 	}
 	msg := message.NewBlocksResponseMessage(message.ResponseCodeOK, message.ResponseCodeOK.String(),

--- a/sync/bundle/message/block_announce.go
+++ b/sync/bundle/message/block_announce.go
@@ -8,16 +8,14 @@ import (
 )
 
 type BlockAnnounceMessage struct {
-	Height      uint32                   `cbor:"1,keyasint"`
-	Block       *block.Block             `cbor:"2,keyasint"`
-	Certificate *certificate.Certificate `cbor:"3,keyasint"`
+	Block       *block.Block             `cbor:"1,keyasint"`
+	Certificate *certificate.Certificate `cbor:"2,keyasint"`
 }
 
-func NewBlockAnnounceMessage(h uint32, b *block.Block, c *certificate.Certificate) *BlockAnnounceMessage {
+func NewBlockAnnounceMessage(blk *block.Block, cert *certificate.Certificate) *BlockAnnounceMessage {
 	return &BlockAnnounceMessage{
-		Height:      h,
-		Block:       b,
-		Certificate: c,
+		Block:       blk,
+		Certificate: cert,
 	}
 }
 
@@ -28,10 +26,16 @@ func (m *BlockAnnounceMessage) BasicCheck() error {
 	return m.Certificate.BasicCheck()
 }
 
+func (m *BlockAnnounceMessage) Height() uint32 {
+	return m.Certificate.Height()
+}
+
 func (m *BlockAnnounceMessage) Type() Type {
 	return TypeBlockAnnounce
 }
 
 func (m *BlockAnnounceMessage) String() string {
-	return fmt.Sprintf("{⌘ %d %v}", m.Height, m.Block.Hash().ShortString())
+	return fmt.Sprintf("{⌘ %d %v}",
+		m.Certificate.Height(),
+		m.Block.Hash().ShortString())
 }

--- a/sync/bundle/message/block_announce_test.go
+++ b/sync/bundle/message/block_announce_test.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pactus-project/pactus/types/certificate"
@@ -17,9 +18,8 @@ func TestBlockAnnounceMessage(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	t.Run("Invalid certificate", func(t *testing.T) {
-		b := ts.GenerateTestBlock()
-		c := certificate.NewCertificate(0, 0, nil, nil, nil)
-		m := NewBlockAnnounceMessage(100, b, c)
+		blk, cert := ts.GenerateTestBlock(0)
+		m := NewBlockAnnounceMessage(blk, cert)
 		err := m.BasicCheck()
 
 		assert.ErrorIs(t, err, certificate.BasicCheckError{
@@ -28,11 +28,12 @@ func TestBlockAnnounceMessage(t *testing.T) {
 	})
 
 	t.Run("OK", func(t *testing.T) {
-		b := ts.GenerateTestBlock()
-		c := ts.GenerateTestCertificate()
-		m := NewBlockAnnounceMessage(100, b, c)
+		height := ts.RandHeight()
+		blk, cert := ts.GenerateTestBlock(height)
+		m := NewBlockAnnounceMessage(blk, cert)
 
 		assert.NoError(t, m.BasicCheck())
-		assert.Contains(t, m.String(), "100")
+		assert.Equal(t, height, m.Height())
+		assert.Contains(t, m.String(), fmt.Sprintf("%d", height))
 	})
 }

--- a/sync/bundle/message/blocks_response.go
+++ b/sync/bundle/message/blocks_response.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/pactus-project/pactus/types/certificate"
-	"github.com/pactus-project/pactus/util/errors"
 )
 
 type BlocksResponseMessage struct {
@@ -30,9 +29,6 @@ func NewBlocksResponseMessage(code ResponseCode, reason string, sid int, from ui
 }
 
 func (m *BlocksResponseMessage) BasicCheck() error {
-	if m.From == 0 && len(m.CommittedBlocksData) != 0 {
-		return errors.Errorf(errors.ErrInvalidHeight, "unexpected block for height zero")
-	}
 	if m.LastCertificate != nil {
 		if err := m.LastCertificate.BasicCheck(); err != nil {
 			return err
@@ -56,13 +52,6 @@ func (m *BlocksResponseMessage) To() uint32 {
 		return 0
 	}
 	return m.From + m.Count() - 1
-}
-
-func (m *BlocksResponseMessage) LastCertificateHeight() uint32 {
-	if m.LastCertificate != nil {
-		return m.From
-	}
-	return 0
 }
 
 func (m *BlocksResponseMessage) String() string {

--- a/sync/cache/cache.go
+++ b/sync/cache/cache.go
@@ -44,7 +44,7 @@ func (c *Cache) GetBlock(height uint32) *block.Block {
 
 func (c *Cache) AddBlock(height uint32, block *block.Block) {
 	c.blocks.Add(height, block)
-	c.AddCertificate(height-1, block.PrevCertificate())
+	c.AddCertificate(block.PrevCertificate())
 }
 
 func (c *Cache) GetCertificate(height uint32) *certificate.Certificate {
@@ -56,9 +56,9 @@ func (c *Cache) GetCertificate(height uint32) *certificate.Certificate {
 	return nil
 }
 
-func (c *Cache) AddCertificate(height uint32, cert *certificate.Certificate) {
+func (c *Cache) AddCertificate(cert *certificate.Certificate) {
 	if cert != nil {
-		c.certs.Add(height, cert)
+		c.certs.Add(cert.Height(), cert)
 	}
 }
 

--- a/sync/cache/cache.go
+++ b/sync/cache/cache.go
@@ -42,9 +42,14 @@ func (c *Cache) GetBlock(height uint32) *block.Block {
 	return nil
 }
 
-func (c *Cache) AddBlock(height uint32, block *block.Block) {
-	c.blocks.Add(height, block)
-	c.AddCertificate(block.PrevCertificate())
+func (c *Cache) AddBlock(blk *block.Block) {
+	prvCert := blk.PrevCertificate()
+	if prvCert == nil {
+		c.blocks.Add(1, blk)
+	} else {
+		c.blocks.Add(prvCert.Height()+1, blk)
+		c.certs.Add(prvCert.Height(), prvCert)
+	}
 }
 
 func (c *Cache) GetCertificate(height uint32) *certificate.Certificate {

--- a/sync/cache/cache_test.go
+++ b/sync/cache/cache_test.go
@@ -66,3 +66,19 @@ func TestCacheIsFull(t *testing.T) {
 	assert.NotNil(t, cache.GetBlock(uint32(i+1)))
 	assert.Nil(t, cache.GetBlock(1))
 }
+
+func TestAddAgain(t *testing.T) {
+	ts := testsuite.NewTestSuite(t)
+
+	cache, _ := NewCache(10)
+
+	height := ts.RandHeight()
+	blk1 := ts.GenerateTestBlock()
+	blk2 := ts.GenerateTestBlock()
+
+	cache.AddBlock(height, blk1)
+	assert.Equal(t, blk1, cache.GetBlock(height))
+
+	cache.AddBlock(height, blk2)
+	assert.Equal(t, blk2, cache.GetBlock(height))
+}

--- a/sync/handler_block_announce.go
+++ b/sync/handler_block_announce.go
@@ -20,7 +20,7 @@ func (handler *blockAnnounceHandler) ParseMessage(m message.Message, initiator p
 	msg := m.(*message.BlockAnnounceMessage)
 	handler.logger.Trace("parsing BlockAnnounce message", "message", msg)
 
-	handler.cache.AddCertificate(msg.Height, msg.Certificate)
+	handler.cache.AddCertificate(msg.Certificate)
 	handler.cache.AddBlock(msg.Height, msg.Block)
 
 	err := handler.tryCommitBlocks()

--- a/sync/handler_block_announce.go
+++ b/sync/handler_block_announce.go
@@ -21,7 +21,7 @@ func (handler *blockAnnounceHandler) ParseMessage(m message.Message, initiator p
 	handler.logger.Trace("parsing BlockAnnounce message", "message", msg)
 
 	handler.cache.AddCertificate(msg.Certificate)
-	handler.cache.AddBlock(msg.Height, msg.Block)
+	handler.cache.AddBlock(msg.Block)
 
 	err := handler.tryCommitBlocks()
 	if err != nil {
@@ -29,7 +29,7 @@ func (handler *blockAnnounceHandler) ParseMessage(m message.Message, initiator p
 	}
 	handler.moveConsensusToNewHeight()
 
-	handler.peerSet.UpdateHeight(initiator, msg.Height, msg.Block.Hash())
+	handler.peerSet.UpdateHeight(initiator, msg.Height(), msg.Block.Hash())
 	handler.updateBlockchain()
 
 	return nil

--- a/sync/handler_blocks_request_test.go
+++ b/sync/handler_blocks_request_test.go
@@ -61,14 +61,12 @@ func TestLatestBlocksRequestMessages(t *testing.T) {
 				assert.Equal(t, bdl1.Message.(*message.BlocksResponseMessage).From, curHeight-config.BlockPerMessage)
 				assert.Equal(t, bdl1.Message.(*message.BlocksResponseMessage).To(), curHeight-1)
 				assert.Equal(t, bdl1.Message.(*message.BlocksResponseMessage).Count(), config.BlockPerMessage)
-				assert.Zero(t, bdl1.Message.(*message.BlocksResponseMessage).LastCertificateHeight())
 
 				bdl2 := td.shouldPublishMessageWithThisType(t, td.network, message.TypeBlocksResponse)
 				assert.Equal(t, bdl2.Message.(*message.BlocksResponseMessage).ResponseCode, message.ResponseCodeNoMoreBlocks)
 				assert.Zero(t, bdl2.Message.(*message.BlocksResponseMessage).From)
 				assert.Zero(t, bdl2.Message.(*message.BlocksResponseMessage).To())
 				assert.Zero(t, bdl2.Message.(*message.BlocksResponseMessage).Count())
-				assert.Zero(t, bdl1.Message.(*message.BlocksResponseMessage).LastCertificateHeight())
 			})
 
 			t.Run("Peer synced", func(t *testing.T) {
@@ -80,14 +78,12 @@ func TestLatestBlocksRequestMessages(t *testing.T) {
 				assert.Equal(t, bdl1.Message.(*message.BlocksResponseMessage).From, curHeight-config.BlockPerMessage+1)
 				assert.Equal(t, bdl1.Message.(*message.BlocksResponseMessage).To(), curHeight)
 				assert.Equal(t, bdl1.Message.(*message.BlocksResponseMessage).Count(), config.BlockPerMessage)
-				assert.Zero(t, bdl1.Message.(*message.BlocksResponseMessage).LastCertificateHeight())
 
 				bdl2 := td.shouldPublishMessageWithThisType(t, td.network, message.TypeBlocksResponse)
 				assert.Equal(t, bdl2.Message.(*message.BlocksResponseMessage).ResponseCode, message.ResponseCodeSynced)
 				assert.Equal(t, bdl2.Message.(*message.BlocksResponseMessage).From, curHeight)
 				assert.Zero(t, bdl2.Message.(*message.BlocksResponseMessage).To())
 				assert.Zero(t, bdl2.Message.(*message.BlocksResponseMessage).Count())
-				assert.Equal(t, bdl2.Message.(*message.BlocksResponseMessage).LastCertificateHeight(), curHeight)
 			})
 		})
 

--- a/sync/handler_blocks_response.go
+++ b/sync/handler_blocks_response.go
@@ -24,6 +24,10 @@ func (handler *blocksResponseHandler) ParseMessage(m message.Message, initiator 
 	if msg.IsRequestRejected() {
 		handler.logger.Warn("blocks request is rejected", "pid", initiator.ShortString(), "reason", msg.Reason)
 	} else {
+		// TODO:
+		// It is good to check the latest height before adding blocks to the cache.
+		// If they have already been committed, this message can be ignored.
+		// Need to test!
 		height := msg.From
 		for _, data := range msg.CommittedBlocksData {
 			blk, err := block.FromBytes(data)

--- a/sync/handler_blocks_response.go
+++ b/sync/handler_blocks_response.go
@@ -30,7 +30,8 @@ func (handler *blocksResponseHandler) ParseMessage(m message.Message, initiator 
 			if err != nil {
 				return err
 			}
-			handler.cache.AddBlock(height, blk)
+			handler.cache.AddBlock(blk)
+
 			height++
 		}
 		handler.cache.AddCertificate(msg.LastCertificate)

--- a/sync/handler_blocks_response.go
+++ b/sync/handler_blocks_response.go
@@ -33,7 +33,7 @@ func (handler *blocksResponseHandler) ParseMessage(m message.Message, initiator 
 			handler.cache.AddBlock(height, blk)
 			height++
 		}
-		handler.cache.AddCertificate(msg.From, msg.LastCertificate)
+		handler.cache.AddCertificate(msg.LastCertificate)
 		err := handler.tryCommitBlocks()
 		if err != nil {
 			return err

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -428,7 +428,7 @@ func (sync *synchronizer) tryCommitBlocks() error {
 		}
 
 		sync.logger.Trace("committing block", "height", height, "block", blk)
-		if err := sync.state.CommitBlock(height, blk, cert); err != nil {
+		if err := sync.state.CommitBlock(blk, cert); err != nil {
 			return err
 		}
 		height = height + 1

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -250,14 +250,12 @@ func TestTestNetFlags(t *testing.T) {
 func TestDownload(t *testing.T) {
 	td := setup(t, nil)
 
-	ourBlockHeight := td.state.LastBlockHeight()
-	// To make sure the peer is not synced,
-	// we add a block in past (more than 2 hours)
+	// LastBlockTime is the genesis time (Testnet)
+	// It should request blocks to get synced.
 
-	blk := td.GenerateTestBlock()
-	cert := td.GenerateTestCertificate()
+	blk, cert := td.GenerateTestBlock(td.RandHeight())
 	pid := td.RandPeerID()
-	msg := message.NewBlockAnnounceMessage(ourBlockHeight+LatestBlockInterval+1, blk, cert)
+	msg := message.NewBlockAnnounceMessage(blk, cert)
 
 	t.Run("try to download blocks, but the peer is not known", func(t *testing.T) {
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))

--- a/types/certificate/certificate_test.go
+++ b/types/certificate/certificate_test.go
@@ -40,18 +40,18 @@ func TestCertificate(t *testing.T) {
 func TestCertificateCBORMarshaling(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	c1 := ts.GenerateTestCertificate()
-	bz1, err := cbor.Marshal(c1)
+	cert1 := ts.GenerateTestCertificate(ts.RandHeight())
+	bz1, err := cbor.Marshal(cert1)
 	assert.NoError(t, err)
-	var c2 certificate.Certificate
-	err = cbor.Unmarshal(bz1, &c2)
+	var cert2 certificate.Certificate
+	err = cbor.Unmarshal(bz1, &cert2)
 	assert.NoError(t, err)
-	assert.NoError(t, c2.BasicCheck())
-	assert.Equal(t, c1.Hash(), c1.Hash())
+	assert.NoError(t, cert2.BasicCheck())
+	assert.Equal(t, cert1.Hash(), cert1.Hash())
 
-	assert.Equal(t, c1.Hash(), c2.Hash())
+	assert.Equal(t, cert1.Hash(), cert2.Hash())
 
-	err = cbor.Unmarshal([]byte{1}, &c2)
+	err = cbor.Unmarshal([]byte{1}, &cert2)
 	assert.Error(t, err)
 }
 
@@ -60,16 +60,16 @@ func TestCertificateSignBytes(t *testing.T) {
 
 	hash := ts.RandHash()
 	height := ts.RandHeight()
-	c1 := ts.GenerateTestCertificate()
-	bz := certificate.BlockCertificateSignBytes(hash, height, c1.Round())
-	assert.NotEqual(t, bz, certificate.BlockCertificateSignBytes(hash, height, c1.Round()+1))
-	assert.NotEqual(t, bz, certificate.BlockCertificateSignBytes(ts.RandHash(), height, c1.Round()))
+	cert := ts.GenerateTestCertificate(height)
+	bz := certificate.BlockCertificateSignBytes(hash, height, cert.Round())
+	assert.NotEqual(t, bz, certificate.BlockCertificateSignBytes(hash, height, cert.Round()+1))
+	assert.NotEqual(t, bz, certificate.BlockCertificateSignBytes(ts.RandHash(), height, cert.Round()))
 }
 
 func TestInvalidCertificate(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	cert0 := ts.GenerateTestCertificate()
+	cert0 := ts.GenerateTestCertificate(ts.RandHeight())
 
 	t.Run("Invalid height", func(t *testing.T) {
 		cert := certificate.NewCertificate(0, 0, cert0.Committers(), cert0.Absentees(), cert0.Signature())
@@ -143,22 +143,22 @@ func TestInvalidCertificate(t *testing.T) {
 func TestCertificateHash(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	temp := ts.GenerateTestCertificate()
+	cert0 := ts.GenerateTestCertificate(ts.RandHeight())
 
-	cert1 := certificate.NewCertificate(temp.Height(), temp.Round(),
-		[]int32{10, 18, 2, 6}, []int32{}, temp.Signature())
+	cert1 := certificate.NewCertificate(cert0.Height(), cert0.Round(),
+		[]int32{10, 18, 2, 6}, []int32{}, cert0.Signature())
 	assert.Equal(t, cert1.Committers(), []int32{10, 18, 2, 6})
 	assert.Equal(t, cert1.Absentees(), []int32{})
 	assert.NoError(t, cert1.BasicCheck())
 
-	cert2 := certificate.NewCertificate(temp.Height(), temp.Round(),
-		[]int32{10, 18, 2, 6}, []int32{2, 6}, temp.Signature())
+	cert2 := certificate.NewCertificate(cert0.Height(), cert0.Round(),
+		[]int32{10, 18, 2, 6}, []int32{2, 6}, cert0.Signature())
 	assert.Equal(t, cert2.Committers(), []int32{10, 18, 2, 6})
 	assert.Equal(t, cert2.Absentees(), []int32{2, 6})
 	assert.NoError(t, cert2.BasicCheck())
 
-	cert3 := certificate.NewCertificate(temp.Height(), temp.Round(),
-		[]int32{10, 18, 2, 6}, []int32{18}, temp.Signature())
+	cert3 := certificate.NewCertificate(cert0.Height(), cert0.Round(),
+		[]int32{10, 18, 2, 6}, []int32{18}, cert0.Signature())
 	assert.Equal(t, cert3.Committers(), []int32{10, 18, 2, 6})
 	assert.Equal(t, cert3.Absentees(), []int32{18})
 	assert.NoError(t, cert3.BasicCheck())
@@ -167,7 +167,7 @@ func TestCertificateHash(t *testing.T) {
 func TestEncodingCertificate(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	cert1 := ts.GenerateTestCertificate()
+	cert1 := ts.GenerateTestCertificate(ts.RandHeight())
 	length := cert1.SerializeSize()
 
 	for i := 0; i < length; i++ {

--- a/types/proposal/proposal.go
+++ b/types/proposal/proposal.go
@@ -22,12 +22,12 @@ type proposalData struct {
 	Signature *bls.Signature `cbor:"4,keyasint"`
 }
 
-func NewProposal(height uint32, round int16, block *block.Block) *Proposal {
+func NewProposal(height uint32, round int16, blk *block.Block) *Proposal {
 	return &Proposal{
 		data: proposalData{
 			Height: height,
 			Round:  round,
-			Block:  block,
+			Block:  blk,
 		},
 	}
 }


### PR DESCRIPTION
## Description

This PR implements a more accurate approach to caching the certificate by its height.
It also removes the `height` parameter from the `CommitBlock` function, as the certificate already contains the `height` of the committing block.