### PR TITLE
chore: updating version.go adding more detail to Agent function

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"runtime"
 )
 
 // These constants follow the semantic versioning 2.0.0 spec (http://semver.org/)


### PR DESCRIPTION
we can't add client type because we are calling Agent() somewhere we don't have access to client type.


- Fixes #823