### PR TITLE
fix: trim transactions in proposed block

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -316,6 +316,7 @@ func (st *state) ProposeBlock(valKey *bls.ValidatorKey, rewardAddr crypto.Addres
 
 	// Re-check all transactions strictly and remove invalid ones
 	txs := st.txPool.PrepareBlockTransactions()
+	txs = util.Trim(txs, maxTransactionsPerBlock-1)
 	for i := 0; i < txs.Len(); i++ {
 		// Only one subsidy transaction per block
 		if txs[i].IsSubsidyTx() {
@@ -328,10 +329,6 @@ func (st *state) ProposeBlock(valKey *bls.ValidatorKey, rewardAddr crypto.Addres
 
 		if err := exe.Execute(txs[i], sb); err != nil {
 			st.logger.Debug("found invalid transaction", "tx", txs[i], "error", err)
-			txs.Remove(i)
-			i--
-		}
-		if i >= maxTransactionsPerBlock-1 {
 			txs.Remove(i)
 			i--
 		}

--- a/util/slice.go
+++ b/util/slice.go
@@ -186,8 +186,8 @@ func Reverse[S ~[]E, E any](s S) {
 	}
 }
 
-// ExtendSlice extends the slice 's' to length 'n' by appending zero-valued elements.
-func ExtendSlice[T any](s *[]T, n int) {
+// Extend extends the slice 's' to length 'n' by appending zero-valued elements.
+func Extend[T any](s *[]T, n int) {
 	if len(*s) < n {
 		temp := make([]T, n-len(*s))
 		*s = append(*s, temp...)
@@ -221,4 +221,11 @@ func RemoveFirstOccurrenceOf[T comparable](s []T, e T) ([]T, bool) {
 		}
 	}
 	return s, false
+}
+
+func Trim[T any](s []T, newLength int) []T {
+	if newLength <= len(s) {
+		return s[:newLength]
+	}
+	return s
 }

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -235,7 +235,7 @@ func TestExtendSlice(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		ExtendSlice(&c.in, c.size)
+		Extend(&c.in, c.size)
 		assert.Equal(t, c.in, c.want, "ExtendSlice(%v, %v) == %v, want %v", c.in, c.size, c.in, c.want)
 	}
 }
@@ -325,5 +325,23 @@ func TestRemoveFirstOccurrenceOf(t *testing.T) {
 				t.Errorf("got %v, want %v", removed, tt.removed)
 			}
 		})
+	}
+}
+
+func TestTrimSlice(t *testing.T) {
+	tests := []struct {
+		input     []int
+		newLength int
+		want      []int
+	}{
+		{[]int{1, 2, 3, 4, 5}, 3, []int{1, 2, 3}},
+		{[]int{1}, 3, []int{1}},
+		{[]int{}, 3, []int{}},
+		{[]int{1, 2, 3, 4, 5}, 0, []int{}},
+	}
+
+	for _, tt := range tests {
+		got := Trim(tt.input, tt.newLength)
+		assert.Equal(t, got, tt.want, "Trim() = %v, want %v", got, tt.want)
 	}
 }


### PR DESCRIPTION
## Description

This PR trims transactions inside the proposed block to ensure they are not more than `maxTransactionsPerBlock`.