### PR TITLE
chore: bumping version to 0.16.0

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -35,9 +35,9 @@ Let's create environment variables for the release version.
 For the rest of this document, we will use these environment variables in the commands.
 
 ```bash
-PRV_VER="0.13.0"
-CUR_VER="0.15.0"
-NEXT_VER="0.16.0"
+PRV_VER="0.15.0"
+CUR_VER="0.16.0"
+NEXT_VER="0.17.0"
 TAG_NAME="v${CUR_VER}"
 TAG_MSG="Version ${CUR_VER}"
 ```

--- a/version/version.go
+++ b/version/version.go
@@ -7,7 +7,7 @@ import (
 // These constants follow the semantic versioning 2.0.0 spec (http://semver.org/)
 const (
 	major uint   = 0
-	minor uint   = 15
+	minor uint   = 16
 	patch uint   = 0
 	meta  string = "beta"
 )


### PR DESCRIPTION
Bumping version to 0.16.0