### PR TITLE
fix(consensus): strong termination for the binary agreement

### DIFF
--- a/consensus/cp.go
+++ b/consensus/cp.go
@@ -375,7 +375,5 @@ func (cp *changeProposer) cpDecide(cpValue vote.CPValue) {
 		}
 		cp.cpDecided = 0
 		cp.enterNewState(cp.prepareState)
-	} else {
-		panic("unreachable")
 	}
 }

--- a/consensus/cp_decide.go
+++ b/consensus/cp_decide.go
@@ -38,7 +38,6 @@ func (s *cpDecideState) decide() {
 			}
 			s.signAddCPDecidedVote(*s.cpWeakValidity, s.cpRound, vote.CPValueZero, just)
 			s.cpDecide(vote.CPValueZero)
-			s.cpDecided = 0
 		} else {
 			// conflicting votes
 			s.logger.Debug("conflicting main votes", "round", s.cpRound)

--- a/consensus/cp_mainvote.go
+++ b/consensus/cp_mainvote.go
@@ -49,6 +49,7 @@ func (s *cpMainVoteState) decide() {
 				Just0: vote0.CPJust(),
 				Just1: vote1.CPJust(),
 			}
+
 			s.signAddCPMainVote(*s.cpWeakValidity, s.cpRound, vote.CPValueAbstain, just)
 			s.enterNewState(s.cpDecideState)
 		}
