### PR TITLE
fix(network): check number of protected connections

### DIFF
--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -67,6 +67,7 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error 
 	handler.peerSet.UpdateStatus(pid, peerset.StatusCodeKnown)
 
 	if msg.Services.IsGossip() {
+		// WARN: Check network::peerMgr if you rename it.
 		handler.network.Protect(msg.PeerID, "GOSSIP")
 	}
 


### PR DESCRIPTION
## Description

This PR checks the number of protected connections with the Gossip nodes. If the count is less than 2, it closes all connections to re-initiate them.

