### PR TITLE
feat(network): making listen address private in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,10 +93,6 @@ func DefaultConfigMainnet(genParams *param.Params) *Config {
 //nolint:lll // long multi-address
 func DefaultConfigTestnet(genParams *param.Params) *Config {
 	conf := defaultConfig()
-	conf.Network.ListenAddrStrings = []string{
-		"/ip4/0.0.0.0/tcp/21777", "/ip4/0.0.0.0/udp/21777/quic-v1",
-		"/ip6/::/tcp/21777", "/ip6/::/udp/21777/quic-v1",
-	}
 	conf.Network.DefaultBootstrapAddrStrings = []string{
 		"/ip4/94.101.184.118/tcp/21777/p2p/12D3KooWCwQZt8UriVXobQHPXPR8m83eceXVoeT6brPNiBHomebc",
 		"/ip4/172.104.46.145/tcp/21777/p2p/12D3KooWNYD4bB82YZRXv6oNyYPwc5ozabx2epv75ATV3D8VD3Mq",
@@ -139,7 +135,6 @@ func DefaultConfigTestnet(genParams *param.Params) *Config {
 
 func DefaultConfigLocalnet(genParams *param.Params) *Config {
 	conf := defaultConfig()
-	conf.Network.ListenAddrStrings = []string{}
 	conf.Network.EnableRelay = false
 	conf.Network.EnableNATService = false
 	conf.Network.EnableUPnP = false

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -61,8 +61,8 @@ func TestTestnetConfig(t *testing.T) {
 	conf := DefaultConfigTestnet(param.DefaultParams())
 
 	assert.NoError(t, conf.BasicCheck())
-	assert.NotEmpty(t, conf.Network.ListenAddrStrings)
 	assert.NotEmpty(t, conf.Network.DefaultRelayAddrStrings)
+	assert.Empty(t, conf.Network.ListenAddrStrings)
 	assert.Empty(t, conf.Network.RelayAddrStrings)
 	assert.Equal(t, conf.Network.NetworkName, "pactus-testnet-v2")
 	assert.Equal(t, conf.Network.DefaultPort, 21777)

--- a/network/config.go
+++ b/network/config.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"fmt"
+
 	lp2pcore "github.com/libp2p/go-libp2p/core"
 	lp2ppeer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
@@ -91,7 +93,16 @@ func (conf *Config) PublicAddr() multiaddr.Multiaddr {
 }
 
 func (conf *Config) ListenAddrs() []multiaddr.Multiaddr {
-	addrs, _ := MakeMultiAddrs(conf.ListenAddrStrings)
+	listenAddrs := conf.ListenAddrStrings
+	if len(listenAddrs) == 0 {
+		listenAddrs = []string{
+			fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", conf.DefaultPort),
+			fmt.Sprintf("/ip4/0.0.0.0/udp/%d/quic-v1", conf.DefaultPort),
+			fmt.Sprintf("/ip6/::/tcp/%d", conf.DefaultPort),
+			fmt.Sprintf("/ip6/::/udp/%d/quic-v1", conf.DefaultPort),
+		}
+	}
+	addrs, _ := MakeMultiAddrs(listenAddrs)
 	return addrs
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -253,7 +253,7 @@ func newNetwork(conf *Config, log *logger.SubLogger, opts []lp2p.Option) (*netwo
 
 	n.logger.Info("network setup", "id", n.host.ID(),
 		"name", conf.NetworkName,
-		"address", conf.ListenAddrStrings,
+		"address", conf.ListenAddrs(),
 		"bootstrapper", conf.IsBootstrapper)
 
 	return n, nil


### PR DESCRIPTION
## Description

The relay address field in the config file has a default value. Users do not need to define the listening addresses.