### PR TITLE
fix: data race issue on updating certificate

### DIFF
--- a/types/certificate/certificate.go
+++ b/types/certificate/certificate.go
@@ -104,15 +104,21 @@ func (cert *Certificate) Hash() hash.Hash {
 }
 
 func (cert *Certificate) Clone() *Certificate {
-	return &Certificate{
+	cloned := &Certificate{
 		data: certificateData{
 			Height:     cert.Height(),
 			Round:      cert.Round(),
-			Committers: cert.Committers(),
-			Absentees:  cert.Absentees(),
-			Signature:  cert.Signature(),
+			Committers: make([]int32, len(cert.data.Committers)),
+			Absentees:  make([]int32, len(cert.data.Absentees)),
+			Signature:  new(bls.Signature),
 		},
 	}
+
+	copy(cloned.data.Committers, cert.data.Committers)
+	copy(cloned.data.Absentees, cert.data.Absentees)
+	*cloned.data.Signature = *cert.data.Signature
+
+	return cloned
 }
 
 // SerializeSize returns the number of bytes it would take to serialize the block.

--- a/types/certificate/certificate_test.go
+++ b/types/certificate/certificate_test.go
@@ -315,6 +315,6 @@ func TestClone(t *testing.T) {
 	cert1 := ts.GenerateTestCertificate(ts.RandHeight())
 	cert2 := cert1.Clone()
 
-	cert1.AddSignature(cert1.Absentees()[0], ts.RandBLSSignature())
+	cert2.AddSignature(cert2.Absentees()[0], ts.RandBLSSignature())
 	assert.NotEqual(t, cert1, cert2)
 }


### PR DESCRIPTION
## Description

A data race issue could occur when updating the certificate, as we can see here in this [action](https://github.com/pactus-project/pactus/actions/runs/6497684575/job/17647318149?pr=745). This PR deeply clones the certificate to prevent it.
