### PR TITLE
fix(sync): peer status set to known on sucessfull handshaking

### DIFF
--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -61,7 +61,7 @@ func (handler *helloHandler) ParseMessage(m message.Message, initiator peer.ID) 
 	}
 
 	handler.peerSet.UpdateHeight(initiator, msg.Height, msg.BlockHash)
-	handler.peerSet.UpdateStatus(initiator, peerset.StatusCodeConnected)
+	handler.peerSet.UpdateStatus(initiator, peerset.StatusCodeKnown)
 
 	response := message.NewHelloAckMessage(message.ResponseCodeOK, "Ok")
 	return handler.acknowledge(response, initiator)

--- a/sync/handler_hello_test.go
+++ b/sync/handler_hello_test.go
@@ -99,7 +99,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			p := td.sync.peerSet.GetPeer(pid)
 
 			pub := valKey.PublicKey()
-			assert.Equal(t, p.Status, peerset.StatusCodeConnected)
+			assert.Equal(t, p.Status, peerset.StatusCodeKnown)
 			assert.Equal(t, p.Agent, version.Agent())
 			assert.Equal(t, p.Moniker, "kitty")
 			assert.Contains(t, p.ConsensusKeys, pub)


### PR DESCRIPTION
## Description

Peer status should set to known after sending hello-ack message.
