### PR TITLE
fix!: upgrading Testnet

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -125,7 +125,7 @@ func DefaultConfigTestnet() *Config {
 	conf.Network.EnableNATService = false
 	conf.Network.EnableUPnP = false
 	conf.Network.EnableRelay = true
-	conf.Network.NetworkName = "pactus-testnet"
+	conf.Network.NetworkName = "pactus-testnet-v2"
 	conf.Network.DefaultPort = 21777
 	conf.GRPC.Enable = true
 	conf.GRPC.Listen = "[::]:50052"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,7 +29,7 @@ func TestSaveTestnetConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, conf.BasicCheck())
-	assert.Equal(t, conf.Network.NetworkName, "pactus-testnet")
+	assert.Equal(t, conf.Network.NetworkName, "pactus-testnet-v2")
 	assert.Equal(t, conf.Network.DefaultPort, 21777)
 }
 

--- a/network/gossip.go
+++ b/network/gossip.go
@@ -24,7 +24,11 @@ type gossipService struct {
 func newGossipService(ctx context.Context, host lp2phost.Host, eventCh chan Event,
 	isBootstrapper bool, log *logger.SubLogger,
 ) *gossipService {
-	opts := []lp2pps.Option{}
+	opts := []lp2pps.Option{
+		lp2pps.WithMessageSignaturePolicy(lp2pps.StrictNoSign),
+		lp2pps.WithNoAuthor(),
+		lp2pps.WithMessageIdFn(MessageIDFunc),
+	}
 
 	if isBootstrapper {
 		// enable Peer eXchange on bootstrappers

--- a/network/utils.go
+++ b/network/utils.go
@@ -6,11 +6,13 @@ import (
 	"net"
 	"time"
 
+	lp2pspb "github.com/libp2p/go-libp2p-pubsub/pb"
 	lp2phost "github.com/libp2p/go-libp2p/core/host"
 	lp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	lp2ppeer "github.com/libp2p/go-libp2p/core/peer"
 	lp2prcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/multiformats/go-multiaddr"
+	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/logger"
 )
@@ -159,4 +161,9 @@ func MakeScalingLimitConfig(minConns, maxConns int) lp2prcmgr.ScalingLimitConfig
 	limit.TransientLimitIncrease.Streams = util.LogScale(minConns)
 
 	return limit
+}
+
+func MessageIDFunc(m *lp2pspb.Message) string {
+	h := hash.CalcHash(m.Data)
+	return string(h[:20])
 }

--- a/network/utils_test.go
+++ b/network/utils_test.go
@@ -3,6 +3,7 @@ package network
 import (
 	"testing"
 
+	lp2pspb "github.com/libp2p/go-libp2p-pubsub/pb"
 	lp2ppeer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
@@ -152,4 +153,11 @@ func TestSubnetsToFilters(t *testing.T) {
 	assert.False(t, f.AddrBlocked(ma1))
 	assert.True(t, f.AddrBlocked(ma2))
 	assert.False(t, f.AddrBlocked(ma3))
+}
+
+func TestMessageIdFunc(t *testing.T) {
+	m := &lp2pspb.Message{Data: []byte("zarb")}
+	id := MessageIDFunc(m)
+
+	assert.Equal(t, "\x12\xb3\x89\x77\xf2\xd6\x7f\x06\xf0\xc0\xcd\x54\xaa\xf7\x32\x4c\xf4\xfe\xe1\x84", id)
 }

--- a/sync/bundle/bundle_test.go
+++ b/sync/bundle/bundle_test.go
@@ -13,22 +13,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewMessage(t *testing.T) {
-	ts := testsuite.NewTestSuite(t)
-
-	pid := ts.RandPeerID()
-	msg := NewBundle(pid, message.NewQueryProposalMessage(100))
-	assert.Zero(t, msg.Flags)
-	assert.Equal(t, msg.Initiator, pid)
-}
-
 func TestInvalidCBOR(t *testing.T) {
-	d1, _ := hex.DecodeString("000000000000000000")
-	d2, _ := hex.DecodeString("A401000242000003000440")
+	d1, _ := hex.DecodeString("00")
+	d2, _ := hex.DecodeString("A3")
+	d3, _ := hex.DecodeString("A3010002000340")
 	m := new(Bundle)
 	_, err := m.Decode(bytes.NewReader(d1))
 	assert.Error(t, err)
 	_, err = m.Decode(bytes.NewReader(d2))
+	assert.Error(t, err)
+	_, err = m.Decode(bytes.NewReader(d3))
 	assert.Error(t, err)
 }
 
@@ -43,7 +37,7 @@ func TestMessageCompress(t *testing.T) {
 	}
 	msg := message.NewBlocksResponseMessage(message.ResponseCodeOK, message.ResponseCodeOK.String(),
 		1234, 888, blocksData, nil)
-	bdl := NewBundle(ts.RandPeerID(), msg)
+	bdl := NewBundle(msg)
 	bs0, err := bdl.Encode()
 	assert.NoError(t, err)
 	bdl.CompressIt()
@@ -68,7 +62,7 @@ func TestDecodeVoteMessage(t *testing.T) {
 
 	v, _ := ts.GenerateTestPrecommitVote(88, 0)
 	msg := message.NewVoteMessage(v)
-	bdl := NewBundle(ts.RandPeerID(), msg)
+	bdl := NewBundle(msg)
 	bs0, err := bdl.Encode()
 	assert.NoError(t, err)
 	bdl.CompressIt()
@@ -81,12 +75,18 @@ func TestDecodeVoteMessage(t *testing.T) {
 
 func TestDecodeVoteCBOR(t *testing.T) {
 	d1, _ := hex.DecodeString(
-		"a401000258221220aa8ece876ceabec6bd64430d0ad8d7bd5dbd72500f0a1642a13bd71b5b3522a90307045879a101a70101" +
+		"a3" +
+			"0100" + // flags: 0
+			"0207" + // Type (vote)
+			"035879a101a70101" +
 			"02186403010458200264572d4d6bfcd2140d4f885fd5a32fe42fdbf40551e4ff89f3d235e32b4b92055501c0067d277f2dff" +
 			"99943016d6a0f379cf09846c6f06f60758308ab7aecbe03c4ed5b688bcb7e848baffa62bcbf1a4021522c56693f0a7bbcc1f" +
 			"e865277556ee59c1f63ba592acfe1b43")
 	d2, _ := hex.DecodeString(
-		"a4011901000258221220aa8ece876ceabec6bd64430d0ad8d7bd5dbd72500f0a1642a13bd71b5b3522a903070458951f8b08" +
+		"a3" +
+			"01190100" + // flags: 0x0100 (compressed)
+			"0207" + // Type (vote)
+			"0358951f8b08" +
 			"000000000000ff00790086ffa101a7010102186403010458200264572d4d6bfcd2140d4f885fd5a32fe42fdbf40551e4ff89" +
 			"f3d235e32b4b92055501c0067d277f2dff99943016d6a0f379cf09846c6f06f60758308ab7aecbe03c4ed5b688bcb7e848ba" +
 			"ffa62bcbf1a4021522c56693f0a7bbcc1fe865277556ee59c1f63ba592acfe1b43010000ffff798ce7ec79000000")
@@ -100,4 +100,5 @@ func TestDecodeVoteCBOR(t *testing.T) {
 	assert.NoError(t, bdl2.BasicCheck())
 
 	assert.Equal(t, bdl1.Message, bdl2.Message)
+	assert.Contains(t, bdl1.String(), "vote")
 }

--- a/sync/firewall/firewall_test.go
+++ b/sync/firewall/firewall_test.go
@@ -69,7 +69,7 @@ func TestInvalidBundlesCounter(t *testing.T) {
 	assert.Nil(t, td.firewall.OpenGossipBundle([]byte("bad"), td.unknownPeerID))
 	assert.Nil(t, td.firewall.OpenGossipBundle(nil, td.unknownPeerID))
 
-	bdl := bundle.NewBundle(td.unknownPeerID, message.NewQueryVotesMessage(0, -1))
+	bdl := bundle.NewBundle(message.NewQueryVotesMessage(0, -1))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	d, _ := bdl.Encode()
 	assert.Nil(t, td.firewall.OpenGossipBundle(d, td.unknownPeerID))
@@ -82,7 +82,7 @@ func TestGossipMessage(t *testing.T) {
 	t.Run("Message  from: unknown => should NOT close the connection", func(t *testing.T) {
 		td := setup(t)
 
-		bdl := bundle.NewBundle(td.unknownPeerID, message.NewQueryVotesMessage(100, 1))
+		bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 		d, _ := bdl.Encode()
 
@@ -94,7 +94,7 @@ func TestGossipMessage(t *testing.T) {
 	t.Run("Message  from: bad => should close the connection", func(t *testing.T) {
 		td := setup(t)
 
-		bdl := bundle.NewBundle(td.badPeerID, message.NewQueryVotesMessage(100, 1))
+		bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 		d, _ := bdl.Encode()
 
@@ -112,7 +112,7 @@ func TestGossipMessage(t *testing.T) {
 	t.Run("Ok => should NOT close the connection", func(t *testing.T) {
 		td := setup(t)
 
-		bdl := bundle.NewBundle(td.goodPeerID, message.NewQueryVotesMessage(100, 1))
+		bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 		d, _ := bdl.Encode()
 
@@ -134,7 +134,7 @@ func TestStreamMessage(t *testing.T) {
 	t.Run("Message from: bad => should close the connection", func(t *testing.T) {
 		td := setup(t)
 
-		bdl := bundle.NewBundle(td.badPeerID, message.NewBlocksRequestMessage(td.RandInt(100), 1, 100))
+		bdl := bundle.NewBundle(message.NewBlocksRequestMessage(td.RandInt(100), 1, 100))
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 		d, _ := bdl.Encode()
 
@@ -146,7 +146,7 @@ func TestStreamMessage(t *testing.T) {
 	t.Run("Ok => should NOT close the connection", func(t *testing.T) {
 		td := setup(t)
 
-		bdl := bundle.NewBundle(td.goodPeerID, message.NewBlocksRequestMessage(td.RandInt(100), 1, 100))
+		bdl := bundle.NewBundle(message.NewBlocksRequestMessage(td.RandInt(100), 1, 100))
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 		d, _ := bdl.Encode()
 
@@ -159,7 +159,7 @@ func TestStreamMessage(t *testing.T) {
 func TestDisabledFirewall(t *testing.T) {
 	td := setup(t)
 
-	bdl := bundle.NewBundle(td.goodPeerID, message.NewQueryVotesMessage(0, -1))
+	bdl := bundle.NewBundle(message.NewQueryVotesMessage(0, -1))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	d, _ := bdl.Encode()
 
@@ -171,7 +171,7 @@ func TestDisabledFirewall(t *testing.T) {
 func TestUpdateLastReceived(t *testing.T) {
 	td := setup(t)
 
-	bdl := bundle.NewBundle(td.goodPeerID, message.NewQueryVotesMessage(100, 1))
+	bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	d, _ := bdl.Encode()
 	now := time.Now().UnixNano()
@@ -185,7 +185,7 @@ func TestNetworkFlags(t *testing.T) {
 	td := setup(t)
 
 	// TODO: add tests for Mainnet and Testnet flags
-	bdl := bundle.NewBundle(td.goodPeerID, message.NewQueryVotesMessage(100, 1))
+	bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	assert.NoError(t, td.firewall.checkBundle(bdl))
 

--- a/sync/handler_block_announce.go
+++ b/sync/handler_block_announce.go
@@ -36,7 +36,7 @@ func (handler *blockAnnounceHandler) ParseMessage(m message.Message, pid peer.ID
 }
 
 func (handler *blockAnnounceHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	bdl := bundle.NewBundle(handler.SelfID(), m)
+	bdl := bundle.NewBundle(m)
 
 	return bdl
 }

--- a/sync/handler_blocks_request.go
+++ b/sync/handler_blocks_request.go
@@ -99,7 +99,7 @@ func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID
 }
 
 func (handler *blocksRequestHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	return bundle.NewBundle(handler.SelfID(), m)
+	return bundle.NewBundle(m)
 }
 
 func (handler *blocksRequestHandler) respond(msg *message.BlocksResponseMessage, to peer.ID) error {

--- a/sync/handler_blocks_response.go
+++ b/sync/handler_blocks_response.go
@@ -48,7 +48,7 @@ func (handler *blocksResponseHandler) ParseMessage(m message.Message, pid peer.I
 }
 
 func (handler *blocksResponseHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	bdl := bundle.NewBundle(handler.SelfID(), m)
+	bdl := bundle.NewBundle(m)
 	bdl.CompressIt()
 
 	return bdl

--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -72,7 +72,7 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error 
 }
 
 func (handler *helloHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	bdl := bundle.NewBundle(handler.SelfID(), m)
+	bdl := bundle.NewBundle(m)
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagHandshaking)
 	return bdl
 }

--- a/sync/handler_hello_ack.go
+++ b/sync/handler_hello_ack.go
@@ -41,7 +41,7 @@ func (handler *helloAckHandler) ParseMessage(m message.Message, pid peer.ID) err
 }
 
 func (handler *helloAckHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	bdl := bundle.NewBundle(handler.SelfID(), m)
+	bdl := bundle.NewBundle(m)
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagHandshaking)
 	return bdl
 }

--- a/sync/handler_hello_test.go
+++ b/sync/handler_hello_test.go
@@ -19,17 +19,16 @@ func TestParsingHelloMessages(t *testing.T) {
 
 	td.state.CommitTestBlocks(21)
 
-	t.Run("Receiving Hello message from a peer. Peer ID is not same as initiator.",
+	t.Run("Receiving Hello message from an unknown peer.",
 		func(t *testing.T) {
 			valKey := td.RandValKey()
 			pid := td.RandPeerID()
-			initiator := td.RandPeerID()
-			msg := message.NewHelloMessage(pid, "bad-genesis", 0, 0,
+			msg := message.NewHelloMessage(pid, "unknown-peer", 0, 0,
 				td.state.LastBlockHash(), td.state.Genesis().Hash())
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, initiator))
-			assert.Equal(t, td.sync.peerSet.GetPeer(initiator).Status, peerset.StatusCodeBanned)
+			from := td.RandPeerID()
+			assert.NoError(t, td.receivingNewMessage(td.sync, msg, from))
 			bdl := td.shouldPublishMessageWithThisType(t, td.network, message.TypeHelloAck)
 			assert.Equal(t, bdl.Message.(*message.HelloAckMessage).ResponseCode, message.ResponseCodeRejected)
 		})
@@ -49,7 +48,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			assert.Equal(t, bdl.Message.(*message.HelloAckMessage).ResponseCode, message.ResponseCodeRejected)
 		})
 
-	t.Run("Receiving Hello message from a peer. Difference is greater or equal than -10 seconds.",
+	t.Run("Receiving a Hello message from a peer. The time difference is greater than or equal to -10",
 		func(t *testing.T) {
 			valKey := td.RandValKey()
 			height := td.RandUint32NonZero(td.state.LastBlockHeight())

--- a/sync/handler_proposal.go
+++ b/sync/handler_proposal.go
@@ -26,5 +26,5 @@ func (handler *proposalHandler) ParseMessage(m message.Message, _ peer.ID) error
 }
 
 func (handler *proposalHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	return bundle.NewBundle(handler.SelfID(), m)
+	return bundle.NewBundle(m)
 }

--- a/sync/handler_proposal_test.go
+++ b/sync/handler_proposal_test.go
@@ -14,8 +14,9 @@ func TestParsingProposalMessages(t *testing.T) {
 		consensusHeight := td.state.LastBlockHeight() + 1
 		prop, _ := td.GenerateTestProposal(consensusHeight, 0)
 		msg := message.NewProposalMessage(prop)
+		pid := td.RandPeerID()
 
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, td.RandPeerID()))
+		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 		assert.NotNil(t, td.consMgr.Proposal())
 	})
 }

--- a/sync/handler_query_proposal.go
+++ b/sync/handler_query_proposal.go
@@ -33,7 +33,7 @@ func (handler *queryProposalHandler) ParseMessage(m message.Message, _ peer.ID) 
 }
 
 func (handler *queryProposalHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	bdl := bundle.NewBundle(handler.SelfID(), m)
+	bdl := bundle.NewBundle(m)
 
 	return bdl
 }

--- a/sync/handler_query_votes.go
+++ b/sync/handler_query_votes.go
@@ -33,7 +33,7 @@ func (handler *queryVotesHandler) ParseMessage(m message.Message, _ peer.ID) err
 }
 
 func (handler *queryVotesHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	bdl := bundle.NewBundle(handler.SelfID(), m)
+	bdl := bundle.NewBundle(m)
 
 	return bdl
 }

--- a/sync/handler_transactions.go
+++ b/sync/handler_transactions.go
@@ -32,5 +32,5 @@ func (handler *transactionsHandler) ParseMessage(m message.Message, _ peer.ID) e
 }
 
 func (handler *transactionsHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	return bundle.NewBundle(handler.SelfID(), m)
+	return bundle.NewBundle(m)
 }

--- a/sync/handler_transactions_test.go
+++ b/sync/handler_transactions_test.go
@@ -14,8 +14,9 @@ func TestParsingTransactionsMessages(t *testing.T) {
 	t.Run("Parsing transactions message", func(t *testing.T) {
 		trx1, _ := td.GenerateTestBondTx()
 		msg := message.NewTransactionsMessage([]*tx.Tx{trx1})
+		pid := td.RandPeerID()
 
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, td.RandPeerID()))
+		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		assert.NotNil(t, td.sync.state.PendingTx(trx1.ID()))
 	})

--- a/sync/handler_vote.go
+++ b/sync/handler_vote.go
@@ -26,5 +26,5 @@ func (handler *voteHandler) ParseMessage(m message.Message, _ peer.ID) error {
 }
 
 func (handler *voteHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	return bundle.NewBundle(handler.SelfID(), m)
+	return bundle.NewBundle(m)
 }

--- a/sync/handler_vote_test.go
+++ b/sync/handler_vote_test.go
@@ -13,8 +13,9 @@ func TestParsingVoteMessages(t *testing.T) {
 	t.Run("Parsing vote message", func(t *testing.T) {
 		v, _ := td.GenerateTestPrecommitVote(1, 0)
 		msg := message.NewVoteMessage(v)
+		pid := td.RandPeerID()
 
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, td.RandPeerID()))
+		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 		assert.Equal(t, td.consMgr.PickRandomVote(0).Hash(), v.Hash())
 	})
 }


### PR DESCRIPTION
## Description

This PR upgrades the Testnet by changing the pubsub options. 
Nodes prior to this version will be unable to connect to the network, and the upgrade is mandatory.

BREAKING CHANGE