### PR TITLE
fix(network): fixing network deadlock on linux arm64

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -289,12 +289,12 @@ func (n *network) Stop() {
 		n.mdns.Stop()
 	}
 
-	n.dht.Stop()
 	n.gossip.Stop()
 	n.stream.Stop()
 	n.peerMgr.Stop()
 	n.notifee.Stop()
 	n.relay.Stop()
+	n.dht.Stop()
 
 	if err := n.host.Close(); err != nil {
 		n.logger.Error("unable to close the network", "error", err)


### PR DESCRIPTION
## Description

This PR prevents a deadlock on stopping the node that happens on Linux ARM 64.