### PR TITLE
fix(sync): remove ReachabilityStatus from agent info

### DIFF
--- a/sync/bundle/message/hello.go
+++ b/sync/bundle/message/hello.go
@@ -26,11 +26,11 @@ type HelloMessage struct {
 }
 
 func NewHelloMessage(pid peer.ID, moniker string,
-	height uint32, services service.Services, blockHash, genesisHash hash.Hash, reachability string,
+	height uint32, services service.Services, blockHash, genesisHash hash.Hash,
 ) *HelloMessage {
 	return &HelloMessage{
 		PeerID:          pid,
-		Agent:           fmt.Sprintf("%v/reachability=%v", version.Agent(), reachability),
+		Agent:           version.Agent(),
 		Moniker:         moniker,
 		GenesisHash:     genesisHash,
 		BlockHash:       blockHash,

--- a/sync/bundle/message/hello_test.go
+++ b/sync/bundle/message/hello_test.go
@@ -21,7 +21,7 @@ func TestHelloMessage(t *testing.T) {
 
 	t.Run("Invalid signature", func(t *testing.T) {
 		valKey := ts.RandValKey()
-		m := NewHelloMessage(ts.RandPeerID(), "Oscar", 100, 0, ts.RandHash(), ts.RandHash(), "public")
+		m := NewHelloMessage(ts.RandPeerID(), "Oscar", 100, 0, ts.RandHash(), ts.RandHash())
 		m.Sign([]*bls.ValidatorKey{valKey})
 		m.Signature = ts.RandBLSSignature()
 
@@ -30,7 +30,7 @@ func TestHelloMessage(t *testing.T) {
 
 	t.Run("Signature is nil", func(t *testing.T) {
 		valKey := ts.RandValKey()
-		m := NewHelloMessage(ts.RandPeerID(), "Oscar", 100, 0, ts.RandHash(), ts.RandHash(), "public")
+		m := NewHelloMessage(ts.RandPeerID(), "Oscar", 100, 0, ts.RandHash(), ts.RandHash())
 		m.Sign([]*bls.ValidatorKey{valKey})
 		m.Signature = nil
 
@@ -39,7 +39,7 @@ func TestHelloMessage(t *testing.T) {
 
 	t.Run("PublicKeys are empty", func(t *testing.T) {
 		valKey := ts.RandValKey()
-		m := NewHelloMessage(ts.RandPeerID(), "Oscar", 100, 0, ts.RandHash(), ts.RandHash(), "public")
+		m := NewHelloMessage(ts.RandPeerID(), "Oscar", 100, 0, ts.RandHash(), ts.RandHash())
 		m.Sign([]*bls.ValidatorKey{valKey})
 		m.PublicKeys = make([]*bls.PublicKey, 0)
 
@@ -50,7 +50,7 @@ func TestHelloMessage(t *testing.T) {
 		time1 := time.Now()
 		myTimeUnixMilli := time1.UnixMilli()
 
-		m := NewHelloMessage(ts.RandPeerID(), "Alice", 100, 0, ts.RandHash(), ts.RandHash(), "public")
+		m := NewHelloMessage(ts.RandPeerID(), "Alice", 100, 0, ts.RandHash(), ts.RandHash())
 
 		assert.LessOrEqual(t, m.MyTimeUnixMilli, time.Now().UnixMilli())
 		assert.GreaterOrEqual(t, m.MyTimeUnixMilli, myTimeUnixMilli)
@@ -58,7 +58,7 @@ func TestHelloMessage(t *testing.T) {
 
 	t.Run("Ok", func(t *testing.T) {
 		valKey := ts.RandValKey()
-		m := NewHelloMessage(ts.RandPeerID(), "Alice", 100, 0, ts.RandHash(), ts.RandHash(), "public")
+		m := NewHelloMessage(ts.RandPeerID(), "Alice", 100, 0, ts.RandHash(), ts.RandHash())
 		m.Sign([]*bls.ValidatorKey{valKey})
 
 		assert.NoError(t, m.BasicCheck())

--- a/sync/handler_hello_test.go
+++ b/sync/handler_hello_test.go
@@ -24,7 +24,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			valKey := td.RandValKey()
 			pid := td.RandPeerID()
 			msg := message.NewHelloMessage(pid, "unknown-peer", 0, 0,
-				td.state.LastBlockHash(), td.state.Genesis().Hash(), "public")
+				td.state.LastBlockHash(), td.state.Genesis().Hash())
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
 			from := td.RandPeerID()
@@ -39,7 +39,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			valKey := td.RandValKey()
 			pid := td.RandPeerID()
 			msg := message.NewHelloMessage(pid, "bad-genesis", 0, 0,
-				td.state.LastBlockHash(), invGenHash, "public")
+				td.state.LastBlockHash(), invGenHash)
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
 			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
@@ -54,7 +54,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			height := td.RandUint32NonZero(td.state.LastBlockHeight())
 			pid := td.RandPeerID()
 			msg := message.NewHelloMessage(pid, "kitty", height, service.New(service.Network),
-				td.state.LastBlockHash(), td.state.Genesis().Hash(), "public")
+				td.state.LastBlockHash(), td.state.Genesis().Hash())
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
 			msg.MyTimeUnixMilli = msg.MyTime().Add(-10 * time.Second).UnixMilli()
@@ -70,7 +70,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			height := td.RandUint32NonZero(td.state.LastBlockHeight())
 			pid := td.RandPeerID()
 			msg := message.NewHelloMessage(pid, "kitty", height, service.New(service.Network),
-				td.state.LastBlockHash(), td.state.Genesis().Hash(), "public")
+				td.state.LastBlockHash(), td.state.Genesis().Hash())
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
 			msg.MyTimeUnixMilli = msg.MyTime().Add(20 * time.Second).UnixMilli()
@@ -86,7 +86,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			height := td.RandUint32NonZero(td.state.LastBlockHeight())
 			pid := td.RandPeerID()
 			msg := message.NewHelloMessage(pid, "kitty", height, service.New(service.Network),
-				td.state.LastBlockHash(), td.state.Genesis().Hash(), "public")
+				td.state.LastBlockHash(), td.state.Genesis().Hash())
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
 			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
@@ -99,7 +99,7 @@ func TestParsingHelloMessages(t *testing.T) {
 
 			pub := valKey.PublicKey()
 			assert.Equal(t, p.Status, peerset.StatusCodeKnown)
-			assert.Equal(t, p.Agent, version.Agent()+"/reachability=public")
+			assert.Equal(t, p.Agent, version.Agent())
 			assert.Equal(t, p.Moniker, "kitty")
 			assert.Contains(t, p.ConsensusKeys, pub)
 			assert.Equal(t, p.PeerID, pid)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -229,7 +229,6 @@ func (sync *synchronizer) sayHello(to peer.ID) {
 		sync.config.Services(),
 		sync.state.LastBlockHash(),
 		sync.state.Genesis().Hash(),
-
 	)
 	msg.Sign(sync.valKeys)
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -229,7 +229,7 @@ func (sync *synchronizer) sayHello(to peer.ID) {
 		sync.config.Services(),
 		sync.state.LastBlockHash(),
 		sync.state.Genesis().Hash(),
-		sync.network.ReachabilityStatus(),
+
 	)
 	msg.Sign(sync.valKeys)
 

--- a/www/grpc/network.go
+++ b/www/grpc/network.go
@@ -2,7 +2,6 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 	"unsafe"
 
 	"github.com/fxamacker/cbor/v2"
@@ -42,7 +41,7 @@ func (s *networkServer) GetNodeInfo(_ context.Context,
 
 	return &pactus.GetNodeInfoResponse{
 		Moniker:       s.sync.Moniker(),
-		Agent:         fmt.Sprintf("%s/reachability=%s", version.Agent(), s.net.ReachabilityStatus()),
+		Agent:         version.Agent(),
 		PeerId:        []byte(s.sync.SelfID()),
 		Reachability:  s.net.ReachabilityStatus(),
 		Addrs:         s.net.HostAddrs(),

--- a/www/grpc/network_test.go
+++ b/www/grpc/network_test.go
@@ -2,7 +2,6 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/libp2p/go-libp2p/core/peer"

--- a/www/grpc/network_test.go
+++ b/www/grpc/network_test.go
@@ -55,7 +55,7 @@ func TestGetNodeInfo(t *testing.T) {
 		&pactus.GetNodeInfoRequest{})
 	assert.NoError(t, err)
 	assert.Nil(t, err)
-	assert.Equal(t, fmt.Sprintf("%v/reachability=%v", version.Agent(), "Unknown"), res.Agent)
+	assert.Equal(t,version.Agent(), res.Agent)
 	assert.Equal(t, []byte(td.mockSync.SelfID()), res.PeerId)
 	assert.Equal(t, "test-moniker", res.Moniker)
 

--- a/www/grpc/network_test.go
+++ b/www/grpc/network_test.go
@@ -54,7 +54,7 @@ func TestGetNodeInfo(t *testing.T) {
 		&pactus.GetNodeInfoRequest{})
 	assert.NoError(t, err)
 	assert.Nil(t, err)
-	assert.Equal(t,version.Agent(), res.Agent)
+	assert.Equal(t, version.Agent(), res.Agent)
 	assert.Equal(t, []byte(td.mockSync.SelfID()), res.PeerId)
 	assert.Equal(t, "test-moniker", res.Moniker)
 


### PR DESCRIPTION
## Description

removed `ReachabilityStatus`.

## Related issue(s)

If this Pull Request is related to an issue, mention it here.
- removed `ReachabilityStatus` from sync, network and test cases.