### PR TITLE
fix: removing BasicCheck for hash

### DIFF
--- a/crypto/hash/hash.go
+++ b/crypto/hash/hash.go
@@ -73,11 +73,3 @@ func (h Hash) ShortString() string {
 func (h Hash) IsUndef() bool {
 	return h == UndefHash
 }
-
-func (h Hash) BasicCheck() error {
-	if h.IsUndef() {
-		return fmt.Errorf("hash is zero")
-	}
-
-	return nil
-}

--- a/crypto/hash/hash_test.go
+++ b/crypto/hash/hash_test.go
@@ -30,9 +30,6 @@ func TestHashFromString(t *testing.T) {
 }
 
 func TestHashEmpty(t *testing.T) {
-	h := hash.Hash{}
-	assert.Error(t, h.BasicCheck())
-
 	_, err := hash.FromBytes(nil)
 	assert.Error(t, err)
 
@@ -58,6 +55,5 @@ func TestHashBasicCheck(t *testing.T) {
 	h, err := hash.FromString("0000000000000000000000000000000000000000000000000000000000000000")
 	assert.NoError(t, err)
 	assert.True(t, h.IsUndef())
-	assert.Error(t, h.BasicCheck())
 	assert.Equal(t, hash.UndefHash.Bytes(), h.Bytes())
 }

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -128,14 +128,15 @@ func TestBlockValidation(t *testing.T) {
 	assert.False(t, td.state1.lastInfo.BlockHash().IsUndef())
 
 	//
-	// Version   			(OK)
-	// UnixTime				(TestValidateBlockTime)
-	// PrevBlockHash		(OK)
-	// StateRoot			(OK)
-	// TxsRoot			    (BasicCheck)
-	// PrevCertificate   	(OK)
-	// SortitionSeed		(OK)
-	// ProposerAddress		(OK)
+	// Test Coverage
+	//
+	// Version   			: TestBlockValidation
+	// UnixTime				: TestValidateBlockTime
+	// PrevBlockHash		: TestBlockValidation
+	// StateRoot			: TestBlockValidation
+	// PrevCertificate   	: TestBlockValidation
+	// SortitionSeed		: TestBlockValidation
+	// ProposerAddress		: TestBlockValidation
 	//
 	prevCert := td.state1.lastInfo.Certificate()
 	proposerAddr := td.state2.valKeys[0].Address()

--- a/sync/handler_block_announce_test.go
+++ b/sync/handler_block_announce_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pactus-project/pactus/sync/bundle/message"
+	"github.com/pactus-project/pactus/types/certificate"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,6 +30,19 @@ func TestParsingBlockAnnounceMessages(t *testing.T) {
 
 		assert.Equal(t, td.sync.state.LastBlockHeight(), lastHeight+2)
 	})
+}
+
+func TestInvalidBlockAnnounce(t *testing.T) {
+	td := setup(t, nil)
+
+	pid := td.RandPeerID()
+	height := td.state.LastBlockHeight() + 1
+	blk, _ := td.GenerateTestBlock(height)
+	invCert := certificate.NewCertificate(height, 0, nil, nil, nil)
+	msg := message.NewBlockAnnounceMessage(blk, invCert)
+
+	err := td.receivingNewMessage(td.sync, msg, pid)
+	assert.Error(t, err)
 }
 
 func TestBroadcastingBlockAnnounceMessages(t *testing.T) {

--- a/types/block/block_test.go
+++ b/types/block/block_test.go
@@ -119,40 +119,6 @@ func TestBasicCheck(t *testing.T) {
 		})
 	})
 
-	t.Run("Invalid state root hash", func(t *testing.T) {
-		d := ts.DecodingHex(
-			"01" + // Version
-				"00000000" + // UnixTime
-				"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" + // PrevBlockHash
-				"0000000000000000000000000000000000000000000000000000000000000000" + // StateRoot
-				"333333333333333333333333333333333333333333333333" + // SortitionSeed
-				"333333333333333333333333333333333333333333333333" +
-				"01AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + // ProposerAddress
-				"04030201" + // PrevCert: Height
-				"0100" + // PrevCert: Round
-				"0401020304" + // PrevCert: Committers
-				"0102" + // PrevCert: Absentees
-				"b53d79e156e9417e010fa21f2b2a96bee6be46fcd233295d" +
-				"2f697cdb9e782b6112ac01c80d0d9d64c2320664c77fa2a6" + // PrevCert: Signature
-				"01" + // Txs: Len
-				"00" + // Tx[0]: Flags
-				"01" + // Tx[0]: Version
-				"01000000" + // Tx[0]: LockTime
-				"01" + // Tx[0]: Fee
-				"00" + // Tx[0]: Memo
-				"01" + // Tx[0]: PayloadType
-				"00" + // Tx[0]: Sender (treasury)
-				"022222222222222222222222222222222222222222" + // Tx[0]: Receiver
-				"01") // Tx[0]: Amount
-
-		b, _ := block.FromBytes(d)
-
-		err := b.BasicCheck()
-		assert.ErrorIs(t, err, block.BasicCheckError{
-			Reason: "invalid state root: hash is zero",
-		})
-	})
-
 	t.Run("Invalid previous block hash", func(t *testing.T) {
 		d := ts.DecodingHex(
 			"01" + // Version

--- a/types/block/header.go
+++ b/types/block/header.go
@@ -75,11 +75,6 @@ func NewHeader(version uint8, tme time.Time, stateRoot, prevBlockHash hash.Hash,
 }
 
 func (h *Header) BasicCheck() error {
-	if err := h.data.StateRoot.BasicCheck(); err != nil {
-		return BasicCheckError{
-			Reason: fmt.Sprintf("invalid state root: %s", err.Error()),
-		}
-	}
 	if !h.data.ProposerAddress.IsValidatorAddress() {
 		return BasicCheckError{
 			Reason: fmt.Sprintf("invalid proposer address: %s",


### PR DESCRIPTION
## Description

This PR removes `BasicCheck` method from the hash.