### PR TITLE
fix(cmd): changing home directory for root users

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -214,13 +214,10 @@ func PrintJSONObject(obj interface{}) {
 func PactusHomeDir() string {
 	home := ""
 	usr, err := user.Current()
-	if err == nil {
-		// Running as root, probably inside docker
-		if usr.HomeDir == "/root" {
-			home = "/pactus/"
-		} else {
-			home = filepath.Join(usr.HomeDir, "pactus")
-		}
+	if err != nil {
+		PrintWarnMsgf("unable to get current user: %v", err)
+	} else {
+		home = filepath.Join(usr.HomeDir, "pactus")
 	}
 	return home
 }


### PR DESCRIPTION
## Description

This PR set working directory to `/root/pactus` instead of `/pactus` for root users (or inside docker)


It is going to fix #842 