### PR TITLE
fix(GUI): updating unbond and withdraw dialogs

### DIFF
--- a/cmd/gtk/assets/ui/dialog_transaction_unbond.ui
+++ b/cmd/gtk/assets/ui/dialog_transaction_unbond.ui
@@ -7,7 +7,7 @@
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Broadcasting Unbond transaction</property>
     <property name="modal">True</property>
-    <property name="default-width">420</property>
+    <property name="default-width">480</property>
     <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox">

--- a/cmd/gtk/assets/ui/dialog_transaction_unbond.ui
+++ b/cmd/gtk/assets/ui/dialog_transaction_unbond.ui
@@ -5,9 +5,9 @@
   <object class="GtkDialog" id="id_dialog_transaction_unbond">
     <property name="width-request">600</property>
     <property name="can-focus">False</property>
-    <property name="title" translatable="yes">Broadcasting UnBond transaction</property>
+    <property name="title" translatable="yes">Broadcasting Unbond transaction</property>
     <property name="modal">True</property>
-    <property name="default-width">480</property>
+    <property name="default-width">420</property>
     <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox">
@@ -80,7 +80,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Account address:</property>
+                <property name="label" translatable="yes">Validator address:</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/cmd/gtk/assets/ui/dialog_transaction_withdraw.ui
+++ b/cmd/gtk/assets/ui/dialog_transaction_withdraw.ui
@@ -138,13 +138,18 @@
               </packing>
             </child>
             <child>
