### PR TITLE
fix: adding querier to query messages

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -364,7 +364,7 @@ func (cs *consensus) signAddVote(v *vote.Vote) {
 
 func (cs *consensus) queryProposal() {
 	cs.broadcaster(cs.valKey.Address(),
-		message.NewQueryProposalMessage(cs.height))
+		message.NewQueryProposalMessage(cs.height, cs.valKey.Address()))
 }
 
 // queryVotes is an anti-entropy mechanism to retrieve missed votes
@@ -372,7 +372,7 @@ func (cs *consensus) queryProposal() {
 // However, invoking this method might result in unnecessary bandwidth usage.
 func (cs *consensus) queryVotes() {
 	cs.broadcaster(cs.valKey.Address(),
-		message.NewQueryVotesMessage(cs.height, cs.round))
+		message.NewQueryVotesMessage(cs.height, cs.round, cs.valKey.Address()))
 }
 
 func (cs *consensus) broadcastProposal(p *proposal.Proposal) {

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -194,12 +194,15 @@ func (td *testData) shouldPublishQueryProposal(t *testing.T, cons *consensus, he
 	t.Helper()
 
 	for _, consMsg := range td.consMessages {
-		if consMsg.sender == cons.valKey.Address() &&
-			consMsg.message.Type() == message.TypeQueryProposal {
-			m := consMsg.message.(*message.QueryProposalMessage)
-			assert.Equal(t, m.Height, height)
-			return
+		if consMsg.sender != cons.valKey.Address() ||
+			consMsg.message.Type() != message.TypeQueryProposal {
+			continue
 		}
+
+		m := consMsg.message.(*message.QueryProposalMessage)
+		assert.Equal(t, m.Height, height)
+		assert.Equal(t, m.Querier, cons.valKey.Address())
+		return
 	}
 	require.NoError(t, fmt.Errorf("Not found"))
 }
@@ -208,13 +211,16 @@ func (td *testData) shouldPublishQueryVote(t *testing.T, cons *consensus, height
 	t.Helper()
 
 	for _, consMsg := range td.consMessages {
-		if consMsg.sender == cons.valKey.Address() &&
-			consMsg.message.Type() == message.TypeQueryVotes {
-			m := consMsg.message.(*message.QueryVotesMessage)
-			assert.Equal(t, m.Height, height)
-			assert.Equal(t, m.Round, round)
-			return
+		if consMsg.sender != cons.valKey.Address() ||
+			consMsg.message.Type() != message.TypeQueryVotes {
+			continue
 		}
+
+		m := consMsg.message.(*message.QueryVotesMessage)
+		assert.Equal(t, m.Height, height)
+		assert.Equal(t, m.Round, round)
+		assert.Equal(t, m.Querier, cons.valKey.Address())
+		return
 	}
 	require.NoError(t, fmt.Errorf("Not found"))
 }

--- a/sync/bundle/message/query_proposal.go
+++ b/sync/bundle/message/query_proposal.go
@@ -2,15 +2,19 @@ package message
 
 import (
 	"fmt"
+
+	"github.com/pactus-project/pactus/crypto"
 )
 
 type QueryProposalMessage struct {
-	Height uint32 `cbor:"1,keyasint"`
+	Height  uint32         `cbor:"1,keyasint"`
+	Querier crypto.Address `cbor:"2,keyasint"`
 }
 
-func NewQueryProposalMessage(h uint32) *QueryProposalMessage {
+func NewQueryProposalMessage(height uint32, querier crypto.Address) *QueryProposalMessage {
 	return &QueryProposalMessage{
-		Height: h,
+		Height:  height,
+		Querier: querier,
 	}
 }
 
@@ -23,5 +27,5 @@ func (m *QueryProposalMessage) Type() Type {
 }
 
 func (m *QueryProposalMessage) String() string {
-	return fmt.Sprintf("{%v}", m.Height)
+	return fmt.Sprintf("{%v %s}", m.Height, m.Querier.ShortString())
 }

--- a/sync/bundle/message/query_proposal_test.go
+++ b/sync/bundle/message/query_proposal_test.go
@@ -3,6 +3,7 @@ package message
 import (
 	"testing"
 
+	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,6 +13,8 @@ func TestQueryProposalType(t *testing.T) {
 }
 
 func TestQueryProposalMessage(t *testing.T) {
-	m := NewQueryProposalMessage(0)
+	ts := testsuite.NewTestSuite(t)
+
+	m := NewQueryProposalMessage(0, ts.RandValAddress())
 	assert.NoError(t, m.BasicCheck())
 }

--- a/sync/bundle/message/query_votes.go
+++ b/sync/bundle/message/query_votes.go
@@ -3,18 +3,21 @@ package message
 import (
 	"fmt"
 
+	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/util/errors"
 )
 
 type QueryVotesMessage struct {
-	Height uint32 `cbor:"1,keyasint"`
-	Round  int16  `cbor:"2,keyasint"`
+	Height  uint32         `cbor:"1,keyasint"`
+	Round   int16          `cbor:"2,keyasint"`
+	Querier crypto.Address `cbor:"3,keyasint"`
 }
 
-func NewQueryVotesMessage(h uint32, r int16) *QueryVotesMessage {
+func NewQueryVotesMessage(height uint32, round int16, querier crypto.Address) *QueryVotesMessage {
 	return &QueryVotesMessage{
-		Height: h,
-		Round:  r,
+		Height:  height,
+		Round:   round,
+		Querier: querier,
 	}
 }
 
@@ -30,5 +33,5 @@ func (m *QueryVotesMessage) Type() Type {
 }
 
 func (m *QueryVotesMessage) String() string {
-	return fmt.Sprintf("{%d/%d}", m.Height, m.Round)
+	return fmt.Sprintf("{%d/%d %s}", m.Height, m.Round, m.Querier.ShortString())
 }

--- a/sync/bundle/message/query_votes_test.go
+++ b/sync/bundle/message/query_votes_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pactus-project/pactus/util/errors"
+	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,14 +14,16 @@ func TestQueryVotesType(t *testing.T) {
 }
 
 func TestQueryVotesMessage(t *testing.T) {
+	ts := testsuite.NewTestSuite(t)
+
 	t.Run("Invalid round", func(t *testing.T) {
-		m := NewQueryVotesMessage(0, -1)
+		m := NewQueryVotesMessage(0, -1, ts.RandValAddress())
 
 		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidRound)
 	})
 
 	t.Run("OK", func(t *testing.T) {
-		m := NewQueryVotesMessage(100, 0)
+		m := NewQueryVotesMessage(100, 0, ts.RandValAddress())
 
 		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), "100")

--- a/sync/firewall/firewall_test.go
+++ b/sync/firewall/firewall_test.go
@@ -69,7 +69,7 @@ func TestInvalidBundlesCounter(t *testing.T) {
 	assert.Nil(t, td.firewall.OpenGossipBundle([]byte("bad"), td.unknownPeerID))
 	assert.Nil(t, td.firewall.OpenGossipBundle(nil, td.unknownPeerID))
 
-	bdl := bundle.NewBundle(message.NewQueryVotesMessage(0, -1))
+	bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), -1, td.RandValAddress()))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	d, _ := bdl.Encode()
 	assert.Nil(t, td.firewall.OpenGossipBundle(d, td.unknownPeerID))
@@ -82,7 +82,7 @@ func TestGossipMessage(t *testing.T) {
 	t.Run("Message  from: unknown => should NOT close the connection", func(t *testing.T) {
 		td := setup(t)
 
-		bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
+		bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 		d, _ := bdl.Encode()
 
@@ -94,7 +94,7 @@ func TestGossipMessage(t *testing.T) {
 	t.Run("Message  from: bad => should close the connection", func(t *testing.T) {
 		td := setup(t)
 
-		bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
+		bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 		d, _ := bdl.Encode()
 
@@ -112,7 +112,7 @@ func TestGossipMessage(t *testing.T) {
 	t.Run("Ok => should NOT close the connection", func(t *testing.T) {
 		td := setup(t)
 
-		bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
+		bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 		bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 		d, _ := bdl.Encode()
 
@@ -159,7 +159,7 @@ func TestStreamMessage(t *testing.T) {
 func TestDisabledFirewall(t *testing.T) {
 	td := setup(t)
 
-	bdl := bundle.NewBundle(message.NewQueryVotesMessage(0, -1))
+	bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), -1, td.RandValAddress()))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	d, _ := bdl.Encode()
 
@@ -171,7 +171,7 @@ func TestDisabledFirewall(t *testing.T) {
 func TestUpdateLastReceived(t *testing.T) {
 	td := setup(t)
 
-	bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
+	bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	d, _ := bdl.Encode()
 	now := time.Now().UnixNano()
@@ -185,7 +185,7 @@ func TestNetworkFlags(t *testing.T) {
 	td := setup(t)
 
 	// TODO: add tests for Mainnet and Testnet flags
-	bdl := bundle.NewBundle(message.NewQueryVotesMessage(100, 1))
+	bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	assert.NoError(t, td.firewall.checkBundle(bdl))
 

--- a/sync/handler_query_proposal_test.go
+++ b/sync/handler_query_proposal_test.go
@@ -16,13 +16,13 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 	td.consMgr.SetProposal(prop)
 
 	t.Run("not the same height", func(t *testing.T) {
-		msg := message.NewQueryProposalMessage(consensusHeight + 1)
+		msg := message.NewQueryProposalMessage(consensusHeight+1, td.RandValAddress())
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
 	})
 	t.Run("should respond to the query proposal message", func(t *testing.T) {
-		msg := message.NewQueryProposalMessage(consensusHeight)
+		msg := message.NewQueryProposalMessage(consensusHeight, td.RandValAddress())
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		bdl := td.shouldPublishMessageWithThisType(t, message.TypeProposal)
@@ -31,7 +31,7 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 
 	t.Run("doesn't have the proposal", func(t *testing.T) {
 		td.consMocks[0].CurProposal = nil
-		msg := message.NewQueryProposalMessage(consensusHeight)
+		msg := message.NewQueryProposalMessage(consensusHeight, td.RandValAddress())
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
@@ -42,7 +42,7 @@ func TestBroadcastingQueryProposalMessages(t *testing.T) {
 	td := setup(t, nil)
 
 	consensusHeight := td.state.LastBlockHeight() + 1
-	msg := message.NewQueryProposalMessage(consensusHeight)
+	msg := message.NewQueryProposalMessage(consensusHeight, td.RandValAddress())
 	td.sync.broadcast(msg)
 
 	td.shouldPublishMessageWithThisType(t, message.TypeQueryProposal)

--- a/sync/handler_query_votes_test.go
+++ b/sync/handler_query_votes_test.go
@@ -14,7 +14,7 @@ func TestParsingQueryVotesMessages(t *testing.T) {
 	v1, _ := td.GenerateTestPrecommitVote(consensusHeight, 0)
 	td.consMgr.AddVote(v1)
 	pid := td.RandPeerID()
-	msg := message.NewQueryVotesMessage(consensusHeight, 1)
+	msg := message.NewQueryVotesMessage(consensusHeight, 1, td.RandValAddress())
 
 	t.Run("should respond to the query votes message", func(t *testing.T) {
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
@@ -24,7 +24,7 @@ func TestParsingQueryVotesMessages(t *testing.T) {
 	})
 
 	t.Run("doesn't have any votes", func(t *testing.T) {
-		msg := message.NewQueryVotesMessage(consensusHeight+1, 1)
+		msg := message.NewQueryVotesMessage(consensusHeight+1, 1, td.RandValAddress())
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeVote)
@@ -35,7 +35,7 @@ func TestBroadcastingQueryVotesMessages(t *testing.T) {
 	td := setup(t, nil)
 
 	consensusHeight := td.state.LastBlockHeight() + 1
-	msg := message.NewQueryVotesMessage(consensusHeight, 1)
+	msg := message.NewQueryVotesMessage(consensusHeight, 1, td.RandValAddress())
 	td.sync.broadcast(msg)
 
 	td.shouldPublishMessageWithThisType(t, message.TypeQueryVotes)

--- a/sync/peerset/service/services_test.go
+++ b/sync/peerset/service/services_test.go
@@ -27,9 +27,13 @@ func TestAppend(t *testing.T) {
 func TestIsNetwork(t *testing.T) {
 	assert.False(t, New(None).IsNetwork())
 	assert.True(t, New(Network).IsNetwork())
+	assert.False(t, New(Gossip).IsNetwork())
+	assert.True(t, New(Gossip, Network).IsNetwork())
 }
 
 func TestIsGossip(t *testing.T) {
 	assert.False(t, New(None).IsGossip())
 	assert.False(t, New(Network).IsGossip())
+	assert.True(t, New(Gossip).IsGossip())
+	assert.True(t, New(Gossip, Network).IsNetwork())
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -291,7 +291,7 @@ func TestTestNetFlags(t *testing.T) {
 	td := setup(t, nil)
 
 	td.addPeerToCommittee(t, td.sync.SelfID(), td.sync.valKeys[0].PublicKey())
-	bdl := td.sync.prepareBundle(message.NewQueryProposalMessage(td.RandHeight()))
+	bdl := td.sync.prepareBundle(message.NewQueryProposalMessage(td.RandHeight(), td.RandValAddress()))
 	require.False(t, util.IsFlagSet(bdl.Flags, bundle.BundleFlagNetworkMainnet), "invalid flag: %v", bdl)
 	require.True(t, util.IsFlagSet(bdl.Flags, bundle.BundleFlagNetworkTestnet), "invalid flag: %v", bdl)
 }


### PR DESCRIPTION
## Description

Add querier to `QueryVote` and `QueryProposal` messages by including the address of the querier. This serves two purposes:

1. Provides which node is querying the vote or proposal.
2. Prevents message ID collisions when multiple nodes query the same vote or proposal, since the querier address are not the same.
