### PR TITLE
fix(execution): fixing mistake on calculating unbonded power

### DIFF
--- a/execution/executor/bond_test.go
+++ b/execution/executor/bond_test.go
@@ -170,3 +170,22 @@ func TestStakeExceeded(t *testing.T) {
 	err := exe.Execute(trx, td.sandbox)
 	assert.Equal(t, errors.Code(err), errors.ErrInvalidAmount)
 }
+
+func TestPwerDeltaBond(t *testing.T) {
+	td := setup(t)
+	exe := NewBondExecutor(true)
+
+	senderAddr, senderAcc := td.sandbox.TestStore.RandomTestAcc()
+	senderBalance := senderAcc.Balance()
+	pub, _ := td.RandBLSKeyPair()
+	receiverAddr := pub.ValidatorAddress()
+	amt, fee := td.randomAmountAndFee(td.sandbox.TestParams.MinimumStake, senderBalance)
+	lockTime := td.sandbox.CurrentHeight()
+	trx := tx.NewBondTx(lockTime, senderAddr,
+		receiverAddr, pub, amt, fee, "ok")
+
+	err := exe.Execute(trx, td.sandbox)
+	assert.NoError(t, err, "Ok")
+
+	assert.Equal(t, amt, td.sandbox.PowerDelta())
+}

--- a/execution/executor/unbond.go
+++ b/execution/executor/unbond.go
@@ -53,7 +53,7 @@ func (e *UnbondExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 	// At this point, the validator's power is zero.
 	// However, we know the validator's stake.
 	// So, we can update the power delta with the negative of the validator's stake.
-	sb.UpdatePowerDelta(-1 * val.Power())
+	sb.UpdatePowerDelta(-1 * val.Stake())
 	sb.UpdateValidator(val)
 
 	return nil

--- a/execution/executor/unbond.go
+++ b/execution/executor/unbond.go
@@ -48,12 +48,13 @@ func (e *UnbondExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 		}
 	}
 
+	unboundedPower := val.Power()
 	val.UpdateUnbondingHeight(sb.CurrentHeight())
 
 	// At this point, the validator's power is zero.
 	// However, we know the validator's stake.
 	// So, we can update the power delta with the negative of the validator's stake.
-	sb.UpdatePowerDelta(-1 * val.Stake())
+	sb.UpdatePowerDelta(-1 * unboundedPower)
 	sb.UpdateValidator(val)
 
 	return nil

--- a/execution/executor/unbond_test.go
+++ b/execution/executor/unbond_test.go
@@ -97,3 +97,22 @@ func TestUnbondJoiningCommittee(t *testing.T) {
 	assert.Error(t, exe1.Execute(trx, td.sandbox))
 	assert.NoError(t, exe2.Execute(trx, td.sandbox))
 }
+
+func TestPwerDeltaUnbond(t *testing.T) {
+	td := setup(t)
+	exe := NewUnbondExecutor(true)
+
+	pub, _ := td.RandBLSKeyPair()
+	valAddr := pub.ValidatorAddress()
+	val := td.sandbox.MakeNewValidator(pub)
+	amt := td.RandInt64(1e9)
+	val.AddToStake(amt)
+	td.sandbox.UpdateValidator(val)
+	lockTime := td.sandbox.CurrentHeight()
+	trx := tx.NewUnbondTx(lockTime, valAddr, "Ok")
+
+	err := exe.Execute(trx, td.sandbox)
+	assert.NoError(t, err)
+
+	assert.Equal(t, -1*amt, td.sandbox.PowerDelta())
+}

--- a/execution/executor/unbond_test.go
+++ b/execution/executor/unbond_test.go
@@ -12,9 +12,16 @@ func TestExecuteUnbondTx(t *testing.T) {
 	td := setup(t)
 	exe := NewUnbondExecutor(true)
 
+	bonderAddr, bonderAcc := td.sandbox.TestStore.RandomTestAcc()
+	bonderBalance := bonderAcc.Balance()
+	stake, _ := td.randomAmountAndFee(td.sandbox.TestParams.MinimumStake, bonderBalance)
+	bonderAcc.SubtractFromBalance(stake)
+	td.sandbox.UpdateAccount(bonderAddr, bonderAcc)
+
 	pub, _ := td.RandBLSKeyPair()
 	valAddr := pub.ValidatorAddress()
 	val := td.sandbox.MakeNewValidator(pub)
+	val.AddToStake(stake)
 	td.sandbox.UpdateValidator(val)
 	lockTime := td.sandbox.CurrentHeight()
 
@@ -53,7 +60,7 @@ func TestExecuteUnbondTx(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	assert.Zero(t, td.sandbox.Validator(valAddr).Stake())
+	assert.Equal(t, stake, td.sandbox.Validator(valAddr).Stake())
 	assert.Zero(t, td.sandbox.Validator(valAddr).Power())
 	assert.Equal(t, td.sandbox.Validator(valAddr).UnbondingHeight(), td.sandbox.CurrentHeight())
 	assert.Equal(t, td.sandbox.PowerDelta(), -1*val.Stake())

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -281,6 +281,8 @@ func (sb *sandbox) VerifyProof(blockHeight uint32, proof sortition.Proof, val *v
 	if err != nil {
 		return false
 	}
+	// TODO: improvement:
+	// We can get the sortition seed without parsing the block
 	blk, err := committedBlock.ToBlock()
 	if err != nil {
 		return false

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -198,15 +198,15 @@ func (sync *synchronizer) receiveLoop() {
 }
 
 func (sync *synchronizer) processConnectEvent(ce *network.ConnectEvent) {
+	sync.peerSet.UpdateStatus(ce.PeerID, peerset.StatusCodeConnected)
+	sync.peerSet.UpdateAddress(ce.PeerID, ce.RemoteAddress)
+
 	if ce.SupportStream {
 		if err := sync.sayHello(ce.PeerID); err != nil {
 			sync.logger.Warn("sending Hello message failed",
 				"to", ce.PeerID, "error", err)
 		}
 	}
-
-	sync.peerSet.UpdateStatus(ce.PeerID, peerset.StatusCodeConnected)
-	sync.peerSet.UpdateAddress(ce.PeerID, ce.RemoteAddress)
 }
 
 func (sync *synchronizer) processDisconnectEvent(de *network.DisconnectEvent) {

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -232,7 +232,6 @@ func TestConnectEvents(t *testing.T) {
 		}
 		td.shouldPublishMessageWithThisType(t, td.network, message.TypeHello)
 		p := td.sync.peerSet.GetPeer(pid)
-		require.NotNil(t, p)
 		assert.Equal(t, p.Status, peerset.StatusCodeConnected)
 		assert.Equal(t, p.Address, "address_1")
 	})
@@ -246,7 +245,6 @@ func TestConnectEvents(t *testing.T) {
 		}
 		td.shouldNotPublishMessageWithThisType(t, td.network, message.TypeHello)
 		p := td.sync.peerSet.GetPeer(pid)
-		require.NotNil(t, p)
 		assert.Equal(t, p.Status, peerset.StatusCodeConnected)
 		assert.Equal(t, p.Address, "address_1")
 	})


### PR DESCRIPTION
## Description

This PR fixes a mistake in calculating unbonded power. 
It is important to note that the power for an unbonded validator is zero. 
Therefore, when calculating the [powerDelta](https://github.com/pactus-project/pactus/blob/02bff51ade9d7c89a72653f59670e6c3b3c50c77/sandbox/sandbox.go#L264), we should consider the stake, not the power.