### PR TITLE
fix(executor): not rejecting bond transaction for bootstrap validator

### DIFF
--- a/execution/executor/bond.go
+++ b/execution/executor/bond.go
@@ -25,7 +25,7 @@ func (e *BondExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 	}
 
 	receiverVal := sb.Validator(pld.To)
-	if receiverVal == nil || receiverVal.LastBondingHeight() == 0 {
+	if receiverVal == nil {
 		if pld.PublicKey == nil {
 			return errors.Errorf(errors.ErrInvalidPublicKey,
 				"public key is not set")

--- a/execution/executor/bond_test.go
+++ b/execution/executor/bond_test.go
@@ -191,27 +191,3 @@ func TestPowerDeltaBond(t *testing.T) {
 
 	assert.Equal(t, amt, td.sandbox.PowerDelta())
 }
-
-// Test case for issue #869: https://github.com/pactus-project/pactus/issues/869
-func TestIssue869(t *testing.T) {
-	td := setup(t)
-	exe := NewBondExecutor(false)
-
-	senderAddr, senderAcc := td.sandbox.TestStore.RandomTestAcc()
-	senderBalance := senderAcc.Balance()
-	pub, _ := td.RandBLSKeyPair()
-	receiverAddr := pub.ValidatorAddress()
-	amt, fee := td.randomAmountAndFee(td.sandbox.TestParams.MinimumStake, senderBalance)
-	lockTime := td.sandbox.CurrentHeight()
-	trx1 := tx.NewBondTx(lockTime, senderAddr,
-		receiverAddr, pub, 1000e9, fee, "insufficient funds") // make sure
-
-	trx2 := tx.NewBondTx(lockTime, senderAddr,
-		receiverAddr, pub, amt, fee, "ok")
-
-	err := exe.Execute(trx1, td.sandbox)
-	assert.Error(t, err, ErrInsufficientFunds)
-
-	err = exe.Execute(trx2, td.sandbox)
-	assert.NoError(t, err)
-}

--- a/sandbox/mock.go
+++ b/sandbox/mock.go
@@ -63,7 +63,7 @@ func (m *MockSandbox) Account(addr crypto.Address) *account.Account {
 	return acc
 }
 
-func (m *MockSandbox) MakeNewAccount(addr crypto.Address) *account.Account {
+func (m *MockSandbox) MakeNewAccount(_ crypto.Address) *account.Account {
 	acc := account.NewAccount(m.TestStore.TotalAccounts())
 	return acc
 }

--- a/sandbox/mock.go
+++ b/sandbox/mock.go
@@ -26,8 +26,6 @@ type MockSandbox struct {
 	TestJoinedValidators map[crypto.Address]bool
 	TestCommittedTrxs    map[tx.ID]*tx.Tx
 	TestPowerDelta       int64
-	TestSandboxVals      map[crypto.Address]*validator.Validator
-	TestSandboxAccs      map[crypto.Address]*account.Account
 }
 
 func MockingSandbox(ts *testsuite.TestSuite) *MockSandbox {
@@ -40,8 +38,6 @@ func MockingSandbox(ts *testsuite.TestSuite) *MockSandbox {
 		TestCommittee:        cmt,
 		TestJoinedValidators: make(map[crypto.Address]bool),
 		TestCommittedTrxs:    make(map[tx.ID]*tx.Tx),
-		TestSandboxVals:      make(map[crypto.Address]*validator.Validator),
-		TestSandboxAccs:      make(map[crypto.Address]*account.Account),
 	}
 
 	treasuryAmt := int64(21000000 * 1e9)
@@ -64,15 +60,11 @@ func MockingSandbox(ts *testsuite.TestSuite) *MockSandbox {
 
 func (m *MockSandbox) Account(addr crypto.Address) *account.Account {
 	acc, _ := m.TestStore.Account(addr)
-	if acc == nil {
-		return m.TestSandboxAccs[addr]
-	}
 	return acc
 }
 
 func (m *MockSandbox) MakeNewAccount(addr crypto.Address) *account.Account {
 	acc := account.NewAccount(m.TestStore.TotalAccounts())
-	m.TestSandboxAccs[addr] = acc
 	return acc
 }
 
@@ -89,9 +81,6 @@ func (m *MockSandbox) AnyRecentTransaction(txID tx.ID) bool {
 
 func (m *MockSandbox) Validator(addr crypto.Address) *validator.Validator {
 	val, _ := m.TestStore.Validator(addr)
-	if val == nil {
-		return m.TestSandboxVals[addr]
-	}
 	return val
 }
 
@@ -105,7 +94,6 @@ func (m *MockSandbox) IsJoinedCommittee(addr crypto.Address) bool {
 
 func (m *MockSandbox) MakeNewValidator(pub *bls.PublicKey) *validator.Validator {
 	val := validator.NewValidator(pub, m.TestStore.TotalValidators())
-	m.TestSandboxVals[val.Address()] = val
 	return val
 }
 


### PR DESCRIPTION
## Description

This PR reverts PR #870  and fixes issue #900.

## Related issue(s)

- Fixes #900 (Related to #869 )