### PR TITLE
feat(network): adding bootstrapper mode to the network config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -76,8 +77,8 @@ func TestExampleConfig(t *testing.T) {
 	exampleToml = strings.ReplaceAll(exampleToml, "\n\n", "\n")
 	defaultToml = strings.ReplaceAll(defaultToml, "\n\n", "\n")
 
-	// fmt.Println(defaultToml)
-	// fmt.Println(exampleToml)
+	fmt.Println(defaultToml)
+	fmt.Println(exampleToml)
 	assert.Equal(t, defaultToml, exampleToml)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -77,8 +76,8 @@ func TestExampleConfig(t *testing.T) {
 	exampleToml = strings.ReplaceAll(exampleToml, "\n\n", "\n")
 	defaultToml = strings.ReplaceAll(defaultToml, "\n\n", "\n")
 
-	fmt.Println(defaultToml)
-	fmt.Println(exampleToml)
+	// fmt.Println(defaultToml)
+	// fmt.Println(exampleToml)
 	assert.Equal(t, defaultToml, exampleToml)
 }
 

--- a/config/example_config.toml
+++ b/config/example_config.toml
@@ -50,6 +50,10 @@
   # Default is false.
  ## enable_metrics = false
 
+  # `bootstrapper` if enabled, it runs the node in bootstrap mode.
+  # Default is false.
+ ## bootstrapper = false
+
     # `network.bootstrap` contains configuration for bootstrapping the node.
   [network.bootstrap]
 

--- a/network/config.go
+++ b/network/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	RelayAddrs    []string         `toml:"relay_addresses"`
 	EnableMdns    bool             `toml:"enable_mdns"`
 	EnableMetrics bool             `toml:"enable_metrics"`
+	Bootstrapper  bool             `toml:"bootstrapper"`
 	Bootstrap     *BootstrapConfig `toml:"bootstrap"`
 }
 
@@ -56,6 +57,7 @@ func DefaultConfig() *Config {
 		EnableRelay:   false,
 		EnableMdns:    false,
 		EnableMetrics: false,
+		Bootstrapper:  false,
 		Bootstrap: &BootstrapConfig{
 			Addresses:    addresses,
 			MinThreshold: 8,

--- a/network/network.go
+++ b/network/network.go
@@ -169,7 +169,7 @@ func newNetwork(networkName string, conf *Config, opts []lp2p.Option) (*network,
 	kadProtocolID := lp2pcore.ProtocolID(fmt.Sprintf("/%s/gossip/v1", n.name))
 	streamProtocolID := lp2pcore.ProtocolID(fmt.Sprintf("/%s/stream/v1", n.name))
 
-	n.dht = newDHTService(n.ctx, n.host, kadProtocolID, conf.Bootstrap, n.logger)
+	n.dht = newDHTService(n.ctx, n.host, kadProtocolID, conf.Bootstrap, conf.Bootstrapper, n.logger)
 	n.stream = newStreamService(ctx, n.host, streamProtocolID, relayAddrs, n.eventChannel, n.logger)
 	n.gossip = newGossipService(ctx, n.host, n.eventChannel, n.logger)
 	n.notifee = newNotifeeService(n.host, n.eventChannel, n.logger, streamProtocolID)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -82,6 +82,7 @@ func TestMain(m *testing.M) {
 		tConfigs[i].Sync.NodeNetwork = false
 		tConfigs[i].Sync.Firewall.Enabled = false
 		tConfigs[i].Network.EnableMdns = true
+		tConfigs[i].Network.Bootstrapper = true
 		tConfigs[i].Network.NetworkKey = util.TempFilePath()
 		tConfigs[i].Network.Listens = []string{"/ip4/127.0.0.1/tcp/0", "/ip4/127.0.0.1/udp/0/quic-v1"}
 		tConfigs[i].Network.Bootstrap.Addresses = []string{}


### PR DESCRIPTION
## Description

This PR adds bootstrapper mode to the config and operates the DHT as a server.

Fixes: #756