### PR TITLE
chore: replacing quic with quic-v1

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -102,33 +102,33 @@ func SaveTestnetConfig(path string, numValidators int) error {
 	conf := DefaultConfig()
 	conf.Node.NumValidators = numValidators
 	conf.Network.Listens = []string{
-		"/ip4/0.0.0.0/tcp/21777", "/ip4/0.0.0.0/udp/21777/quic",
-		"/ip6/::/tcp/21777", "/ip6/::/udp/21777/quic",
+		"/ip4/0.0.0.0/tcp/21777", "/ip4/0.0.0.0/udp/21777/quic-v1",
+		"/ip6/::/tcp/21777", "/ip6/::/udp/21777/quic-v1",
 	}
 	conf.Network.Bootstrap.Addresses = []string{
 		"/ip4/94.101.184.118/tcp/21777/p2p/12D3KooWCwQZt8UriVXobQHPXPR8m83eceXVoeT6brPNiBHomebc",
-		"/ip4/94.101.184.118/udp/21777/quic/p2p/12D3KooWCwQZt8UriVXobQHPXPR8m83eceXVoeT6brPNiBHomebc",
+		"/ip4/94.101.184.118/udp/21777/quic-v1/p2p/12D3KooWCwQZt8UriVXobQHPXPR8m83eceXVoeT6brPNiBHomebc",
 		"/ip4/172.104.46.145/tcp/21777/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
-		"/ip4/172.104.46.145/udp/21777/quic/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
+		"/ip4/172.104.46.145/udp/21777/quic-v1/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
 		"/ip6/2400:8901::f03c:93ff:fe1c:c3ec/tcp/21777/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
-		"/ip6/2400:8901::f03c:93ff:fe1c:c3ec/udp/21777/quic/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
+		"/ip6/2400:8901::f03c:93ff:fe1c:c3ec/udp/21777/quic-v1/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
 		"/ip4/13.115.190.71/tcp/21777/p2p/12D3KooWBGNEH8NqdK1UddSnPV1yRHGLYpaQUcnujC24s7YNWPiq",
-		"/ip4/13.115.190.71/udp/21777/quic/p2p/12D3KooWBGNEH8NqdK1UddSnPV1yRHGLYpaQUcnujC24s7YNWPiq",
+		"/ip4/13.115.190.71/udp/21777/quic-v1/p2p/12D3KooWBGNEH8NqdK1UddSnPV1yRHGLYpaQUcnujC24s7YNWPiq",
 		"/ip4/163.172.178.141/tcp/21777/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
-		"/ip4/163.172.178.141/udp/21777/quic/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
+		"/ip4/163.172.178.141/udp/21777/quic-v1/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
 		"/ip6/2001:bc8:700:8017::1/tcp/21777/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
-		"/ip6/2001:bc8:700:8017::1/udp/21777/quic/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
+		"/ip6/2001:bc8:700:8017::1/udp/21777/quic-v1/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
 	}
 	conf.Network.Bootstrap.MinThreshold = 4
 	conf.Network.Bootstrap.MaxThreshold = 8
 	conf.Network.EnableRelay = true
 	conf.Network.RelayAddrs = []string{
 		"/ip4/139.162.153.10/tcp/4002/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
-		"/ip4/139.162.153.10/udp/4002/quic/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
+		"/ip4/139.162.153.10/udp/4002/quic-v1/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
 		"/ip6/2a01:7e01::f03c:93ff:fed2:84c5/tcp/4002/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
-		"/ip6/2a01:7e01::f03c:93ff:fed2:84c5/udp/4002/quic/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
+		"/ip6/2a01:7e01::f03c:93ff:fed2:84c5/udp/4002/quic-v1/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
 		"/ip4/94.101.184.118/tcp/4002/p2p/12D3KooWCRHn8vjrKNBEQcut8uVCYX5q77RKidPaE6iMK31qEVHb",
-		"/ip4/94.101.184.118/udp/4002/quic/p2p/12D3KooWCRHn8vjrKNBEQcut8uVCYX5q77RKidPaE6iMK31qEVHb",
+		"/ip4/94.101.184.118/udp/4002/quic-v1/p2p/12D3KooWCRHn8vjrKNBEQcut8uVCYX5q77RKidPaE6iMK31qEVHb",
 	}
 	conf.GRPC.Enable = true
 	conf.GRPC.Listen = "[::]:50052"

--- a/config/example_config.toml
+++ b/config/example_config.toml
@@ -22,7 +22,7 @@
 [network]
 
   # `listens` specifies the addresses and ports where the node will listen for incoming connections from other nodes.
- ## listens = ["/ip4/0.0.0.0/tcp/21888", "/ip6/::/tcp/21888", "/ip4/0.0.0.0/udp/21888/quic", "/ip6/::/udp/21888/quic"]
+ ## listens = ["/ip4/0.0.0.0/tcp/21888", "/ip6/::/tcp/21888", "/ip4/0.0.0.0/udp/21888/quic-v1", "/ip6/::/udp/21888/quic-v1"]
 
   # `network_key` specifies the private key filename to use for node authentication and encryption in the p2p protocol.
  ## network_key = "network_key"

--- a/network/config.go
+++ b/network/config.go
@@ -49,7 +49,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Listens: []string{
 			"/ip4/0.0.0.0/tcp/21888", "/ip6/::/tcp/21888",
-			"/ip4/0.0.0.0/udp/21888/quic", "/ip6/::/udp/21888/quic",
+			"/ip4/0.0.0.0/udp/21888/quic-v1", "/ip6/::/udp/21888/quic-v1",
 		},
 		NetworkKey:    "network_key",
 		EnableNAT:     true,

--- a/network/stream.go
+++ b/network/stream.go
@@ -119,7 +119,7 @@ func (s *streamService) SendRequest(msg []byte, pid lp2peer.ID) error {
 	if err != nil {
 		return LibP2PError{Err: err}
 	}
-	err = stream.Close()
+	err = stream.CloseWrite()
 	if err != nil {
 		return LibP2PError{Err: err}
 	}

--- a/sync/firewall/firewall.go
+++ b/sync/firewall/firewall.go
@@ -50,7 +50,6 @@ func (f *Firewall) OpenGossipBundle(data []byte, source peer.ID, from peer.ID) *
 	if err != nil {
 		f.logger.Warn("firewall: unable to open a gossip bundle",
 			"error", err, "bundle", bdl, "source", source)
-		f.closeConnection(from)
 		return nil
 	}
 
@@ -60,12 +59,11 @@ func (f *Firewall) OpenGossipBundle(data []byte, source peer.ID, from peer.ID) *
 	return bdl
 }
 
-func (f *Firewall) OpenStreamBundle(r io.Reader, from peer.ID) *bundle.Bundle {
-	bdl, err := f.openBundle(r, from)
+func (f *Firewall) OpenStreamBundle(r io.Reader, source peer.ID) *bundle.Bundle {
+	bdl, err := f.openBundle(r, source)
 	if err != nil {
 		f.logger.Warn("firewall: unable to open a stream bundle",
-			"error", err, "bundle", bdl, "from", from)
-		f.closeConnection(from)
+			"error", err, "bundle", bdl, "source", source)
 		return nil
 	}
 

--- a/sync/firewall/firewall_test.go
+++ b/sync/firewall/firewall_test.go
@@ -93,7 +93,6 @@ func TestGossipMessage(t *testing.T) {
 
 		assert.False(t, td.firewall.isPeerBanned(td.unknownPeerID))
 		assert.False(t, td.network.IsClosed(td.unknownPeerID))
-		// TODO: should only accepts hello from unknown peers?
 		assert.NotNil(t, td.firewall.OpenGossipBundle(d, td.unknownPeerID, td.unknownPeerID))
 		assert.False(t, td.network.IsClosed(td.unknownPeerID))
 	})
@@ -115,11 +114,7 @@ func TestGossipMessage(t *testing.T) {
 	t.Run("Message is nil => should close the connection", func(t *testing.T) {
 		td := setup(t)
 
-		assert.False(t, td.network.IsClosed(td.badPeerID))
-		assert.False(t, td.network.IsClosed(td.unknownPeerID))
 		assert.Nil(t, td.firewall.OpenGossipBundle(nil, td.badPeerID, td.unknownPeerID))
-		assert.True(t, td.network.IsClosed(td.badPeerID))
-		assert.True(t, td.network.IsClosed(td.unknownPeerID))
 	})
 
 	t.Run("Message source: bad, from: unknown => should close the connection", func(t *testing.T) {
@@ -133,10 +128,10 @@ func TestGossipMessage(t *testing.T) {
 		assert.False(t, td.network.IsClosed(td.unknownPeerID))
 		assert.Nil(t, td.firewall.OpenGossipBundle(d, td.badPeerID, td.unknownPeerID))
 		assert.True(t, td.network.IsClosed(td.badPeerID))
-		assert.True(t, td.network.IsClosed(td.unknownPeerID))
+		assert.False(t, td.network.IsClosed(td.unknownPeerID))
 	})
 
-	t.Run("Message initiator is not the same as source => should close the connection", func(t *testing.T) {
+	t.Run("Message initiator is not the same as source => should NOT close the connection", func(t *testing.T) {
 		td := setup(t)
 
 		bdl := bundle.NewBundle(td.badPeerID, message.NewQueryVotesMessage(100, 1))
@@ -144,7 +139,7 @@ func TestGossipMessage(t *testing.T) {
 		d, _ := bdl.Encode()
 
 		assert.Nil(t, td.firewall.OpenGossipBundle(d, td.unknownPeerID, td.unknownPeerID))
-		assert.True(t, td.network.IsClosed(td.unknownPeerID))
+		assert.False(t, td.network.IsClosed(td.unknownPeerID))
 	})
 
 	t.Run("Ok => should NOT close the connection", func(t *testing.T) {

--- a/sync/handler_blocks_request.go
+++ b/sync/handler_blocks_request.go
@@ -97,7 +97,6 @@ func (handler *blocksRequestHandler) respond(msg *message.BlocksResponseMessage,
 	if msg.ResponseCode == message.ResponseCodeRejected {
 		handler.logger.Error("rejecting block request message", "message", msg,
 			"to", to, "reason", msg.Reason)
-		handler.network.CloseConnection(to)
 	} else {
 		handler.logger.Info("responding block request message", "message", msg,
 			"to", to)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -296,9 +296,6 @@ func (sync *synchronizer) sendTo(msg message.Message, to peer.ID) error {
 
 		err := sync.network.SendTo(data, to)
 		if err != nil {
-			sync.logger.Warn("error on sending bundle",
-				"bundle", bdl, "to", to, "error", err)
-
 			return err
 		}
 		sync.logger.Info("sending bundle to a peer",

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -163,7 +163,6 @@ func (sync *synchronizer) receiveLoop() {
 			return
 
 		case e := <-sync.networkCh:
-
 			switch e.Type() {
 			case network.EventTypeGossip:
 				ge := e.(*network.GossipMessage)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -83,7 +83,7 @@ func TestMain(m *testing.M) {
 		tConfigs[i].Sync.Firewall.Enabled = false
 		tConfigs[i].Network.EnableMdns = true
 		tConfigs[i].Network.NetworkKey = util.TempFilePath()
-		tConfigs[i].Network.Listens = []string{"/ip4/127.0.0.1/tcp/0", "/ip4/127.0.0.1/udp/0/quic"}
+		tConfigs[i].Network.Listens = []string{"/ip4/127.0.0.1/tcp/0", "/ip4/127.0.0.1/udp/0/quic-v1"}
 		tConfigs[i].Network.Bootstrap.Addresses = []string{}
 		tConfigs[i].Network.Bootstrap.Period = 10 * time.Second
 		tConfigs[i].Network.Bootstrap.MinThreshold = 3

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -74,9 +74,9 @@ func TestMain(m *testing.M) {
 		tConfigs[i].Consensus.ChangeProposerTimeout = 4 * time.Second
 		tConfigs[i].Logger.Levels["default"] = "warn"
 		tConfigs[i].Logger.Levels["_state"] = "warn"
-		tConfigs[i].Logger.Levels["_sync"] = "warn"
+		tConfigs[i].Logger.Levels["_sync"] = "debug"
 		tConfigs[i].Logger.Levels["_consensus"] = "warn"
-		tConfigs[i].Logger.Levels["_network"] = "warn"
+		tConfigs[i].Logger.Levels["_network"] = "debug"
 		tConfigs[i].Logger.Levels["_pool"] = "warn"
 		tConfigs[i].Sync.CacheSize = 1000
 		tConfigs[i].Sync.NodeNetwork = false


### PR DESCRIPTION
## Description

This PR replaces QUIC with QUICv1 in the config file. Read more about QUIC protocol [here](https://docs.libp2p.io/concepts/transports/quic/)