### PR TITLE
fix: not close connection for bootstrap nodes

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -214,7 +214,7 @@ func newNetwork(networkName string, conf *Config, opts []lp2p.Option) (*network,
 	n.peerMgr = newPeerMgr(ctx, host, n.dht.kademlia, conf, n.logger)
 	n.stream = newStreamService(ctx, n.host, streamProtocolID, relayAddrs, n.eventChannel, n.logger)
 	n.gossip = newGossipService(ctx, n.host, n.eventChannel, conf, n.logger)
-	n.notifee = newNotifeeService(n.host, n.eventChannel, n.logger, streamProtocolID)
+	n.notifee = newNotifeeService(n.host, n.eventChannel, n.logger, streamProtocolID, conf.Bootstrapper)
 
 	n.host.Network().Notify(n.notifee)
 

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -15,16 +15,18 @@ type NotifeeService struct {
 	eventChannel chan<- Event
 	logger       *logger.SubLogger
 	protocolID   protocol.ID
+	bootstrapper bool
 }
 
 func newNotifeeService(host lp2phost.Host, eventChannel chan<- Event,
-	log *logger.SubLogger, protocolID protocol.ID,
+	log *logger.SubLogger, protocolID protocol.ID, bootstrapper bool,
 ) *NotifeeService {
 	notifee := &NotifeeService{
 		host:         host,
 		eventChannel: eventChannel,
 		logger:       log,
 		protocolID:   protocolID,
+		bootstrapper: bootstrapper,
 	}
 	host.Network().Notify(notifee)
 	return notifee
@@ -49,8 +51,10 @@ func (n *NotifeeService) Connected(lp2pn lp2pnetwork.Network, conn lp2pnetwork.C
 
 		n.logger.Info("unable to get supported protocols", "pid", peerID)
 
-		// Close this connection since we can't send a direct message to this peer.
-		_ = n.host.Network().ClosePeer(peerID)
+		if !n.bootstrapper {
+			// Close this connection since we can't send a direct message to this peer.
+			_ = n.host.Network().ClosePeer(peerID)
+		}
 	}()
 }
 


### PR DESCRIPTION
## Description

If the node is a bootstrap node and the protocol negotiation cannot be established, the connection will not be closed.