### PR TITLE
fix: removing UDP support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -102,33 +102,23 @@ func SaveTestnetConfig(path string, numValidators int) error {
 	conf := DefaultConfig()
 	conf.Node.NumValidators = numValidators
 	conf.Network.Listens = []string{
-		"/ip4/0.0.0.0/tcp/21777", "/ip4/0.0.0.0/udp/21777/quic",
-		"/ip6/::/tcp/21777", "/ip6/::/udp/21777/quic",
+		"/ip4/0.0.0.0/tcp/21777", "/ip6/::/tcp/21777",
 	}
 	conf.Network.Bootstrap.Addresses = []string{
 		"/ip4/94.101.184.118/tcp/21777/p2p/12D3KooWCwQZt8UriVXobQHPXPR8m83eceXVoeT6brPNiBHomebc",
-		"/ip4/94.101.184.118/udp/21777/quic/p2p/12D3KooWCwQZt8UriVXobQHPXPR8m83eceXVoeT6brPNiBHomebc",
 		"/ip4/172.104.46.145/tcp/21777/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
-		"/ip4/172.104.46.145/udp/21777/quic/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
 		"/ip6/2400:8901::f03c:93ff:fe1c:c3ec/tcp/21777/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
-		"/ip6/2400:8901::f03c:93ff:fe1c:c3ec/udp/21777/quic/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
 		"/ip4/13.115.190.71/tcp/21777/p2p/12D3KooWBGNEH8NqdK1UddSnPV1yRHGLYpaQUcnujC24s7YNWPiq",
-		"/ip4/13.115.190.71/udp/21777/quic/p2p/12D3KooWBGNEH8NqdK1UddSnPV1yRHGLYpaQUcnujC24s7YNWPiq",
 		"/ip4/163.172.178.141/tcp/21777/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
-		"/ip4/163.172.178.141/udp/21777/quic/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
 		"/ip6/2001:bc8:700:8017::1/tcp/21777/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
-		"/ip6/2001:bc8:700:8017::1/udp/21777/quic/p2p/12D3KooWDF8a4goNCHriP1y922y4jagaPwHdX4eSrG5WtQpjzS6k",
 	}
 	conf.Network.Bootstrap.MinThreshold = 4
 	conf.Network.Bootstrap.MaxThreshold = 8
 	conf.Network.EnableRelay = true
 	conf.Network.RelayAddrs = []string{
 		"/ip4/139.162.153.10/tcp/4002/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
-		"/ip4/139.162.153.10/udp/4002/quic/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
 		"/ip6/2a01:7e01::f03c:93ff:fed2:84c5/tcp/4002/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
-		"/ip6/2a01:7e01::f03c:93ff:fed2:84c5/udp/4002/quic/p2p/12D3KooWNR79jqHVVNhNVrqnDbxbJJze4VjbEsBjZhz6mkvinHAN",
 		"/ip4/94.101.184.118/tcp/4002/p2p/12D3KooWCRHn8vjrKNBEQcut8uVCYX5q77RKidPaE6iMK31qEVHb",
-		"/ip4/94.101.184.118/udp/4002/quic/p2p/12D3KooWCRHn8vjrKNBEQcut8uVCYX5q77RKidPaE6iMK31qEVHb",
 	}
 	conf.GRPC.Enable = true
 	conf.GRPC.Listen = "[::]:50052"

--- a/config/example_config.toml
+++ b/config/example_config.toml
@@ -22,7 +22,7 @@
 [network]
 
   # `listens` specifies the addresses and ports where the node will listen for incoming connections from other nodes.
- ## listens = ["/ip4/0.0.0.0/tcp/21888", "/ip6/::/tcp/21888", "/ip4/0.0.0.0/udp/21888/quic", "/ip6/::/udp/21888/quic"]
+ ## listens = ["/ip4/0.0.0.0/tcp/21888", "/ip6/::/tcp/21888"]
 
   # `network_key` specifies the private key filename to use for node authentication and encryption in the p2p protocol.
  ## network_key = "network_key"

--- a/network/config.go
+++ b/network/config.go
@@ -49,7 +49,6 @@ func DefaultConfig() *Config {
 	return &Config{
 		Listens: []string{
 			"/ip4/0.0.0.0/tcp/21888", "/ip6/::/tcp/21888",
-			"/ip4/0.0.0.0/udp/21888/quic", "/ip6/::/udp/21888/quic",
 		},
 		NetworkKey:    "network_key",
 		EnableNAT:     true,

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -83,7 +83,7 @@ func TestMain(m *testing.M) {
 		tConfigs[i].Sync.Firewall.Enabled = false
 		tConfigs[i].Network.EnableMdns = true
 		tConfigs[i].Network.NetworkKey = util.TempFilePath()
-		tConfigs[i].Network.Listens = []string{"/ip4/127.0.0.1/tcp/0", "/ip4/127.0.0.1/udp/0/quic"}
+		tConfigs[i].Network.Listens = []string{"/ip4/127.0.0.1/tcp/0"}
 		tConfigs[i].Network.Bootstrap.Addresses = []string{}
 		tConfigs[i].Network.Bootstrap.Period = 10 * time.Second
 		tConfigs[i].Network.Bootstrap.MinThreshold = 3


### PR DESCRIPTION
## Description

This PR removes the support for UDP due to persistent and significant errors encountered during Pre-Testnet operations. Our recent data has shown a substantial number of issues related to UDP communications, compromising network reliability and stability.
