### PR TITLE
fix(sync): ignore publishing a block if it is received before

### DIFF
--- a/network/gossip.go
+++ b/network/gossip.go
@@ -53,7 +53,11 @@ func newGossipService(ctx context.Context, host lp2phost.Host, eventCh chan Even
 
 // BroadcastMessage broadcasts a message to the specified topic.
 func (g *gossipService) BroadcastMessage(msg []byte, topic *lp2pps.Topic) error {
-	return topic.Publish(g.ctx, msg)
+	err := topic.Publish(g.ctx, msg)
+	if err != nil {
+		return LibP2PError{Err: err}
+	}
+	return nil
 }
 
 // JoinTopic joins a topic with the given name.

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -10,7 +10,7 @@ import (
 	lp2p "github.com/libp2p/go-libp2p"
 	lp2phost "github.com/libp2p/go-libp2p/core/host"
 	lp2ppeer "github.com/libp2p/go-libp2p/core/peer"
-	ma "github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/logger"
 	"github.com/pactus-project/pactus/util/testsuite"
@@ -32,7 +32,7 @@ func makeTestRelay(t *testing.T) lp2phost.Host {
 		lp2p.DisableRelay(),
 		lp2p.EnableRelayService(),
 		lp2p.ForceReachabilityPublic(),
-		lp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {
+		lp2p.AddrsFactory(func(addrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 			return addrs
 		}),
 	)
@@ -59,7 +59,6 @@ func makeTestNetwork(t *testing.T, conf *Config, opts []lp2p.Option) *network {
 		fmt.Sprintf("%s - %s: ", net.SelfID().ShortString(), t.Name()), net))
 
 	assert.NoError(t, net.Start())
-	assert.NoError(t, net.JoinGeneralTopic(alwaysPropagate))
 
 	return net
 }
@@ -231,6 +230,12 @@ func TestNetwork(t *testing.T) {
 		lp2p.ForceReachabilityPrivate(),
 	})
 
+	assert.NoError(t, networkB.JoinGeneralTopic(alwaysPropagate))
+	assert.NoError(t, networkP.JoinGeneralTopic(alwaysPropagate))
+	assert.NoError(t, networkM.JoinGeneralTopic(alwaysPropagate))
+	assert.NoError(t, networkN.JoinGeneralTopic(alwaysPropagate))
+	assert.NoError(t, networkX.JoinGeneralTopic(alwaysPropagate))
+
 	assert.NoError(t, networkB.JoinConsensusTopic(alwaysPropagate))
 	assert.NoError(t, networkP.JoinConsensusTopic(alwaysPropagate))
 	assert.NoError(t, networkM.JoinConsensusTopic(alwaysPropagate))
