### PR TITLE
fix(store): use cache to check if public key exists

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,6 @@ func defaultConfig() *Config {
 
 func DefaultConfigMainnet(genParams *param.Params) *Config {
 	conf := defaultConfig()
-	// TO BE DEFINED
 
 	// Store private configs
 	conf.Store.TxCacheSize = genParams.TransactionToLiveInterval

--- a/store/account_test.go
+++ b/store/account_test.go
@@ -140,9 +140,6 @@ func TestAccountDeepCopy(t *testing.T) {
 
 	acc2, _ := td.store.Account(addr)
 	acc2.AddToBalance(1)
-	accCache, _ := td.store.accountStore.accInCache.Get(addr)
+	accCache, _ := td.store.accountStore.accCache.Get(addr)
 	assert.NotEqual(t, accCache.Hash(), acc2.Hash())
-
-	expectedAcc, _ := td.store.accountStore.accInCache.Get(addr)
-	assert.NotEqual(t, expectedAcc.Hash(), acc2.Hash())
 }

--- a/store/config.go
+++ b/store/config.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/pactus-project/pactus/util"
-	"github.com/pactus-project/pactus/util/errors"
 )
 
 type Config struct {
@@ -23,8 +22,8 @@ func DefaultConfig() *Config {
 		Path:               "data",
 		TxCacheSize:        0,
 		SortitionCacheSize: 0,
-		AccountCacheSize:   0,
-		PublicKeyCacheSize: 0,
+		AccountCacheSize:   1024,
+		PublicKeyCacheSize: 1024,
 	}
 }
 
@@ -39,7 +38,19 @@ func (conf *Config) StorePath() string {
 // BasicCheck performs basic checks on the configuration.
 func (conf *Config) BasicCheck() error {
 	if !util.IsValidDirPath(conf.Path) {
-		return errors.Errorf(errors.ErrInvalidConfig, "path is not valid")
+		return InvalidConfigError{
+			Reason: "path is not valid",
+		}
 	}
+
+	if conf.TxCacheSize == 0 ||
+		conf.SortitionCacheSize == 0 ||
+		conf.AccountCacheSize == 0 ||
+		conf.PublicKeyCacheSize == 0 {
+		return InvalidConfigError{
+			Reason: "cache size set to zero",
+		}
+	}
+
 	return nil
 }

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -9,12 +9,19 @@ import (
 )
 
 func TestDefaultConfigCheck(t *testing.T) {
-	c := DefaultConfig()
-	assert.NoError(t, c.BasicCheck())
+	conf := DefaultConfig()
+
+	err := conf.BasicCheck()
+	assert.ErrorIs(t, InvalidConfigError{"cache size set to zero"}, err)
+
+	conf.TxCacheSize = 1
+	conf.SortitionCacheSize = 1
+	err = conf.BasicCheck()
+	assert.NoError(t, err)
 
 	if runtime.GOOS != "windows" {
-		c.Path = util.TempDirPath()
-		assert.NoError(t, c.BasicCheck())
-		assert.Equal(t, c.StorePath(), c.Path+"/store.db")
+		conf.Path = util.TempDirPath()
+		assert.NoError(t, conf.BasicCheck())
+		assert.Equal(t, conf.StorePath(), conf.Path+"/store.db")
 	}
 }

--- a/store/errors.go
+++ b/store/errors.go
@@ -6,6 +6,15 @@ import (
 	"github.com/pactus-project/pactus/crypto"
 )
 
+// InvalidConfigError is returned when the store configuration is invalid.
+type InvalidConfigError struct {
+	Reason string
+}
+
+func (e InvalidConfigError) Error() string {
+	return e.Reason
+}
+
 // PublicKeyNotFoundError is returned when the public key associated with an address
 // is not found in the store.
 type PublicKeyNotFoundError struct {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -121,7 +121,7 @@ func TestIndexingPublicKeys(t *testing.T) {
 	for _, trx := range blk.Transactions() {
 		addr := trx.Payload().Signer()
 		pub, found := td.store.PublicKey(addr)
-		pubKeyLruCache, ok := td.store.pubKeyCache.Get(addr)
+		pubKeyLruCache, ok := td.store.blockStore.pubKeyCache.Get(addr)
 
 		assert.NoError(t, found)
 		assert.True(t, ok)
@@ -136,7 +136,7 @@ func TestIndexingPublicKeys(t *testing.T) {
 
 	randValAddress := td.RandValAddress()
 	pub, found := td.store.PublicKey(randValAddress)
-	pubKeyLruCache, ok := td.store.pubKeyCache.Get(randValAddress)
+	pubKeyLruCache, ok := td.store.blockStore.pubKeyCache.Get(randValAddress)
 
 	assert.Error(t, found)
 	assert.Nil(t, pub)


### PR DESCRIPTION
## Description

This PR uses a cache to check if a public key exists or not. If not, it looks up the DB. 
It also defines a new error for invalid config data.