### PR TITLE
fix(network): turn off mesh for gossiper node

### DIFF
--- a/network/config.go
+++ b/network/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	DefaultPort                 int      `toml:"-"`
 	DefaultRelayAddrStrings     []string `toml:"-"`
 	DefaultBootstrapAddrStrings []string `toml:"-"`
+	IsBootstrapper              bool     `toml:"-"`
+	IsGossiper                  bool     `toml:"-"`
 }
 
 func DefaultConfig() *Config {
@@ -43,6 +45,8 @@ func DefaultConfig() *Config {
 		EnableMetrics:        false,
 		ForcePrivateNetwork:  false,
 		DefaultPort:          21888,
+		IsBootstrapper:       false,
+		IsGossiper:           false,
 	}
 }
 
@@ -103,15 +107,14 @@ func (conf *Config) BootstrapAddrInfos() []lp2ppeer.AddrInfo {
 	return addrInfos
 }
 
-func (conf *Config) IsBootstrapper(pid lp2pcore.PeerID) bool {
+func (conf *Config) CheckIsBootstrapper(pid lp2pcore.PeerID) {
 	addrInfos := conf.BootstrapAddrInfos()
 	for _, ai := range addrInfos {
 		if ai.ID == pid {
-			return true
+			conf.IsBootstrapper = true
+			break
 		}
 	}
-
-	return false
 }
 
 func (conf *Config) ScaledMaxConns() int {

--- a/network/config_test.go
+++ b/network/config_test.go
@@ -121,9 +121,14 @@ func TestIsBootstrapper(t *testing.T) {
 	pid2, _ := lp2ppeer.Decode("12D3KooWQBpPV6NtZy1dvN2oF7dJdLoooRZfEmwtHiDUf42ArDjT")
 	pid3, _ := lp2ppeer.Decode("12D3KooWBqutgDboACf1i1c9uN9BQg9xdREoeXYb2rvFHQU1QcAp")
 
-	assert.False(t, conf.IsBootstrapper(pid1))
-	assert.True(t, conf.IsBootstrapper(pid2))
-	assert.True(t, conf.IsBootstrapper(pid3))
+	conf.CheckIsBootstrapper(pid1)
+	assert.False(t, conf.IsBootstrapper)
+
+	conf.CheckIsBootstrapper(pid2)
+	assert.True(t, conf.IsBootstrapper)
+
+	conf.CheckIsBootstrapper(pid3)
+	assert.True(t, conf.IsBootstrapper)
 }
 
 func TestScaledConns(t *testing.T) {

--- a/network/dht.go
+++ b/network/dht.go
@@ -17,10 +17,10 @@ type dhtService struct {
 }
 
 func newDHTService(ctx context.Context, host lp2phost.Host, protocolID lp2pcore.ProtocolID,
-	isBootstrapper bool, conf *Config, log *logger.SubLogger,
+	conf *Config, log *logger.SubLogger,
 ) *dhtService {
 	mode := lp2pdht.ModeAuto
-	if isBootstrapper {
+	if conf.IsBootstrapper || conf.IsGossiper {
 		mode = lp2pdht.ModeServer
 	}
 	opts := []lp2pdht.Option{

--- a/network/network.go
+++ b/network/network.go
@@ -228,18 +228,19 @@ func newNetwork(conf *Config, log *logger.SubLogger, opts []lp2p.Option) (*netwo
 
 	log.SetObj(n)
 
-	isBootstrapper := conf.IsBootstrapper(host.ID())
+	conf.CheckIsBootstrapper(host.ID())
+
 	kadProtocolID := lp2pcore.ProtocolID(fmt.Sprintf("/%s/gossip/v1", conf.NetworkName)) // TODO: better name?
 	streamProtocolID := lp2pcore.ProtocolID(fmt.Sprintf("/%s/stream/v1", conf.NetworkName))
 
 	if conf.EnableMdns {
 		n.mdns = newMdnsService(ctx, n.host, n.logger)
 	}
-	n.dht = newDHTService(n.ctx, n.host, kadProtocolID, isBootstrapper, conf, n.logger)
+	n.dht = newDHTService(n.ctx, n.host, kadProtocolID, conf, n.logger)
 	n.peerMgr = newPeerMgr(ctx, host, conf, n.logger)
 	n.stream = newStreamService(ctx, n.host, streamProtocolID, n.eventChannel, n.logger)
-	n.gossip = newGossipService(ctx, n.host, n.eventChannel, isBootstrapper, n.logger)
-	n.notifee = newNotifeeService(ctx, n.host, n.eventChannel, n.peerMgr, streamProtocolID, isBootstrapper, n.logger)
+	n.gossip = newGossipService(ctx, n.host, n.eventChannel, conf, n.logger)
+	n.notifee = newNotifeeService(ctx, n.host, n.eventChannel, n.peerMgr, streamProtocolID, n.logger)
 
 	n.host.Network().Notify(n.notifee)
 	n.connGater.SetPeerManager(n.peerMgr)
@@ -247,7 +248,8 @@ func newNetwork(conf *Config, log *logger.SubLogger, opts []lp2p.Option) (*netwo
 	n.logger.Info("network setup", "id", n.host.ID(),
 		"name", conf.NetworkName,
 		"address", conf.ListenAddrStrings,
-		"bootstrapper", isBootstrapper)
+		"bootstrapper", conf.IsBootstrapper,
+		"gossiper", conf.IsGossiper)
 
 	return n, nil
 }

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -20,11 +20,10 @@ type NotifeeService struct {
 	logger           *logger.SubLogger
 	streamProtocolID lp2pcore.ProtocolID
 	peerMgr          *peerMgr
-	bootstrapper     bool
 }
 
 func newNotifeeService(ctx context.Context, host lp2phost.Host, eventChannel chan<- Event, peerMgr *peerMgr,
-	protocolID lp2pcore.ProtocolID, bootstrapper bool, log *logger.SubLogger,
+	protocolID lp2pcore.ProtocolID, log *logger.SubLogger,
 ) *NotifeeService {
 	events := []interface{}{
 		new(lp2pevent.EvtLocalReachabilityChanged),
@@ -41,7 +40,6 @@ func newNotifeeService(ctx context.Context, host lp2phost.Host, eventChannel cha
 		lp2pEventSub:     eventSub,
 		eventChannel:     eventChannel,
 		streamProtocolID: protocolID,
-		bootstrapper:     bootstrapper,
 		peerMgr:          peerMgr,
 		logger:           log,
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -48,6 +48,7 @@ func NewNode(genDoc *genesis.Genesis, conf *config.Config,
 		"version", version.Version(),
 		"network", genDoc.ChainType())
 
+	conf.Network.IsGossiper = conf.Sync.NodeGossip
 	net, err := network.NewNetwork(conf.Network)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

This PR turns off the mesh for gossiper nodes, allows it to gossip messages to more peers.