### PR TITLE
fix: implement error handling to prevent panic for path

### DIFF
--- a/wallet/addresspath/path.go
+++ b/wallet/addresspath/path.go
@@ -52,18 +52,30 @@ func (p Path) String() string {
 	return builder.String()
 }
 
-func (p Path) Purpose() uint32 {
-	return p[0]
+func (p Path) Purpose() (uint32, error) {
+	if len(p) < 1 {
+		return 0, ErrInvalidPath
+	}
+	return p[0], nil
 }
 
-func (p Path) CoinType() uint32 {
-	return p[len(p)-3]
+func (p Path) CoinType() (uint32, error) {
+	if len(p) < 2 {
+		return 0, ErrInvalidPath
+	}
+	return p[1], nil
 }
 
-func (p Path) AddressType() uint32 {
-	return p[len(p)-2]
+func (p Path) AddressType() (uint32, error) {
+	if len(p) < 3 {
+		return 0, ErrInvalidPath
+	}
+	return p[2], nil
 }
 
-func (p Path) AddressIndex() uint32 {
-	return p[len(p)-1]
+func (p Path) AddressIndex() (uint32, error) {
+	if len(p) < 4 {
+		return 0, ErrInvalidPath
+	}
+	return p[3], nil
 }

--- a/wallet/addresspath/path_test.go
+++ b/wallet/addresspath/path_test.go
@@ -55,8 +55,23 @@ func TestPathHelpers(t *testing.T) {
 	purpose, coinType, addressType, addressIndex := 12381, 21888, 2, 0
 	path := Path{12381, 21888, 2, 0}
 
-	assert.Equal(t, uint32(purpose), path.Purpose())
-	assert.Equal(t, uint32(coinType), path.CoinType())
-	assert.Equal(t, uint32(addressType), path.AddressType())
-	assert.Equal(t, uint32(addressIndex), path.AddressIndex())
+	pathPurpose, _ := path.Purpose()
+	pathCoinType, _ := path.CoinType()
+	pathAddressType, _ := path.AddressType()
+	pathAddressIndex, _ := path.AddressIndex()
+
+	assert.Equal(t, uint32(purpose), pathPurpose)
+	assert.Equal(t, uint32(coinType), pathCoinType)
+	assert.Equal(t, uint32(addressType), pathAddressType)
+	assert.Equal(t, uint32(addressIndex), pathAddressIndex)
+
+	path = Path{}
+	_, err := path.Purpose()
+	assert.EqualError(t, ErrInvalidPath, err.Error())
+	_, err = path.CoinType()
+	assert.EqualError(t, ErrInvalidPath, err.Error())
+	_, err = path.AddressType()
+	assert.EqualError(t, ErrInvalidPath, err.Error())
+	_, err = path.AddressIndex()
+	assert.EqualError(t, ErrInvalidPath, err.Error())
 }

--- a/wallet/vault/vault.go
+++ b/wallet/vault/vault.go
@@ -216,7 +216,11 @@ func (v *Vault) AddressInfos() []AddressInfo {
 		}
 
 		path, _ := addresspath.NewPathFromString(info.Path)
-		addressType := path.AddressType()
+		addressType, err := path.AddressType()
+		if err != nil {
+			continue
+		}
+
 		addrsMap[int(addressType)] = append(addrsMap[int(addressType)], info)
 	}
 
@@ -232,7 +236,10 @@ func (v *Vault) AddressInfos() []AddressInfo {
 			pathA, _ := addresspath.NewPathFromString(a.Path)
 			pathB, _ := addresspath.NewPathFromString(b.Path)
 
-			if pathA.AddressIndex() < pathB.AddressIndex() {
+			pathAAddressIndex, _ := pathA.AddressIndex()
+			pathBAddressIndex, _ := pathB.AddressIndex()
+
+			if pathAAddressIndex < pathBAddressIndex {
 				return -1
 			}
 			return 1
@@ -443,7 +450,12 @@ func (v *Vault) AddressInfo(addr string) *AddressInfo {
 			return nil
 		}
 
-		extendedKey, err := ext.Derive(p.AddressIndex())
+		addressIndex, err := p.AddressIndex()
+		if err != nil {
+			return nil
+		}
+
+		extendedKey, err := ext.Derive(addressIndex)
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
## Description

error handling of path helper methods to prevent panic if `Path` Len not be enough.


