### PR TITLE
feat(network): adding relay service to dial relay nodes

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -13,6 +13,7 @@ import (
 	lp2phost "github.com/libp2p/go-libp2p/core/host"
 	lp2pmetrics "github.com/libp2p/go-libp2p/core/metrics"
 	lp2ppeer "github.com/libp2p/go-libp2p/core/peer"
+	lp2pautorelay "github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	lp2prcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	lp2pconnmgr "github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	"github.com/multiformats/go-multiaddr"
@@ -159,9 +160,14 @@ func newNetwork(conf *Config, log *logger.SubLogger, opts []lp2p.Option) (*netwo
 
 	if conf.EnableRelay {
 		log.Info("relay enabled", "addrInfos", conf.RelayAddrInfos())
+		autoRelayOpt := []lp2pautorelay.Option{
+			lp2pautorelay.WithMinCandidates(2),
+			lp2pautorelay.WithMinInterval(1 * time.Minute),
+		}
+
 		opts = append(opts,
 			lp2p.EnableRelay(),
-			lp2p.EnableAutoRelayWithStaticRelays(conf.RelayAddrInfos()),
+			lp2p.EnableAutoRelayWithStaticRelays(conf.RelayAddrInfos(), autoRelayOpt...),
 			lp2p.EnableHolePunching(),
 		)
 	} else {

--- a/network/network.go
+++ b/network/network.go
@@ -16,6 +16,9 @@ import (
 	lp2pautorelay "github.com/libp2p/go-libp2p/p2p/host/autorelay"
 	lp2prcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	lp2pconnmgr "github.com/libp2p/go-libp2p/p2p/net/connmgr"
+	lp2pnoise "github.com/libp2p/go-libp2p/p2p/security/noise"
+	lp2quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	lp2ptcp "github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/logger"
@@ -142,6 +145,9 @@ func newNetwork(conf *Config, log *logger.SubLogger, opts []lp2p.Option) (*netwo
 		lp2p.ResourceManager(resMgr),
 		lp2p.ConnectionManager(connMgr),
 		lp2p.Ping(false),
+		lp2p.Transport(lp2ptcp.NewTCPTransport),
+		lp2p.Transport(lp2quic.NewTransport),
+		lp2p.Security(lp2pnoise.ID, lp2pnoise.New),
 	)
 
 	if conf.EnableNATService {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -157,9 +157,9 @@ func TestNetwork(t *testing.T) {
 
 	relayAddrs := []string{}
 	for _, addr := range nodeR.Addrs() {
-		addr2 := fmt.Sprintf("%s/p2p/%s", addr, nodeR.ID().String())
-		fmt.Printf("relay address: %s\n", addr2)
-		relayAddrs = append(relayAddrs, addr2)
+		addr := fmt.Sprintf("%s/p2p/%s", addr, nodeR.ID().String())
+		fmt.Printf("relay address: %s\n", addr)
+		relayAddrs = append(relayAddrs, addr)
 	}
 
 	bootstrapPort := ts.RandInt32(9999) + 10000

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -20,9 +20,11 @@ type NotifeeService struct {
 	logger           *logger.SubLogger
 	streamProtocolID lp2pcore.ProtocolID
 	peerMgr          *peerMgr
+	relay            *relayService
 }
 
-func newNotifeeService(ctx context.Context, host lp2phost.Host, eventChannel chan<- Event, peerMgr *peerMgr,
+func newNotifeeService(ctx context.Context, host lp2phost.Host, eventChannel chan<- Event,
+	peerMgr *peerMgr, relay *relayService,
 	protocolID lp2pcore.ProtocolID, log *logger.SubLogger,
 ) *NotifeeService {
 	events := []interface{}{
@@ -41,6 +43,7 @@ func newNotifeeService(ctx context.Context, host lp2phost.Host, eventChannel cha
 		eventChannel:     eventChannel,
 		streamProtocolID: protocolID,
 		peerMgr:          peerMgr,
+		relay:            relay,
 		logger:           log,
 	}
 	host.Network().Notify(notifee)
@@ -56,6 +59,7 @@ func (s *NotifeeService) Start() {
 				switch e := evt.(type) {
 				case lp2pevent.EvtLocalReachabilityChanged:
 					s.logger.Info("reachability changed", "reachability", e.Reachability)
+					s.relay.SetReachability(e.Reachability)
 
 				case lp2pevent.EvtPeerIdentificationCompleted:
 					s.logger.Debug("identification completed", "pid", e.Peer)

--- a/network/peermgr.go
+++ b/network/peermgr.go
@@ -68,9 +68,7 @@ func (mgr *peerMgr) Start() {
 	}()
 }
 
-// Stop stops the Bootstrap.
 func (mgr *peerMgr) Stop() {
-	// TODO: complete me
 }
 
 func (mgr *peerMgr) NumOfConnected() int {

--- a/network/relay_service.go
+++ b/network/relay_service.go
@@ -30,10 +30,10 @@ func newRelayService(ctx context.Context, host lp2phost.Host, conf *Config, log 
 	}
 }
 
-func (rs *relayService) Start() error {
+func (rs *relayService) Start() {
 	if rs.conf.EnableRelay {
 		go func() {
-			ticker := time.NewTicker(10 * time.Second)
+			ticker := time.NewTicker(60 * time.Second)
 			defer ticker.Stop()
 
 			for {
@@ -46,8 +46,6 @@ func (rs *relayService) Start() error {
 			}
 		}()
 	}
-
-	return nil
 }
 
 func (rs *relayService) Stop() {

--- a/network/relay_service.go
+++ b/network/relay_service.go
@@ -1,0 +1,96 @@
+package network
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	lp2phost "github.com/libp2p/go-libp2p/core/host"
+	lp2pnetwork "github.com/libp2p/go-libp2p/core/network"
+	"github.com/pactus-project/pactus/util/logger"
+)
+
+type relayService struct {
+	lk sync.RWMutex
+
+	ctx          context.Context
+	host         lp2phost.Host
+	reachability lp2pnetwork.Reachability
+	conf         *Config
+	logger       *logger.SubLogger
+}
+
+func newRelayService(ctx context.Context, host lp2phost.Host, conf *Config, log *logger.SubLogger) *relayService {
+	return &relayService{
+		ctx:          ctx,
+		host:         host,
+		conf:         conf,
+		logger:       log,
+		reachability: lp2pnetwork.ReachabilityUnknown,
+	}
+}
+
+func (rs *relayService) Start() error {
+	if rs.conf.EnableRelay {
+		go func() {
+			ticker := time.NewTicker(10 * time.Second)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-rs.ctx.Done():
+					return
+				case <-ticker.C:
+					rs.checkConnectivity()
+				}
+			}
+		}()
+	}
+
+	return nil
+}
+
+func (rs *relayService) Stop() {
+}
+
+func (rs *relayService) SetHost(host lp2phost.Host) {
+	rs.host = host
+}
+
+func (rs *relayService) SetReachability(reachability lp2pnetwork.Reachability) {
+	rs.lk.Lock()
+	rs.reachability = reachability
+	rs.lk.Unlock()
+
+	if rs.conf.EnableRelay {
+		rs.checkConnectivity()
+	}
+}
+
+func (rs *relayService) Reachability() lp2pnetwork.Reachability {
+	rs.lk.RLock()
+	defer rs.lk.RUnlock()
+
+	return rs.reachability
+}
+
+func (rs *relayService) checkConnectivity() {
+	rs.lk.Lock()
+	defer rs.lk.Unlock()
+
+	if rs.reachability != lp2pnetwork.ReachabilityPrivate {
+		return
+	}
+	net := rs.host.Network()
+	for _, ai := range rs.conf.RelayAddrInfos() {
+		if net.Connectedness(ai.ID) != lp2pnetwork.Connected {
+			rs.logger.Info("try connecting relay node", "addr", ai.Addrs)
+			err := ConnectSync(rs.ctx, rs.host, ai)
+			if err != nil {
+				rs.logger.Warn("unable to connect to relay node", "error", err, "addr", ai.Addrs)
+			} else {
+				rs.logger.Info("connect to relay node", "addr", ai.Addrs)
+			}
+		}
+	}
+}

--- a/network/relay_service.go
+++ b/network/relay_service.go
@@ -51,10 +51,6 @@ func (rs *relayService) Start() {
 func (rs *relayService) Stop() {
 }
 
-func (rs *relayService) SetHost(host lp2phost.Host) {
-	rs.host = host
-}
-
 func (rs *relayService) SetReachability(reachability lp2pnetwork.Reachability) {
 	rs.lk.Lock()
 	rs.reachability = reachability

--- a/network/utils.go
+++ b/network/utils.go
@@ -74,17 +74,19 @@ func HasPID(pids []lp2ppeer.ID, pid lp2ppeer.ID) bool {
 
 func ConnectAsync(ctx context.Context, h lp2phost.Host, addrInfo lp2ppeer.AddrInfo, log *logger.SubLogger) {
 	go func() {
-		err := h.Connect(lp2pnetwork.WithDialPeerTimeout(ctx, 30*time.Second), addrInfo)
-		if err != nil {
-			if log != nil {
+		err := ConnectSync(ctx, h, addrInfo)
+		if log != nil {
+			if err != nil {
 				log.Warn("connection failed", "addr", addrInfo.Addrs, "err", err)
-			}
-		} else {
-			if log != nil {
+			} else {
 				log.Debug("connection successful", "addr", addrInfo.Addrs)
 			}
 		}
 	}()
+}
+
+func ConnectSync(ctx context.Context, h lp2phost.Host, addrInfo lp2ppeer.AddrInfo) error {
+	return h.Connect(lp2pnetwork.WithDialPeerTimeout(ctx, 30*time.Second), addrInfo)
 }
 
 func PrivateSubnets() []*net.IPNet {

--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -67,7 +67,6 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error 
 	handler.peerSet.UpdateStatus(pid, peerset.StatusCodeKnown)
 
 	if msg.Services.IsGossip() {
-		// WARN: Check network::peerMgr if you rename it.
 		handler.network.Protect(msg.PeerID, "GOSSIP")
 	}
 

--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -67,6 +67,7 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error 
 	handler.peerSet.UpdateStatus(pid, peerset.StatusCodeKnown)
 
 	if msg.Services.IsGossip() {
+		// WARN: Check network::peerMgr if you rename it.
 		handler.network.Protect(msg.PeerID, "GOSSIP")
 	}
 


### PR DESCRIPTION
## Description

Relay nodes are operating separately. In this PR, we add a relay service to connect to relay nodes if the node's reachability is private. This service checks every minute to ensure there is a connection with the relay nodes.
