### PR TITLE
fix(network): subscribing to the Libp2p event bus

### DIFF
--- a/consensus/manager.go
+++ b/consensus/manager.go
@@ -1,8 +1,6 @@
 package consensus
 
 import (
-	"sync"
-
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/bls"
 	"github.com/pactus-project/pactus/state"
@@ -14,8 +12,6 @@ import (
 )
 
 type manager struct {
-	lk sync.RWMutex
-
 	instances []Consensus
 
 	// Caching future votes and proposals due to potential server time misalignments.
@@ -107,9 +103,6 @@ func (mgr *manager) HasActiveInstance() bool {
 
 // MoveToNewHeight moves all consensus instances to a new height.
 func (mgr *manager) MoveToNewHeight() {
-	mgr.lk.Lock()
-	defer mgr.lk.Unlock()
-
 	for _, cons := range mgr.instances {
 		cons.MoveToNewHeight()
 	}
@@ -159,9 +152,6 @@ func (mgr *manager) MoveToNewHeight() {
 
 // AddVote adds a vote to all consensus instances.
 func (mgr *manager) AddVote(v *vote.Vote) {
-	mgr.lk.Lock()
-	defer mgr.lk.Unlock()
-
 	inst := mgr.getBestInstance()
 	curHeight, _ := inst.HeightRound()
 	switch {
@@ -180,9 +170,6 @@ func (mgr *manager) AddVote(v *vote.Vote) {
 
 // SetProposal sets the proposal for all consensus instances.
 func (mgr *manager) SetProposal(p *proposal.Proposal) {
-	mgr.lk.Lock()
-	defer mgr.lk.Unlock()
-
 	inst := mgr.getBestInstance()
 	curHeight, _ := inst.HeightRound()
 	switch {

--- a/network/gater_test.go
+++ b/network/gater_test.go
@@ -71,9 +71,9 @@ func TestMaxConnection(t *testing.T) {
 	pid := ts.RandPeerID()
 
 	net.peerMgr.AddPeer(ts.RandPeerID(),
-		multiaddr.StringCast("/ip4/2.2.2.2/tcp/1234"), lp2pnet.DirInbound, nil)
+		multiaddr.StringCast("/ip4/2.2.2.2/tcp/1234"), lp2pnet.DirInbound)
 	net.peerMgr.AddPeer(ts.RandPeerID(),
-		multiaddr.StringCast("/ip4/3.3.3.3/tcp/1234"), lp2pnet.DirInbound, nil)
+		multiaddr.StringCast("/ip4/3.3.3.3/tcp/1234"), lp2pnet.DirInbound)
 
 	assert.False(t, net.connGater.InterceptPeerDial(pid))
 	assert.False(t, net.connGater.InterceptAddrDial(pid, maPrivate))

--- a/network/interface.go
+++ b/network/interface.go
@@ -76,7 +76,6 @@ func (*StreamMessage) Type() EventType {
 type ConnectEvent struct {
 	PeerID        lp2pcore.PeerID
 	RemoteAddress string
-	SupportStream bool
 }
 
 func (*ConnectEvent) Type() EventType {

--- a/network/network.go
+++ b/network/network.go
@@ -226,10 +226,10 @@ func newNetwork(conf *Config, log *logger.SubLogger, opts []lp2p.Option) (*netwo
 		n.mdns = newMdnsService(ctx, n.host, n.logger)
 	}
 	n.dht = newDHTService(n.ctx, n.host, kadProtocolID, isBootstrapper, conf, n.logger)
-	n.peerMgr = newPeerMgr(ctx, host, n.dht.kademlia, streamProtocolID, conf, n.logger)
+	n.peerMgr = newPeerMgr(ctx, host, n.dht.kademlia, conf, n.logger)
 	n.stream = newStreamService(ctx, n.host, streamProtocolID, n.eventChannel, n.logger)
 	n.gossip = newGossipService(ctx, n.host, n.eventChannel, isBootstrapper, n.logger)
-	n.notifee = newNotifeeService(n.host, n.eventChannel, n.peerMgr, streamProtocolID, isBootstrapper, n.logger)
+	n.notifee = newNotifeeService(ctx, n.host, n.eventChannel, n.peerMgr, streamProtocolID, isBootstrapper, n.logger)
 
 	n.host.Network().Notify(n.notifee)
 	n.connGater.SetPeerManager(n.peerMgr)
@@ -258,6 +258,7 @@ func (n *network) Start() error {
 	n.gossip.Start()
 	n.stream.Start()
 	n.peerMgr.Start()
+	n.notifee.Start()
 
 	n.logger.Info("network started", "addr", n.host.Addrs(), "id", n.host.ID())
 	return nil
@@ -274,6 +275,7 @@ func (n *network) Stop() {
 	n.gossip.Stop()
 	n.stream.Stop()
 	n.peerMgr.Stop()
+	n.notifee.Stop()
 
 	if err := n.host.Close(); err != nil {
 		n.logger.Error("unable to close the network", "error", err)

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -61,7 +61,7 @@ func (s *NotifeeService) Start() {
 
 				case lp2pevent.EvtPeerIdentificationCompleted:
 					s.logger.Debug("identification completed", "pid", e.Peer)
-					s.sendConnectEven(e.Peer)
+					s.sendConnectEvent(e.Peer)
 
 				case lp2pevent.EvtPeerProtocolsUpdated:
 					s.logger.Debug("protocols updated", "pid", e.Peer, "protocols", e.Added)

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -65,7 +65,7 @@ func (s *NotifeeService) Start() {
 
 				case lp2pevent.EvtPeerProtocolsUpdated:
 					s.logger.Debug("protocols updated", "pid", e.Peer, "protocols", e.Added)
-					s.sendConnectEven(e.Peer)
+					s.sendConnectEvent(e.Peer)
 
 				default:
 					s.logger.Debug("unhandled libp2p event", "event", evt)

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -68,7 +68,7 @@ func (s *NotifeeService) Start() {
 					s.sendConnectEven(e.Peer)
 
 				default:
-					s.logger.Info("unhandled libp2p event", "evt", evt)
+					s.logger.Info("unhandled libp2p event", "event", evt)
 				}
 
 			case <-s.ctx.Done():

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -106,7 +106,7 @@ func (s *NotifeeService) ListenClose(_ lp2pnetwork.Network, ma multiaddr.Multiad
 	s.logger.Debug("notifee ListenClose event emitted", "addr", ma.String())
 }
 
-func (s *NotifeeService) sendConnectEven(pid lp2pcore.PeerID) {
+func (s *NotifeeService) sendConnectEvent(pid lp2pcore.PeerID) {
 	protocols, err := s.host.Peerstore().GetProtocols(pid)
 	if err != nil {
 		s.logger.Error("unable to get supported protocols", "pid", pid)

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -68,7 +68,7 @@ func (s *NotifeeService) Start() {
 					s.sendConnectEven(e.Peer)
 
 				default:
-					s.logger.Info("unhandled libp2p event", "event", evt)
+					s.logger.Debug("unhandled libp2p event", "event", evt)
 				}
 
 			case <-s.ctx.Done():

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -1,31 +1,39 @@
 package network
 
 import (
-	"time"
+	"context"
 
 	lp2pcore "github.com/libp2p/go-libp2p/core"
+	lp2pevent "github.com/libp2p/go-libp2p/core/event"
 	lp2phost "github.com/libp2p/go-libp2p/core/host"
 	lp2pnetwork "github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pactus-project/pactus/util/logger"
 	"golang.org/x/exp/slices"
 )
 
 type NotifeeService struct {
+	ctx              context.Context
 	host             lp2phost.Host
+	lp2pEventSub     lp2pevent.Subscription
 	eventChannel     chan<- Event
 	logger           *logger.SubLogger
-	streamProtocolID protocol.ID
+	streamProtocolID lp2pcore.ProtocolID
 	peerMgr          *peerMgr
 	bootstrapper     bool
 }
 
-func newNotifeeService(host lp2phost.Host, eventChannel chan<- Event, peerMgr *peerMgr,
-	protocolID protocol.ID, bootstrapper bool, log *logger.SubLogger,
+func newNotifeeService(ctx context.Context, host lp2phost.Host, eventChannel chan<- Event, peerMgr *peerMgr,
+	protocolID lp2pcore.ProtocolID, bootstrapper bool, log *logger.SubLogger,
 ) *NotifeeService {
+	eventSub, err := host.EventBus().Subscribe(lp2pevent.WildcardSubscription)
+	if err != nil {
+		logger.Error("failed to register for libp2p events")
+	}
 	notifee := &NotifeeService{
+		ctx:              ctx,
 		host:             host,
+		lp2pEventSub:     eventSub,
 		eventChannel:     eventChannel,
 		streamProtocolID: protocolID,
 		bootstrapper:     bootstrapper,
@@ -33,58 +41,84 @@ func newNotifeeService(host lp2phost.Host, eventChannel chan<- Event, peerMgr *p
 		logger:           log,
 	}
 	host.Network().Notify(notifee)
+
 	return notifee
 }
 
-func (n *NotifeeService) Connected(lp2pn lp2pnetwork.Network, conn lp2pnetwork.Conn) {
-	pid := conn.RemotePeer()
-	n.logger.Info("connected to peer", "pid", pid, "direction", conn.Stat().Direction)
-
-	var protocols []lp2pcore.ProtocolID
+func (s *NotifeeService) Start() {
 	go func() {
-		for i := 0; i < 10; i++ {
-			protocols, _ = lp2pn.Peerstore().GetProtocols(pid)
-			if len(protocols) > 0 {
-				break
+		defer s.lp2pEventSub.Close()
+
+		for {
+			select {
+			case evt := <-s.lp2pEventSub.Out():
+				switch e := evt.(type) {
+				case lp2pevent.EvtLocalReachabilityChanged:
+					s.logger.Info("reachability changed", "reachability", e.Reachability)
+
+				case lp2pevent.EvtPeerConnectednessChanged:
+					s.logger.Debug("connectedness changed", "pid", e.Peer, "connectedness", e.Connectedness)
+
+				case lp2pevent.EvtPeerIdentificationCompleted:
+					s.logger.Debug("identification completed", "pid", e.Peer)
+					s.sendConnectEven(e.Peer)
+
+				case lp2pevent.EvtPeerProtocolsUpdated:
+					s.logger.Debug("protocols updated", "pid", e.Peer, "protocols", e.Added)
+					s.sendConnectEven(e.Peer)
+
+				default:
+					s.logger.Info("unhandled libp2p event", "evt", evt)
+				}
+
+			case <-s.ctx.Done():
+				return
 			}
-
-			// TODO: better way?
-			// Wait to complete libp2p identify
-			time.Sleep(1 * time.Second)
-		}
-
-		if len(protocols) == 0 {
-			n.logger.Info("unable to get supported protocols", "pid", pid)
-		} else {
-			n.logger.Debug("get supported protocols", "pid", pid, "protocols", protocols)
-		}
-
-		n.peerMgr.AddPeer(pid, conn.RemoteMultiaddr(), conn.Stat().Direction, protocols)
-
-		supportStream := slices.Contains(protocols, n.streamProtocolID)
-		n.eventChannel <- &ConnectEvent{
-			PeerID:        pid,
-			RemoteAddress: conn.RemoteMultiaddr().String(),
-			SupportStream: supportStream,
 		}
 	}()
 }
 
-func (n *NotifeeService) Disconnected(_ lp2pnetwork.Network, conn lp2pnetwork.Conn) {
-	pid := conn.RemotePeer()
-	n.logger.Info("disconnected from peer", "pid", pid)
-	n.eventChannel <- &DisconnectEvent{PeerID: pid}
-
-	n.peerMgr.RemovePeer(pid)
+func (s *NotifeeService) Stop() {
 }
 
-func (n *NotifeeService) Listen(_ lp2pnetwork.Network, ma multiaddr.Multiaddr) {
+func (s *NotifeeService) Connected(_ lp2pnetwork.Network, conn lp2pnetwork.Conn) {
+	pid := conn.RemotePeer()
+	s.logger.Info("connected to peer", "pid", pid, "direction", conn.Stat().Direction)
+	s.peerMgr.AddPeer(pid, conn.RemoteMultiaddr(), conn.Stat().Direction)
+}
+
+func (s *NotifeeService) Disconnected(_ lp2pnetwork.Network, conn lp2pnetwork.Conn) {
+	pid := conn.RemotePeer()
+	s.logger.Info("disconnected from peer", "pid", pid)
+	s.eventChannel <- &DisconnectEvent{PeerID: pid}
+
+	s.peerMgr.RemovePeer(pid)
+}
+
+func (s *NotifeeService) Listen(_ lp2pnetwork.Network, ma multiaddr.Multiaddr) {
 	// Handle listen event if needed.
-	n.logger.Debug("notifee Listen event emitted", "addr", ma.String())
+	s.logger.Debug("notifee Listen event emitted", "addr", ma.String())
 }
 
 // ListenClose is called when your node stops listening on an address.
-func (n *NotifeeService) ListenClose(_ lp2pnetwork.Network, ma multiaddr.Multiaddr) {
+func (s *NotifeeService) ListenClose(_ lp2pnetwork.Network, ma multiaddr.Multiaddr) {
 	// Handle listen close event if needed.
-	n.logger.Debug("notifee ListenClose event emitted", "addr", ma.String())
+	s.logger.Debug("notifee ListenClose event emitted", "addr", ma.String())
+}
+
+func (s *NotifeeService) sendConnectEven(pid lp2pcore.PeerID) {
+	protocols, err := s.host.Peerstore().GetProtocols(pid)
+	if err != nil {
+		s.logger.Error("unable to get supported protocols", "pid", pid)
+	}
+	supportStream := slices.Contains(protocols, s.streamProtocolID)
+	if supportStream {
+		addr := s.peerMgr.GetMultiAddr(pid)
+		if supportStream && addr != nil {
+			s.eventChannel <- &ConnectEvent{
+				PeerID:        pid,
+				RemoteAddress: addr.String(),
+			}
+		}
+	}
 }

--- a/network/peermgr_test.go
+++ b/network/peermgr_test.go
@@ -1,0 +1,26 @@
+package network
+
+import (
+	"testing"
+
+	lp2pnet "github.com/libp2p/go-libp2p/core/network"
+	"github.com/pactus-project/pactus/util/testsuite"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMultiAddr(t *testing.T) {
+	ts := testsuite.NewTestSuite(t)
+
+	conf := testConfig()
+	net := makeTestNetwork(t, conf, nil)
+
+	pid := ts.RandPeerID()
+	addr, _ := IPToMultiAddr("1.2.3.4", 1234)
+	assert.Nil(t, net.peerMgr.GetMultiAddr(pid))
+
+	net.peerMgr.AddPeer(pid, addr, lp2pnet.DirOutbound)
+	assert.Equal(t, addr, net.peerMgr.GetMultiAddr(pid))
+
+	net.peerMgr.RemovePeer(pid)
+	assert.Nil(t, net.peerMgr.GetMultiAddr(pid))
+}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -280,11 +280,9 @@ func (sync *synchronizer) processConnectEvent(ce *network.ConnectEvent) {
 	sync.peerSet.UpdateStatus(ce.PeerID, peerset.StatusCodeConnected)
 	sync.peerSet.UpdateAddress(ce.PeerID, ce.RemoteAddress)
 
-	if ce.SupportStream {
-		if err := sync.sayHello(ce.PeerID); err != nil {
-			sync.logger.Warn("sending Hello message failed",
-				"to", ce.PeerID, "error", err)
-		}
+	if err := sync.sayHello(ce.PeerID); err != nil {
+		sync.logger.Warn("sending Hello message failed",
+			"to", ce.PeerID, "error", err)
 	}
 }
 


### PR DESCRIPTION
## Description

Subscribing to the EventBus of LibP2P helped us figure out when we have a healthy direct connection with a peer. This enables us to send the `connect` event more effectively and initiate handshaking with a peer.