### PR TITLE
feat(logger): adding rotate log file after days, compress and maxgae for logger config

### DIFF
--- a/config/example_config.toml
+++ b/config/example_config.toml
@@ -124,6 +124,18 @@
   # Default is `true`.
  ## colorful = true
 
+  # `max_backups` is the maximum number of old log files to retain.
+  # Default is `0`.
+ ## max_backups = 0
+
+  # `rotate_log_after_days` is the maximum number of days to retain old log files.
+  # Default is `1`.
+ ## rotate_log_after_days = 1
+
+  # `compress` determines if the rotated log files should be compressed.
+  # Default is `false`.
+ ## compress = false
+
   # `logger.levels` contains the level of logger per module.
   # Available log levels are:
   #   "trace", "debug", "info", "warn", and "error".

--- a/util/logger/config.go
+++ b/util/logger/config.go
@@ -1,14 +1,20 @@
 package logger
 
 type Config struct {
-	Colorful bool              `toml:"colorful"`
-	Levels   map[string]string `toml:"levels"`
+	Colorful           bool              `toml:"colorful"`
+	MaxBackups         int               `toml:"max_backups"`
+	RotateLogAfterDays int               `toml:"rotate_log_after_days"`
+	Compress           bool              `toml:"compress"`
+	Levels             map[string]string `toml:"levels"`
 }
 
 func DefaultConfig() *Config {
 	conf := &Config{
-		Levels:   make(map[string]string),
-		Colorful: true,
+		Levels:             make(map[string]string),
+		Colorful:           true,
+		MaxBackups:         0,
+		RotateLogAfterDays: 1,
+		Compress:           false,
 	}
 
 	conf.Levels["default"] = "info"

--- a/util/logger/logger.go
+++ b/util/logger/logger.go
@@ -149,8 +149,9 @@ func (l *logger) writers() io.Writer {
 	fw := &lumberjack.Logger{
 		Filename:   LogFilename,
 		MaxSize:    MaxLogSize,
-		MaxBackups: 0,
-		Compress:   true,
+		MaxBackups: l.config.MaxBackups,
+		Compress:   l.config.Compress,
+		MaxAge:     l.config.RotateLogAfterDays,
 	}
 	writers = append(writers, fw)
 


### PR DESCRIPTION
## Description

we have 3 new options for logger config now.
the reason for a lot of compressed backup files was enabling compress by default, not setting max-age and rotate interval for them.
but now, all of them in configurable.

## Related issue(s)

- Fixes #755 