@@ -248,7 +253,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("Gossip: all nodes receive general gossip messages", func(t *testing.T) {
-		msg := []byte("test-general-topic")
+		msg := ts.RandBytes(64)
 
 		require.NoError(t, networkP.Broadcast(msg, TopicIDGeneral))
 
@@ -264,7 +269,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("only nodes subscribed to the consensus topic receive consensus gossip messages", func(t *testing.T) {
-		msg := []byte("test-consensus-topic")
+		msg := ts.RandBytes(64)
 
 		require.NoError(t, networkP.Broadcast(msg, TopicIDConsensus))
 
@@ -281,7 +286,7 @@ func TestNetwork(t *testing.T) {
 	t.Run("node P (public) is directly accessible by nodes M and N (private behind NAT)", func(t *testing.T) {
 		require.NoError(t, networkM.host.Connect(networkM.ctx, *publicAddrInfo))
 
-		msgM := []byte("test-stream-from-m")
+		msgM := ts.RandBytes(64)
 		require.NoError(t, networkM.SendTo(msgM, networkP.SelfID()))
 		eP := shouldReceiveEvent(t, networkP, EventTypeStream).(*StreamMessage)
 		assert.Equal(t, eP.From, networkM.SelfID())
@@ -291,7 +296,7 @@ func TestNetwork(t *testing.T) {
 	t.Run("node P (public) is directly accessible by node X (private behind NAT, without relay)", func(t *testing.T) {
 		require.NoError(t, networkX.host.Connect(networkX.ctx, *publicAddrInfo))
 
-		msgX := []byte("test-stream-from-x")
+		msgX := ts.RandBytes(64)
 		require.NoError(t, networkX.SendTo(msgX, networkP.SelfID()))
 		eP := shouldReceiveEvent(t, networkP, EventTypeStream).(*StreamMessage)
 		assert.Equal(t, eP.From, networkX.SelfID())
@@ -299,12 +304,27 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("node P (public) is directly accessible by node B (bootstrap)", func(t *testing.T) {
-		msgB := []byte("test-stream-from-b")
+		msgB := ts.RandBytes(64)
 
 		require.NoError(t, networkB.SendTo(msgB, networkP.SelfID()))
 		eB := shouldReceiveEvent(t, networkP, EventTypeStream).(*StreamMessage)
 		assert.Equal(t, eB.From, networkB.SelfID())
 		assert.Equal(t, readData(t, eB.Reader, len(msgB)), msgB)
+	})
+
+	t.Run("Ignore broadcasting identical messages", func(t *testing.T) {
+		msg := ts.RandBytes(64)
+
+		require.NoError(t, networkM.Broadcast(msg, TopicIDGeneral))
+		require.NoError(t, networkN.Broadcast(msg, TopicIDGeneral))
+
+		eX := shouldReceiveEvent(t, networkX, EventTypeGossip).(*GossipMessage)
+
+		assert.Equal(t, eX.Data, msg)
+		assert.NotEqual(t, eX.From, networkM.SelfID(), "network X has no direct connection with M")
+		assert.NotEqual(t, eX.From, networkN.SelfID(), "network X has no direct connection with N")
+
+		shouldNotReceiveEvent(t, networkX)
 	})
 
 	circuitAddrInfoN, _ := lp2ppeer.AddrInfoFromString(
@@ -313,23 +333,22 @@ func TestNetwork(t *testing.T) {
 	t.Run("node X (private, not connected via relay) is not accessible by node M", func(t *testing.T) {
 		require.Error(t, networkX.host.Connect(networkX.ctx, *circuitAddrInfoN))
 
-		msgM := []byte("test-stream-from-m")
+		msgM := ts.RandBytes(64)
 		require.Error(t, networkM.SendTo(msgM, networkX.SelfID()))
 	})
 
-	t.Run("nodes M and N (private, connected via relay) can communicate using the relay node R", func(t *testing.T) {
-		require.NoError(t, networkM.host.Connect(networkM.ctx, *circuitAddrInfoN))
+	// t.Run("nodes M and N (private, connected via relay) can communicate using the relay node R", func(t *testing.T) {
+	// 	require.NoError(t, networkM.host.Connect(networkM.ctx, *circuitAddrInfoN))
 
-		// TODO: How to test this?
-		// msgM := []byte("test-stream-from-m")
-		// require.NoError(t, networkM.SendTo(msgM, networkN.SelfID()))
-		// eM := shouldReceiveEvent(t, networkN, EventTypeStream).(*StreamMessage)
-		// assert.Equal(t, eM.Source, networkM.SelfID())
-		// assert.Equal(t, readData(t, eM.Reader, len(msgM)), msgM)
-	})
+	// 	// TODO: How to test this?
+	// 	msgM :=  ts.RandBytes(64)
+	// 	require.NoError(t, networkM.SendTo(msgM, networkN.SelfID()))
+	// 	eM := shouldReceiveEvent(t, networkN, EventTypeStream).(*StreamMessage)
+	// 	assert.Equal(t, readData(t, eM.Reader, len(msgM)), msgM)
+	// })
 
 	t.Run("closing connection", func(t *testing.T) {
-		msgB := []byte("test-stream-from-b")
+		msgB := ts.RandBytes(64)
 
 		networkP.Stop()
 		networkB.CloseConnection(networkP.SelfID())

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -337,10 +337,10 @@ func TestNetwork(t *testing.T) {
 		require.Error(t, networkM.SendTo(msgM, networkX.SelfID()))
 	})
 
+	// TODO: How to test this?
 	// t.Run("nodes M and N (private, connected via relay) can communicate using the relay node R", func(t *testing.T) {
 	// 	require.NoError(t, networkM.host.Connect(networkM.ctx, *circuitAddrInfoN))
 
-	// 	// TODO: How to test this?
 	// 	msgM :=  ts.RandBytes(64)
 	// 	require.NoError(t, networkM.SendTo(msgM, networkN.SelfID()))
 	// 	eM := shouldReceiveEvent(t, networkN, EventTypeStream).(*StreamMessage)

--- a/sync/handler_blocks_request.go
+++ b/sync/handler_blocks_request.go
@@ -28,8 +28,6 @@ func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID
 		response := message.NewBlocksResponseMessage(message.ResponseCodeRejected,
 			fmt.Sprintf("unknown peer (%s)", pid.String()), msg.SessionID, 0, nil, nil)
 
-		handler.network.CloseConnection(pid)
-
 		return handler.respond(response, pid)
 	}
 

--- a/sync/handler_blocks_response.go
+++ b/sync/handler_blocks_response.go
@@ -22,7 +22,7 @@ func (handler *blocksResponseHandler) ParseMessage(m message.Message, pid peer.I
 	handler.logger.Trace("parsing BlocksResponse message", "msg", msg)
 
 	if msg.IsRequestRejected() {
-		handler.logger.Warn("blocks request is rejected", "pid", pid, "reason", msg.Reason)
+		handler.logger.Warn("blocks request is rejected", "pid", pid, "reason", msg.Reason, "sid", msg.SessionID)
 	} else {
 		// TODO:
 		// It is good to check the latest height before adding blocks to the cache.

--- a/sync/peerset/peer_set.go
+++ b/sync/peerset/peer_set.go
@@ -43,11 +43,11 @@ func NewPeerSet(sessionTimeout time.Duration) *PeerSet {
 	}
 }
 
-func (ps *PeerSet) OpenSession(pid peer.ID, from, to uint32) *session.Session {
+func (ps *PeerSet) OpenSession(pid peer.ID, from, count uint32) *session.Session {
 	ps.lk.Lock()
 	defer ps.lk.Unlock()
 
-	ssn := session.NewSession(ps.nextSessionID, pid, from, to)
+	ssn := session.NewSession(ps.nextSessionID, pid, from, count)
 	ps.sessions[ssn.SessionID] = ssn
 	ps.nextSessionID++
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -169,24 +169,17 @@ func (sync *synchronizer) sendTo(msg message.Message, to peer.ID) error {
 	return nil
 }
 
-func (sync *synchronizer) shouldBroadcast(msg message.Message) bool {
+func (sync *synchronizer) broadcast(msg message.Message) {
 	if msg.Type() == message.TypeBlockAnnounce {
 		m := msg.(*message.BlockAnnounceMessage)
 		if sync.cache.HasBlockInCache(m.Height()) {
 			// We have received the block announcement from other peers before,
 			// so we can simply ignore broadcasting it again.
 			// This helps to reduce the network bandwidth.
-			return false
+			return
 		}
 	}
 
-	return true
-}
-
-func (sync *synchronizer) broadcast(msg message.Message) {
-	if !sync.shouldBroadcast(msg) {
-		return
-	}
 	bdl := sync.prepareBundle(msg)
 	if bdl != nil {
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagBroadcasted)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -294,6 +294,10 @@ func (sync *synchronizer) processStreamMessage(msg *network.StreamMessage) {
 }
 
 func (sync *synchronizer) processConnectEvent(ce *network.ConnectEvent) {
+	peer := sync.peerSet.GetPeer(ce.PeerID)
+	if peer != nil && peer.IsKnownOrTrusty() {
+		return
+	}
 	sync.peerSet.UpdateStatus(ce.PeerID, peerset.StatusCodeConnected)
 	sync.peerSet.UpdateAddress(ce.PeerID, ce.RemoteAddress)
 
@@ -445,7 +449,7 @@ func (sync *synchronizer) sendBlockRequestToRandomPeer(from, count uint32, onlyN
 		}
 
 		sync.logger.Debug("sending download request", "from", from+1, "count", count, "pid", p.PeerID)
-		ssn := sync.peerSet.OpenSession(p.PeerID, from, from+count-1)
+		ssn := sync.peerSet.OpenSession(p.PeerID, from, count)
 		msg := message.NewBlocksRequestMessage(ssn.SessionID, from, count)
 		err := sync.sendTo(msg, p.PeerID)
 		if err != nil {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -287,8 +287,8 @@ func (sync *synchronizer) processStreamMessage(msg *network.StreamMessage) {
 }
 
 func (sync *synchronizer) processConnectEvent(ce *network.ConnectEvent) {
-	peer := sync.peerSet.GetPeer(ce.PeerID)
-	if peer != nil && peer.IsKnownOrTrusty() {
+	p := sync.peerSet.GetPeer(ce.PeerID)
+	if p != nil && p.IsKnownOrTrusty() {
 		return
 	}
 	sync.peerSet.UpdateStatus(ce.PeerID, peerset.StatusCodeConnected)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -335,3 +335,26 @@ func TestDownload(t *testing.T) {
 		td.shouldNotPublishMessageWithThisType(t, td.network, message.TypeBlocksRequest)
 	})
 }
+
+func TestBroadcastBlockAnnounce(t *testing.T) {
+	td := setup(t, nil)
+
+	t.Run("Should announce the block", func(t *testing.T) {
+		blk, cert := td.GenerateTestBlock(td.RandHeight())
+		msg := message.BlockAnnounceMessage{Block: blk, Certificate: cert}
+
+		td.broadcastCh <- &msg
+
+		td.shouldPublishMessageWithThisType(t, td.network, message.TypeBlockAnnounce)
+	})
+
+	t.Run("Should NOT announce the block", func(t *testing.T) {
+		blk, cert := td.GenerateTestBlock(td.RandHeight())
+		msg := message.BlockAnnounceMessage{Block: blk, Certificate: cert}
+
+		td.sync.cache.AddBlock(blk)
+		td.broadcastCh <- &msg
+
+		td.shouldNotPublishMessageWithThisType(t, td.network, message.TypeBlockAnnounce)
+	})
+}


### PR DESCRIPTION
## Description

This PR checks if a new block has been received before; if it has, it won't be published again. 
The purpose of this change is to reduce network bandwidth usage by preventing the unnecessary publication of new blocks by all validators.