### PR TITLE
chore: bumping version to 0.18.3

### DIFF
--- a/docs/patching.md
+++ b/docs/patching.md
@@ -34,9 +34,9 @@ git push
 Let's create environment variables for the patch version. For the rest of this document, we will use these environment variables in the commands.
 
 ```bash
-PRV_VER="0.18.1"
-CUR_VER="0.18.2"
-NEXT_VER="0.18.3"
+PRV_VER="0.18.2"
+CUR_VER="0.18.3"
+NEXT_VER="0.18.4"
 TAG_NAME="v${CUR_VER}"
 TAG_MSG="Version ${CUR_VER}"
 BASE_BRANCH="0.18.x"

--- a/version/version.go
+++ b/version/version.go
@@ -11,8 +11,8 @@ import (
 const (
 	major           uint   = 0
 	minor           uint   = 18
-	patch           uint   = 2
-	meta            string = ""
+	patch           uint   = 3
+	meta            string = "beta"
 	protocolVersion uint   = 1
 )
 


### PR DESCRIPTION
Bumping version to 0.18.3