@@ -88,6 +89,8 @@ func (s *cpMainVoteState) onAddVote(v *vote.Vote) {
 	if v.Type() == vote.VoteTypeCPPreVote {
 		s.decide()
 	}
+
+	s.checkForTermination(v)
 }
 
 func (s *cpMainVoteState) name() string {

--- a/consensus/cp_test.go
+++ b/consensus/cp_test.go
@@ -52,14 +52,7 @@ func TestChangeProposerAgreement1(t *testing.T) {
 	td.addCPMainVote(td.consP, hash.UndefHash, h, r, 0, vote.CPValueOne, mainVote0.CPJust(), tIndexX)
 	td.addCPMainVote(td.consP, hash.UndefHash, h, r, 0, vote.CPValueOne, mainVote0.CPJust(), tIndexY)
 
-	preVote1 := td.shouldPublishVote(t, td.consP, vote.VoteTypeCPPreVote, hash.UndefHash)
-	td.addCPPreVote(td.consP, hash.UndefHash, h, r, 1, vote.CPValueOne, preVote1.CPJust(), tIndexX)
-	td.addCPPreVote(td.consP, hash.UndefHash, h, r, 1, vote.CPValueOne, preVote1.CPJust(), tIndexY)
-
-	mainVote1 := td.shouldPublishVote(t, td.consP, vote.VoteTypeCPMainVote, hash.UndefHash)
-	td.addCPMainVote(td.consP, hash.UndefHash, h, r, 1, vote.CPValueOne, mainVote1.CPJust(), tIndexX)
-	td.addCPMainVote(td.consP, hash.UndefHash, h, r, 1, vote.CPValueOne, mainVote1.CPJust(), tIndexY)
-
+	td.shouldPublishVote(t, td.consP, vote.VoteTypeCPDecided, hash.UndefHash)
 	checkHeightRound(t, td.consP, h, r+1)
 }
 
@@ -90,14 +83,7 @@ func TestChangeProposerAgreement0(t *testing.T) {
 	td.addCPMainVote(td.consP, p.Block().Hash(), h, r, 0, vote.CPValueZero, mainVote0.CPJust(), tIndexX)
 	td.addCPMainVote(td.consP, p.Block().Hash(), h, r, 0, vote.CPValueZero, mainVote0.CPJust(), tIndexY)
 
-	preVote1 := td.shouldPublishVote(t, td.consP, vote.VoteTypeCPPreVote, p.Block().Hash())
-	td.addCPPreVote(td.consP, p.Block().Hash(), h, r, 1, vote.CPValueZero, preVote1.CPJust(), tIndexX)
-	td.addCPPreVote(td.consP, p.Block().Hash(), h, r, 1, vote.CPValueZero, preVote1.CPJust(), tIndexY)
-
-	mainVote1 := td.shouldPublishVote(t, td.consP, vote.VoteTypeCPMainVote, p.Block().Hash())
-	td.addCPMainVote(td.consP, p.Block().Hash(), h, r, 1, vote.CPValueZero, mainVote1.CPJust(), tIndexX)
-	td.addCPMainVote(td.consP, p.Block().Hash(), h, r, 1, vote.CPValueZero, mainVote1.CPJust(), tIndexY)
-
+	td.shouldPublishVote(t, td.consP, vote.VoteTypeCPDecided, p.Block().Hash())
 	td.shouldPublishQueryProposal(t, td.consP, h)
 	td.addPrecommitVote(td.consP, p.Block().Hash(), h, r, tIndexX)
 	td.addPrecommitVote(td.consP, p.Block().Hash(), h, r, tIndexY)

--- a/consensus/log/log.go
+++ b/consensus/log/log.go
@@ -42,6 +42,7 @@ func (log *Log) mustGetRoundMessages(round int16) *Messages {
 			precommitVotes: voteset.NewPrecommitVoteSet(round, log.totalPower, log.validators),
 			cpPreVotes:     voteset.NewCPPreVoteVoteSet(round, log.totalPower, log.validators),
 			cpMainVotes:    voteset.NewCPMainVoteVoteSet(round, log.totalPower, log.validators),
+			cpDecidedVotes: voteset.NewCPDecidedVoteVoteSet(round, log.totalPower, log.validators),
 		}
 		log.roundMessages[round] = rm
 	}
@@ -72,6 +73,11 @@ func (log *Log) CPPreVoteVoteSet(round int16) *voteset.BinaryVoteSet {
 func (log *Log) CPMainVoteVoteSet(round int16) *voteset.BinaryVoteSet {
 	m := log.mustGetRoundMessages(round)
 	return m.cpMainVotes
+}
+
+func (log *Log) CPDecidedVoteVoteSet(round int16) *voteset.BinaryVoteSet {
+	m := log.mustGetRoundMessages(round)
+	return m.cpDecidedVotes
 }
 
 func (log *Log) HasRoundProposal(round int16) bool {

--- a/consensus/log/messages.go
+++ b/consensus/log/messages.go
@@ -14,6 +14,7 @@ type Messages struct {
 	precommitVotes *voteset.BlockVoteSet  // Precommit votes
 	cpPreVotes     *voteset.BinaryVoteSet // Change proposer Pre-votes
 	cpMainVotes    *voteset.BinaryVoteSet // Change proposer Main-votes
+	cpDecidedVotes *voteset.BinaryVoteSet // Change proposer Decided-votes
 	proposal       *proposal.Proposal
 }
 
@@ -27,6 +28,8 @@ func (m *Messages) addVote(v *vote.Vote) (bool, error) {
 		return m.cpPreVotes.AddVote(v)
 	case vote.VoteTypeCPMainVote:
 		return m.cpMainVotes.AddVote(v)
+	case vote.VoteTypeCPDecided:
+		return m.cpDecidedVotes.AddVote(v)
 	}
 
 	return false, fmt.Errorf("unexpected vote type: %v", v.Type())
@@ -48,6 +51,7 @@ func (m *Messages) AllVotes() []*vote.Vote {
 	votes = append(votes, m.precommitVotes.AllVotes()...)
 	votes = append(votes, m.cpPreVotes.AllVotes()...)
 	votes = append(votes, m.cpMainVotes.AllVotes()...)
+	votes = append(votes, m.cpDecidedVotes.AllVotes()...)
 
 	return votes
 }

--- a/consensus/voteset/binary_voteset.go
+++ b/consensus/voteset/binary_voteset.go
@@ -40,14 +40,21 @@ type BinaryVoteSet struct {
 func NewCPPreVoteVoteSet(round int16, totalPower int64,
 	validators map[crypto.Address]*validator.Validator,
 ) *BinaryVoteSet {
-	voteSet := newVoteSet(vote.VoteTypeCPPreVote, round, totalPower, validators)
+	voteSet := newVoteSet(round, totalPower, validators)
 	return newBinaryVoteSet(voteSet)
 }
 
 func NewCPMainVoteVoteSet(round int16, totalPower int64,
 	validators map[crypto.Address]*validator.Validator,
 ) *BinaryVoteSet {
-	voteSet := newVoteSet(vote.VoteTypeCPMainVote, round, totalPower, validators)
+	voteSet := newVoteSet(round, totalPower, validators)
+	return newBinaryVoteSet(voteSet)
+}
+
+func NewCPDecidedVoteVoteSet(round int16, totalPower int64,
+	validators map[crypto.Address]*validator.Validator,
+) *BinaryVoteSet {
+	voteSet := newVoteSet(round, totalPower, validators)
 	return newBinaryVoteSet(voteSet)
 }
 

--- a/consensus/voteset/block_voteset.go
+++ b/consensus/voteset/block_voteset.go
@@ -18,14 +18,14 @@ type BlockVoteSet struct {
 func NewPrepareVoteSet(round int16, totalPower int64,
 	validators map[crypto.Address]*validator.Validator,
 ) *BlockVoteSet {
-	voteSet := newVoteSet(vote.VoteTypePrepare, round, totalPower, validators)
+	voteSet := newVoteSet(round, totalPower, validators)
 	return newBlockVoteSet(voteSet)
 }
 
 func NewPrecommitVoteSet(round int16, totalPower int64,
 	validators map[crypto.Address]*validator.Validator,
 ) *BlockVoteSet {
-	voteSet := newVoteSet(vote.VoteTypePrecommit, round, totalPower, validators)
+	voteSet := newVoteSet(round, totalPower, validators)
 	return newBlockVoteSet(voteSet)
 }
 

--- a/consensus/voteset/voteset.go
+++ b/consensus/voteset/voteset.go
@@ -1,8 +1,6 @@
 package voteset
 
 import (
-	"fmt"
-
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/types/validator"
 	"github.com/pactus-project/pactus/types/vote"
@@ -10,25 +8,19 @@ import (
 )
 
 type voteSet struct {
-	voteType   vote.Type
 	round      int16
 	validators map[crypto.Address]*validator.Validator
 	totalPower int64
 }
 
-func newVoteSet(voteType vote.Type, round int16, totalPower int64,
+func newVoteSet(round int16, totalPower int64,
 	validators map[crypto.Address]*validator.Validator,
 ) *voteSet {
 	return &voteSet{
 		round:      round,
-		voteType:   voteType,
 		validators: validators,
 		totalPower: totalPower,
 	}
-}
-
-func (vs *voteSet) Type() vote.Type {
-	return vs.voteType
 }
 
 // Round returns the round number for the VoteSet.
@@ -60,8 +52,4 @@ func (vs *voteSet) isTwoThirdOfTotalPower(power int64) bool {
 
 func (vs *voteSet) isOneThirdOfTotalPower(power int64) bool {
 	return power > (vs.totalPower * 1 / 3)
-}
-
-func (vs *voteSet) String() string {
-	return fmt.Sprintf("{%v/%s TOTAL:%v}", vs.round, vs.voteType, vs.totalPower)
 }

--- a/consensus/voteset/voteset_test.go
+++ b/consensus/voteset/voteset_test.go
@@ -379,3 +379,23 @@ func TestOneThirdPower(t *testing.T) {
 	assert.Contains(t, bv1, v3.Signer())
 	assert.Contains(t, bv2, v4.Signer())
 }
+
+func TestDecidedVoteset(t *testing.T) {
+	ts := testsuite.NewTestSuite(t)
+	valsMap, valKeys, totalPower := setupCommittee(ts, 1, 1, 1, 1)
+
+	hash := ts.RandHash()
+	height := ts.RandHeight()
+	round := ts.RandRound()
+	just := &vote.JustInitOne{}
+	vs := NewCPDecidedVoteVoteSet(round, totalPower, valsMap)
+
+	v1 := vote.NewCPDecidedVote(hash, height, round, 0, vote.CPValueOne, just, valKeys[0].Address())
+
+	ts.HelperSignVote(valKeys[0], v1)
+
+	_, err := vs.AddVote(v1)
+	assert.NoError(t, err)
+	assert.True(t, vs.HasAnyVoteFor(0, vote.CPValueOne))
+	assert.False(t, vs.HasAnyVoteFor(0, vote.CPValueZero))
+}

--- a/network/utils.go
+++ b/network/utils.go
@@ -29,7 +29,7 @@ func ConnectAsync(ctx context.Context, h lp2phost.Host, addrInfo lp2ppeer.AddrIn
 			}
 		} else {
 			if logger != nil {
-				logger.Debug("connected", "addr", addrInfo.Addrs, "err", err)
+				logger.Debug("connected", "addr", addrInfo.Addrs)
 			}
 		}
 	}()

--- a/types/vote/cp_just.go
+++ b/types/vote/cp_just.go
@@ -14,6 +14,7 @@ const (
 	JustTypePreVoteHard        = JustType(4)
 	JustTypeMainVoteConflict   = JustType(5)
 	JustTypeMainVoteNoConflict = JustType(6)
+	JustTypeDecided            = JustType(7)
 )
 
 func (t JustType) String() string {
@@ -30,6 +31,8 @@ func (t JustType) String() string {
 		return "JustMainVoteConflict"
 	case JustTypeMainVoteNoConflict:
 		return "JustMainVoteNoConflict"
+	case JustTypeDecided:
+		return "JustDecided"
 
 	default:
 		return "Unknown"
@@ -55,6 +58,8 @@ func makeJust(t JustType) (Just, error) {
 		return &JustMainVoteConflict{}, nil
 	case JustTypeMainVoteNoConflict:
 		return &JustMainVoteNoConflict{}, nil
+	case JustTypeDecided:
+		return &JustDecided{}, nil
 
 	default:
 		return nil, errors.Errorf(errors.ErrInvalidVote, "invalid justification")
@@ -83,6 +88,10 @@ type JustMainVoteNoConflict struct {
 	QCert *certificate.Certificate `cbor:"1,keyasint"`
 }
 
+type JustDecided struct {
+	QCert *certificate.Certificate `cbor:"1,keyasint"`
+}
+
 func (j *JustInitZero) Type() JustType {
 	return JustTypeInitZero
 }
@@ -105,6 +114,10 @@ func (j *JustMainVoteConflict) Type() JustType {
 
 func (j *JustMainVoteNoConflict) Type() JustType {
 	return JustTypeMainVoteNoConflict
+}
+
+func (j *JustDecided) Type() JustType {
+	return JustTypeDecided
 }
 
 func (j *JustInitZero) BasicCheck() error {
@@ -131,5 +144,9 @@ func (j *JustMainVoteConflict) BasicCheck() error {
 }
 
 func (j *JustMainVoteNoConflict) BasicCheck() error {
+	return j.QCert.BasicCheck()
+}
+
+func (j *JustDecided) BasicCheck() error {
 	return j.QCert.BasicCheck()
 }

--- a/types/vote/vote_type.go
+++ b/types/vote/vote_type.go
@@ -7,12 +7,13 @@ const (
 	VoteTypePrecommit  = Type(2) // precommit vote
 	VoteTypeCPPreVote  = Type(3) // change-proposer:pre-vote
 	VoteTypeCPMainVote = Type(4) // change-proposer:main-vote
+	VoteTypeCPDecided  = Type(5) // change-proposer:decided
 )
 
 func (t Type) IsValid() bool {
 	switch t {
 	case VoteTypePrepare, VoteTypePrecommit,
-		VoteTypeCPPreVote, VoteTypeCPMainVote:
+		VoteTypeCPPreVote, VoteTypeCPMainVote, VoteTypeCPDecided:
 		return true
 	}
 
@@ -29,6 +30,8 @@ func (t Type) String() string {
 		return "PRE-VOTE"
 	case VoteTypeCPMainVote:
 		return "MAIN-VOTE"
+	case VoteTypeCPDecided:
+		return "DECIDED"
 	default:
 		return ("invalid vote type")
 	}


### PR DESCRIPTION
## Description

This pull request (PR) implements strong termination for binary agreement. 
Any validator who makes a decision in the MainVote step will broadcast the `decide` message.
Any validator who sees a proper and justified `decide` message can decide on the agreed-upon value and terminate immediately.

This is based on section 5.3.1 of the ABBA spec: "Achieving Stronger Termination"
