### PR TITLE
fix(sync): prevent opening sessions indefinitely

### DIFF
--- a/sync/config.go
+++ b/sync/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	Firewall       *firewall.Config `toml:"firewall"`
 
 	// Private configs
-	MaxOpenSessions     int    `toml:"-"`
+	MaxSessions         int    `toml:"-"`
 	LatestBlockInterval uint32 `toml:"-"`
 	BlockPerMessage     uint32 `toml:"-"`
 }
@@ -27,7 +27,7 @@ func DefaultConfig() *Config {
 		NodeNetwork:         true,
 		NodeGossip:          false,
 		BlockPerMessage:     60,
-		MaxOpenSessions:     8,
+		MaxSessions:         8,
 		LatestBlockInterval: 720,
 		Firewall:            firewall.DefaultConfig(),
 	}

--- a/sync/peerset/peer_set.go
+++ b/sync/peerset/peer_set.go
@@ -66,22 +66,11 @@ func (ps *PeerSet) FindSession(sid int) *session.Session {
 	return nil
 }
 
-func (ps *PeerSet) NumberOfOpenSessions() int {
+func (ps *PeerSet) NumberOfSessions() int {
 	ps.lk.Lock()
 	defer ps.lk.Unlock()
 
-	return ps.numberOfOpenSessions()
-}
-
-func (ps *PeerSet) numberOfOpenSessions() int {
-	count := 0
-	for _, ssn := range ps.sessions {
-		if ssn.Status == session.Open {
-			count++
-		}
-	}
-
-	return count
+	return len(ps.sessions)
 }
 
 func (ps *PeerSet) HasOpenSession(pid peer.ID) bool {
@@ -142,7 +131,13 @@ func (ps *PeerSet) HasAnyOpenSession() bool {
 	ps.lk.RLock()
 	defer ps.lk.RUnlock()
 
-	return ps.numberOfOpenSessions() != 0
+	for _, ssn := range ps.sessions {
+		if ssn.Status == session.Open {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (ps *PeerSet) SetExpiredSessionsAsUncompleted() {

--- a/sync/peerset/peer_set_test.go
+++ b/sync/peerset/peer_set_test.go
@@ -162,7 +162,7 @@ func TestOpenSession(t *testing.T) {
 	assert.LessOrEqual(t, ssn.StartedAt, time.Now())
 	assert.True(t, ps.HasOpenSession(pid))
 	assert.False(t, ps.HasOpenSession("peer2"))
-	assert.Equal(t, 1, ps.NumberOfOpenSessions())
+	assert.Equal(t, 1, ps.NumberOfSessions())
 }
 
 func TestFindSession(t *testing.T) {
@@ -180,18 +180,18 @@ func TestFindSession(t *testing.T) {
 	assert.Nil(t, nonExistingSsn)
 }
 
-func TestNumberOfOpenSessions(t *testing.T) {
+func TestNumberOfSessions(t *testing.T) {
 	ps := NewPeerSet(time.Minute)
 
 	// Test when there are no open sessions
-	assert.Equal(t, 0, ps.NumberOfOpenSessions())
+	assert.Equal(t, 0, ps.NumberOfSessions())
 
 	// Test when there are multiple open sessions
 	ps.OpenSession("peer1", 100, 101)
 	ps.OpenSession("peer2", 200, 201)
 	ps.OpenSession("peer3", 300, 301)
 
-	assert.Equal(t, 3, ps.NumberOfOpenSessions())
+	assert.Equal(t, 3, ps.NumberOfSessions())
 }
 
 func TestHasAnyOpenSession(t *testing.T) {
@@ -215,7 +215,7 @@ func TestRemoveAllSessions(t *testing.T) {
 	_ = ps.OpenSession("peer3", 100, 101)
 
 	ps.RemoveAllSessions()
-	assert.Zero(t, ps.NumberOfOpenSessions())
+	assert.Zero(t, ps.NumberOfSessions())
 	assert.False(t, ps.HasAnyOpenSession())
 }
 
@@ -226,7 +226,7 @@ func TestCompletedSession(t *testing.T) {
 	assert.Equal(t, session.Open, ssn.Status)
 
 	ps.SetSessionCompleted(ssn.SessionID)
-	assert.Zero(t, ps.NumberOfOpenSessions())
+	assert.Equal(t, 1, ps.NumberOfSessions())
 	assert.False(t, ps.HasAnyOpenSession())
 	assert.Equal(t, session.Completed, ssn.Status)
 }
@@ -238,7 +238,7 @@ func TestUncompletedSession(t *testing.T) {
 	assert.Equal(t, session.Open, ssn.Status)
 
 	ps.SetSessionUncompleted(ssn.SessionID)
-	assert.Zero(t, ps.NumberOfOpenSessions())
+	assert.Equal(t, 1, ps.NumberOfSessions())
 	assert.False(t, ps.HasAnyOpenSession())
 	assert.Equal(t, session.Uncompleted, ssn.Status)
 }
@@ -251,7 +251,7 @@ func TestExpireSessions(t *testing.T) {
 	time.Sleep(timeout)
 
 	ps.SetExpiredSessionsAsUncompleted()
-	assert.Zero(t, ps.NumberOfOpenSessions())
+	assert.Equal(t, 1, ps.NumberOfSessions())
 	assert.False(t, ps.HasAnyOpenSession())
 	assert.Equal(t, session.Uncompleted, ssn.Status)
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -384,11 +384,7 @@ func (sync *synchronizer) updateBlockchain() {
 func (sync *synchronizer) downloadBlocks(from uint32, onlyNodeNetwork bool) {
 	sync.logger.Debug("downloading blocks", "from", from)
 
-	for i := 0; i < sync.config.MaxOpenSessions; i++ {
-		if sync.peerSet.NumberOfOpenSessions() >= sync.config.MaxOpenSessions {
-			return
-		}
-
+	for i := sync.peerSet.NumberOfSessions(); i < sync.config.MaxSessions; i++ {
 		count := sync.config.LatestBlockInterval
 		sent := sync.sendBlockRequestToRandomPeer(from, count, onlyNodeNetwork)
 		if !sent {
@@ -400,7 +396,7 @@ func (sync *synchronizer) downloadBlocks(from uint32, onlyNodeNetwork bool) {
 }
 
 func (sync *synchronizer) sendBlockRequestToRandomPeer(from, count uint32, onlyNodeNetwork bool) bool {
-	for i := 0; i < sync.config.MaxOpenSessions; i++ {
+	for i := sync.peerSet.NumberOfSessions(); i < sync.config.MaxSessions; i++ {
 		p := sync.peerSet.GetRandomPeer()
 		if p == nil {
 			break
@@ -440,7 +436,7 @@ func (sync *synchronizer) sendBlockRequestToRandomPeer(from, count uint32, onlyN
 		}
 	}
 
-	sync.logger.Debug("not enough peers to download blocks",
+	sync.logger.Debug("unable to open a new session",
 		"stats", sync.peerSet.SessionStats())
 	return false
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -45,7 +45,7 @@ func testConfig() *Config {
 		SessionTimeout:      time.Second * 1,
 		NodeNetwork:         true,
 		BlockPerMessage:     11,
-		MaxOpenSessions:     8,
+		MaxSessions:         8,
 		LatestBlockInterval: 23,
 		Firewall:            firewall.DefaultConfig(),
 	}


### PR DESCRIPTION
## Description

This PR fixes a bug that allows opening an unlimited number of sessions in bootstrap nodes.