-              <object class="GtkEntry" id="id_entry_receiver">
+              <object class="GtkComboBoxText" id="id_combo_receiver">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="width-chars">32</property>
-                <property name="caps-lock-warning">False</property>
-                <signal name="changed" handler="on_receiver_changed" swapped="no"/>
+                <property name="has-focus">True</property>
+                <property name="is-focus">True</property>
+                <property name="has-entry">True</property>
+                <child internal-child="entry">
+                  <object class="GtkEntry">
+                    <property name="can-focus">True</property>
+                    <signal name="changed" handler="on_receiver_changed" swapped="no"/>
+                  </object>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/cmd/gtk/dialog_transaction_bond.go
+++ b/cmd/gtk/dialog_transaction_bond.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/gotk3/gotk3/gtk"
-	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/types/tx/payload"
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/wallet"
@@ -16,7 +15,7 @@ import (
 //go:embed assets/ui/dialog_transaction_bond.ui
 var uiTransactionBondDialog []byte
 
-func broadcastTransactionBond(wlt *wallet.Wallet, valAddrs []crypto.Address) {
+func broadcastTransactionBond(wlt *wallet.Wallet) {
 	builder, err := gtk.BuilderNewFromString(string(uiTransactionBondDialog))
 	fatalErrorCheck(err)
 
@@ -32,12 +31,13 @@ func broadcastTransactionBond(wlt *wallet.Wallet, valAddrs []crypto.Address) {
 	getButtonObj(builder, "id_button_cancel").SetImage(CancelIcon())
 	getButtonObj(builder, "id_button_send").SetImage(SendIcon())
 
-	for _, i := range wlt.AddressInfos() {
-		senderEntry.Append(i.Address, i.Address)
+	// TODO: we need something like: wlt.AllAccountAddresses()
+	for _, ai := range wlt.AddressInfos() {
+		senderEntry.Append(ai.Address, ai.Address)
 	}
 
-	for _, addr := range valAddrs {
-		receiverCombo.Append(addr.String(), addr.String())
+	for _, ai := range wlt.AllValidatorAddresses() {
+		receiverCombo.Append(ai.Address, ai.Address)
 	}
 
 	senderEntry.SetActive(0)

--- a/cmd/gtk/dialog_transaction_transfer.go
+++ b/cmd/gtk/dialog_transaction_transfer.go
@@ -30,6 +30,7 @@ func broadcastTransactionTransfer(wlt *wallet.Wallet) {
 	getButtonObj(builder, "id_button_cancel").SetImage(CancelIcon())
 	getButtonObj(builder, "id_button_send").SetImage(SendIcon())
 
+	// TODO: we need something like: wlt.AllAccountAddresses()
 	for _, i := range wlt.AddressInfos() {
 		senderEntry.Append(i.Address, i.Address)
 	}

--- a/cmd/gtk/dialog_transaction_unbond.go
+++ b/cmd/gtk/dialog_transaction_unbond.go
@@ -7,14 +7,13 @@ import (
 	"fmt"
 
 	"github.com/gotk3/gotk3/gtk"
-	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/wallet"
 )
 
 //go:embed assets/ui/dialog_transaction_unbond.ui
 var uiTransactionUnBondDialog []byte
 
-func broadcastTransactionUnBond(wlt *wallet.Wallet, valAddrs []crypto.Address) {
+func broadcastTransactionUnbond(wlt *wallet.Wallet) {
 	builder, err := gtk.BuilderNewFromString(string(uiTransactionUnBondDialog))
 	fatalErrorCheck(err)
 
@@ -25,8 +24,8 @@ func broadcastTransactionUnBond(wlt *wallet.Wallet, valAddrs []crypto.Address) {
 	getButtonObj(builder, "id_button_cancel").SetImage(CancelIcon())
 	getButtonObj(builder, "id_button_send").SetImage(SendIcon())
 
-	for _, addr := range valAddrs {
-		validatorCombo.Append(addr.String(), addr.String())
+	for _, ai := range wlt.AllValidatorAddresses() {
+		validatorCombo.Append(ai.Address, ai.Address)
 	}
 
 	onValidatorChanged := func() {

--- a/cmd/gtk/dialog_transaction_withdraw.go
+++ b/cmd/gtk/dialog_transaction_withdraw.go
@@ -23,24 +23,30 @@ func broadcastTransactionWithdraw(wlt *wallet.Wallet) {
 
 	validatorEntry := getComboBoxTextObj(builder, "id_combo_validator")
 	validatorHint := getLabelObj(builder, "id_hint_validator")
-	receiverEntry := getEntryObj(builder, "id_entry_receiver")
+	receiverCombo := getComboBoxTextObj(builder, "id_combo_receiver")
 	receiverHint := getLabelObj(builder, "id_hint_receiver")
 	stakeEntry := getEntryObj(builder, "id_entry_stake")
 	stakeHint := getLabelObj(builder, "id_hint_stake")
 	getButtonObj(builder, "id_button_cancel").SetImage(CancelIcon())
 	getButtonObj(builder, "id_button_send").SetImage(SendIcon())
 
-	for _, i := range wlt.AddressInfos() {
-		validatorEntry.Append(i.Address, i.Address)
+	for _, ai := range wlt.AllValidatorAddresses() {
+		validatorEntry.Append(ai.Address, ai.Address)
 	}
 	validatorEntry.SetActive(0)
 
+	// TODO: we need something like: wlt.AllAccountAddresses()
+	for _, ai := range wlt.AddressInfos() {
+		receiverCombo.Append(ai.Address, ai.Address)
+	}
+
 	onSenderChanged := func() {
 		senderStr := validatorEntry.GetActiveID()
-		updateAccountHint(validatorHint, senderStr, wlt)
+		updateValidatorHint(validatorHint, senderStr, wlt)
 	}
 
 	onReceiverChanged := func() {
+		receiverEntry, _ := receiverCombo.GetEntry()
 		receiverStr, _ := receiverEntry.GetText()
 		updateAccountHint(receiverHint, receiverStr, wlt)
 	}
@@ -52,6 +58,7 @@ func broadcastTransactionWithdraw(wlt *wallet.Wallet) {
 
 	onSend := func() {
 		sender := validatorEntry.GetActiveID()
+		receiverEntry, _ := receiverCombo.GetEntry()
 		receiver, _ := receiverEntry.GetText()
 		amountStr, _ := stakeEntry.GetText()
 

--- a/cmd/gtk/main_window.go
+++ b/cmd/gtk/main_window.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gotk3/gotk3/gdk"
 	"github.com/gotk3/gotk3/gtk"
-	"github.com/pactus-project/pactus/crypto"
 )
 
 //go:embed assets/ui/main_window.ui
@@ -64,7 +63,7 @@ func buildMainWindow(nodeModel *nodeModel, walletModel *walletModel) *mainWindow
 		"on_quit":                 mw.onQuit,
 		"on_transaction_transfer": mw.OnTransactionTransfer,
 		"on_transaction_bond":     mw.OnTransactionBond,
-		"on_transaction_unbond":   mw.OnTransactionUnBond,
+		"on_transaction_unbond":   mw.OnTransactionUnbond,
 		"on_transaction_withdraw": mw.OnTransactionWithdraw,
 	}
 	builder.ConnectSignals(signals)
@@ -101,17 +100,16 @@ func (mw *mainWindow) OnTransactionTransfer() {
 	broadcastTransactionTransfer(mw.widgetWallet.model.wallet)
 }
 
-func (mw *mainWindow) OnTransactionWithdraw() {
-	broadcastTransactionWithdraw(mw.widgetWallet.model.wallet)
+func (mw *mainWindow) OnTransactionBond() {
+	broadcastTransactionBond(mw.widgetWallet.model.wallet)
 }
 
-func (mw *mainWindow) OnTransactionUnBond() {
-	valAddrs := []crypto.Address{}
-	consMgr := mw.widgetNode.model.node.ConsManager()
-	for _, inst := range consMgr.Instances() {
-		valAddrs = append(valAddrs, inst.ConsensusKey().ValidatorAddress())
-	}
-	broadcastTransactionUnBond(mw.widgetWallet.model.wallet, valAddrs)
+func (mw *mainWindow) OnTransactionUnbond() {
+	broadcastTransactionUnbond(mw.widgetWallet.model.wallet)
+}
+
+func (mw *mainWindow) OnTransactionWithdraw() {
+	broadcastTransactionWithdraw(mw.widgetWallet.model.wallet)
 }
 
 func (mw *mainWindow) onMenuItemActivateWebsite(_ *gtk.MenuItem) {
@@ -130,13 +128,4 @@ func (mw *mainWindow) onMenuItemActivateLearn(_ *gtk.MenuItem) {
 	if err := openURLInBrowser("https://pactus.org/learn/"); err != nil {
 		fatalErrorCheck(err)
 	}
-}
-
-func (mw *mainWindow) OnTransactionBond() {
-	valAddrs := []crypto.Address{}
-	consMgr := mw.widgetNode.model.node.ConsManager()
-	for _, inst := range consMgr.Instances() {
-		valAddrs = append(valAddrs, inst.ConsensusKey().ValidatorAddress())
-	}
-	broadcastTransactionBond(mw.widgetWallet.model.wallet, valAddrs)
 }

--- a/consensus/propose.go
+++ b/consensus/propose.go
@@ -30,6 +30,8 @@ func (s *proposeState) decide() {
 	// Based on PIP-19, if the Availability Score is less than 0.9,
 	// we initiate the Change-Proposer phase.
 	if score < 0.80 { // TODO: add it to the config
+		s.logger.Info("availability score of proposer is low",
+			"score", score, "proposer", proposer.Address())
 		s.startChangingProposer()
 	} else {
 		s.enterNewState(s.prepareState)


### PR DESCRIPTION
## Description

This PR:
- Fixes a typo in the Unbond dialog.
- Adds the account addresses to the receiver entry in the withdraw dialog.
- Uses `AllValidatorAddresses` from the wallet to retrieve validator addresses.

