### PR TITLE
test: remove default bootstrap nodes from the main test

### DIFF
--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -81,6 +81,8 @@ func TestMain(m *testing.M) {
 		tConfigs[i].Sync.Firewall.Enabled = false
 		tConfigs[i].Sync.LatestBlockInterval = 10
 		tConfigs[i].Network.EnableMdns = true
+		tConfigs[i].Network.EnableRelay = false
+		tConfigs[i].Network.DefaultBootstrapAddrStrings = []string{}
 		tConfigs[i].Network.ForcePrivateNetwork = true
 		tConfigs[i].Network.NetworkKey = util.TempFilePath()
 		tConfigs[i].Network.NetworkName = "test"


### PR DESCRIPTION
## Description

This PR removes the default bootstrap nodes from the main tests and prevents it from accidentally connecting to the bootstrap nodes during testing.