### PR TITLE
chore(logeer): change colorful logger time-format

### DIFF
--- a/util/logger/logger.go
+++ b/util/logger/logger.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"time"
 
 	"github.com/pactus-project/pactus/util"
 	"github.com/rs/zerolog"
@@ -116,7 +115,6 @@ func addFields(event *zerolog.Event, keyvals ...interface{}) *zerolog.Event {
 
 func NewSubLogger(name string, obj fmt.Stringer) *SubLogger {
 	inst := getLoggersInst()
-	
 	sl := &SubLogger{
 		logger: zerolog.New(inst.writers()).With().Timestamp().Logger(),
 		name:   name,
@@ -142,7 +140,7 @@ func (l *logger) writers() io.Writer {
 	writers := []io.Writer{}
 	// console writer
 	if l.config.Colorful {
-		writers = append(writers, zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
+		writers = append(writers, zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"})
 	} else {
 		writers = append(writers, os.Stderr)
 	}

--- a/util/logger/logger.go
+++ b/util/logger/logger.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"time"
 
 	"github.com/pactus-project/pactus/util"
 	"github.com/rs/zerolog"
@@ -115,7 +116,7 @@ func addFields(event *zerolog.Event, keyvals ...interface{}) *zerolog.Event {
 
 func NewSubLogger(name string, obj fmt.Stringer) *SubLogger {
 	inst := getLoggersInst()
-
+	
 	sl := &SubLogger{
 		logger: zerolog.New(inst.writers()).With().Timestamp().Logger(),
 		name:   name,
@@ -141,7 +142,7 @@ func (l *logger) writers() io.Writer {
 	writers := []io.Writer{}
 	// console writer
 	if l.config.Colorful {
-		writers = append(writers, zerolog.ConsoleWriter{Out: os.Stderr})
+		writers = append(writers, zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
 	} else {
 		writers = append(writers, os.Stderr)
 	}


### PR DESCRIPTION
## Description

current log time format:
```sh
2023-11-17T10:40:25Z WRN connection failed _network={2} addr=["/ip4/51.158.118.181/tcp/21777"] err="failed to dial: context canceled"
2023-11-17T10:40:25Z WRN connection failed _network={2} addr=["/ip4/172.104.46.145/tcp/21777"] err="failed to dial: context canceled"
2023-11-17T10:40:25Z INF disconnected from peer _network={0} pid=12D3KooWBGNEH8NqdK1UddSnPV1yRHGLYpaQUcnujC24s7YNWPiq
2023-11-17T10:40:25Z INF disconnected from peer _network={0} pid=12D3KooWCwQZt8UriVXobQHPXPR8m83eceXVoeT6brPNiBHomebc
```
## Related issue(s)

If this Pull Request is related to an issue, mention it here.
- Fixes #808 