### PR TITLE
fix(sync): ignore block request if blocks are already inside the cache

### DIFF
--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -146,15 +146,12 @@ func TestStrippedPublicKey(t *testing.T) {
 	}
 }
 
-func shouldPublishBlockRequest(t *testing.T, net *network.MockNetwork,
-	from, count uint32,
-) {
+func shouldPublishBlockRequest(t *testing.T, net *network.MockNetwork, from uint32) {
 	t.Helper()
 
 	bdl := shouldPublishMessageWithThisType(t, net, message.TypeBlocksRequest)
 	msg := bdl.Message.(*message.BlocksRequestMessage)
 	require.Equal(t, from, msg.From)
-	require.Equal(t, count, msg.Count)
 }
 
 func shouldPublishBlockResponse(t *testing.T, net *network.MockNetwork,
@@ -310,32 +307,32 @@ func TestSyncing(t *testing.T) {
 	assert.Equal(t, uint32(23), td.syncAlice.config.LatestBlockInterval)
 
 	shouldNotPublishMessageWithThisType(t, td.networkBob, message.TypeBlocksRequest)
-	shouldPublishBlockRequest(t, td.networkAlice, 1, 23)
+	shouldPublishBlockRequest(t, td.networkAlice, 1)
 	shouldPublishBlockResponse(t, td.networkBob, 1, 11, message.ResponseCodeMoreBlocks)  // 1-11
 	shouldPublishBlockResponse(t, td.networkBob, 12, 11, message.ResponseCodeMoreBlocks) // 12-22
 	shouldPublishBlockResponse(t, td.networkBob, 23, 1, message.ResponseCodeMoreBlocks)  // 23-23
 	shouldPublishBlockResponse(t, td.networkBob, 0, 0, message.ResponseCodeNoMoreBlocks) // NoMoreBlock
 
-	shouldPublishBlockRequest(t, td.networkAlice, 24, 23)
+	shouldPublishBlockRequest(t, td.networkAlice, 24)
 	shouldPublishBlockResponse(t, td.networkBob, 24, 11, message.ResponseCodeMoreBlocks) // 24-34
 	shouldPublishBlockResponse(t, td.networkBob, 35, 11, message.ResponseCodeMoreBlocks) // 35-45
 	shouldPublishBlockResponse(t, td.networkBob, 46, 1, message.ResponseCodeMoreBlocks)  // 46-46
 	shouldPublishBlockResponse(t, td.networkBob, 0, 0, message.ResponseCodeNoMoreBlocks) // NoMoreBlock
 
-	shouldPublishBlockRequest(t, td.networkAlice, 47, 23)
+	shouldPublishBlockRequest(t, td.networkAlice, 47)
 	shouldPublishBlockResponse(t, td.networkBob, 47, 11, message.ResponseCodeMoreBlocks) // 47-57
 	shouldPublishBlockResponse(t, td.networkBob, 58, 11, message.ResponseCodeMoreBlocks) // 58-68
 	shouldPublishBlockResponse(t, td.networkBob, 69, 1, message.ResponseCodeMoreBlocks)  // 69-69
 	shouldPublishBlockResponse(t, td.networkBob, 0, 0, message.ResponseCodeNoMoreBlocks) // NoMoreBlock
 
-	shouldPublishBlockRequest(t, td.networkAlice, 70, 23)
+	shouldPublishBlockRequest(t, td.networkAlice, 70)
 	shouldPublishBlockResponse(t, td.networkBob, 70, 11, message.ResponseCodeMoreBlocks) // 70-80
 	shouldPublishBlockResponse(t, td.networkBob, 81, 11, message.ResponseCodeMoreBlocks) // 81-91
 	shouldPublishBlockResponse(t, td.networkBob, 92, 1, message.ResponseCodeMoreBlocks)  // 92-92
 	shouldPublishBlockResponse(t, td.networkBob, 0, 0, message.ResponseCodeNoMoreBlocks) // NoMoreBlock
 
 	// Last block requests
-	shouldPublishBlockRequest(t, td.networkAlice, 93, 23)                               // 93-116
+	shouldPublishBlockRequest(t, td.networkAlice, 93)                                   // 93-116
 	shouldPublishBlockResponse(t, td.networkBob, 93, 8, message.ResponseCodeMoreBlocks) // 93-100
 	shouldPublishBlockResponse(t, td.networkBob, 100, 0, message.ResponseCodeSynced)    // Synced
 
@@ -377,7 +374,7 @@ func TestSyncingHasBlockInCache(t *testing.T) {
 
 	shouldNotPublishMessageWithThisType(t, td.networkBob, message.TypeBlocksRequest)
 	// blocks 1-2 are inside the cache
-	shouldPublishBlockRequest(t, td.networkAlice, 4, 23)
+	shouldPublishBlockRequest(t, td.networkAlice, 4)
 	shouldPublishBlockResponse(t, td.networkBob, 4, 11, message.ResponseCodeMoreBlocks) // 4-14
 	shouldPublishBlockResponse(t, td.networkBob, 15, 9, message.ResponseCodeMoreBlocks) // 15-23
 	shouldPublishBlockResponse(t, td.networkBob, 23, 0, message.ResponseCodeSynced)     // Synced

--- a/sync/peerset/peer_set_test.go
+++ b/sync/peerset/peer_set_test.go
@@ -151,12 +151,11 @@ func TestOpenSession(t *testing.T) {
 	ps := NewPeerSet(time.Minute)
 
 	pid := peer.ID("peer1")
-	ssn := ps.OpenSession(pid, 100, 101)
+	ssn := ps.OpenSession(pid, 100, 1)
 
 	assert.NotNil(t, ssn)
-	from, to := ssn.Range()
-	assert.Equal(t, uint32(100), from)
-	assert.Equal(t, uint32(101), to)
+	assert.Equal(t, uint32(100), ssn.From)
+	assert.Equal(t, uint32(1), ssn.Count)
 	assert.Equal(t, pid, ssn.PeerID)
 	assert.Equal(t, session.Open, ssn.Status)
 	assert.LessOrEqual(t, ssn.StartedAt, time.Now())

--- a/sync/peerset/session/session.go
+++ b/sync/peerset/session/session.go
@@ -20,21 +20,17 @@ type Session struct {
 	Status    Status
 	PeerID    peer.ID
 	From      uint32
-	To        uint32
+	Count     uint32
 	StartedAt time.Time
 }
 
-func NewSession(id int, peerID peer.ID, from, to uint32) *Session {
+func NewSession(id int, peerID peer.ID, from, count uint32) *Session {
 	return &Session{
 		SessionID: id,
 		Status:    Open,
 		PeerID:    peerID,
 		From:      from,
-		To:        to,
+		Count:     count,
 		StartedAt: util.Now(),
 	}
-}
-
-func (s *Session) Range() (uint32, uint32) {
-	return s.From, s.To
 }


### PR DESCRIPTION
## Description

This PR updates the logic to avoid sending the block request message if the requested blocks are already present in the cache.