### PR TITLE
fix(config): restore default config when it is deleted

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,9 +3,7 @@ package config
 import (
 	"bytes"
 	_ "embed"
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/pactus-project/pactus/consensus"
 	"github.com/pactus-project/pactus/crypto"
@@ -151,21 +149,12 @@ func DefaultConfigLocalnet() *Config {
 	return conf
 }
 
-func SaveMainnetConfig(path string, numValidators int) error {
+func SaveMainnetConfig(path string) error {
 	conf := string(exampleConfigBytes)
-	conf = strings.Replace(conf, "%num_validators%",
-		fmt.Sprintf("%v", numValidators), 1)
-
 	return util.WriteFile(path, []byte(conf))
 }
 
-func SaveTestnetConfig(path string) error {
-	conf := DefaultConfigTestnet()
-	return util.WriteFile(path, conf.toTOML())
-}
-
-func SaveLocalnetConfig(path string) error {
-	conf := DefaultConfigLocalnet()
+func (conf *Config) Save(path string) error {
 	return util.WriteFile(path, conf.toTOML())
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestSaveMainnetConfig(t *testing.T) {
 	path := util.TempFilePath()
-	assert.NoError(t, SaveMainnetConfig(path, 7))
+	assert.NoError(t, SaveMainnetConfig(path))
 
 	defConf := DefaultConfigMainnet()
 	conf, err := LoadFromFile(path, true, defConf)
@@ -20,9 +20,10 @@ func TestSaveMainnetConfig(t *testing.T) {
 	assert.NoError(t, conf.BasicCheck())
 }
 
-func TestSaveTestnetConfig(t *testing.T) {
+func TestSaveConfig(t *testing.T) {
 	path := util.TempFilePath()
-	assert.NoError(t, SaveTestnetConfig(path))
+	conf := defaultConfig()
+	assert.NoError(t, conf.Save(path))
 
 	defConf := DefaultConfigTestnet()
 	conf, err := LoadFromFile(path, true, defConf)
@@ -33,13 +34,8 @@ func TestSaveTestnetConfig(t *testing.T) {
 	assert.Equal(t, conf.Network.DefaultPort, 21777)
 }
 
-func TestSaveLocalnetConfig(t *testing.T) {
-	path := util.TempFilePath()
-	assert.NoError(t, SaveLocalnetConfig(path))
-
-	defConf := DefaultConfigLocalnet()
-	conf, err := LoadFromFile(path, true, defConf)
-	assert.NoError(t, err)
+func TestLocalnetConfig(t *testing.T) {
+	conf := DefaultConfigLocalnet()
 
 	assert.NoError(t, conf.BasicCheck())
 	assert.Empty(t, conf.Network.ListenAddrStrings)


### PR DESCRIPTION
## Description

If a user deletes the configuration file, the node will automatically generate a new configuration file with default values when it is run again.

Fixing #478 