### PR TITLE
fix(consensus): detect if the system time is behind the network

### DIFF
--- a/consensus/height_test.go
+++ b/consensus/height_test.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"testing"
 
+	"github.com/pactus-project/pactus/types/vote"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,4 +39,23 @@ func TestNewHeightDoubleEntry(t *testing.T) {
 	td.checkHeightRound(t, td.consX, 2, 0)
 	assert.True(t, td.consX.active)
 	assert.NotEqual(t, td.consX.currentState.name(), "new-height")
+}
+
+func TestNewHeightTimeBehindNetwork(t *testing.T) {
+	td := setup(t)
+
+	td.commitBlockForAllStates(t)
+	td.consP.MoveToNewHeight()
+
+	h := uint32(2)
+	r := int16(0)
+	p := td.makeProposal(t, h, r)
+
+	td.consP.SetProposal(p)
+	td.addPrepareVote(td.consP, p.Block().Hash(), h, r, tIndexX)
+	td.addPrepareVote(td.consP, p.Block().Hash(), h, r, tIndexY)
+	td.addPrepareVote(td.consP, p.Block().Hash(), h, r, tIndexB)
+
+	td.shouldPublishVote(t, td.consP, vote.VoteTypePrepare, p.Block().Hash())
+	td.shouldPublishVote(t, td.consP, vote.VoteTypePrecommit, p.Block().Hash())
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -229,7 +229,7 @@ func (sync *synchronizer) sayHello(to peer.ID) {
 		sync.config.Services(),
 		sync.state.LastBlockHash(),
 		sync.state.Genesis().Hash(),
-		sync.network.Name(),
+		sync.network.ReachabilityStatus(),
 	)
 	msg.Sign(sync.valKeys)
 


### PR DESCRIPTION
## Description

This PR added logic to detect when the network majority has voted for a block,
but the new height timer has not yet started. This situation can occur if the system
time is lagging behind the network time.
