### PR TITLE
test: increase receive timeout in tests

### DIFF
--- a/network/network_test.go
+++ b/network/network_test.go
@@ -56,7 +56,7 @@ func testConfig() *Config {
 func shouldReceiveEvent(t *testing.T, net *network, eventType EventType) Event {
 	t.Helper()
 
-	timeout := time.NewTimer(2 * time.Second)
+	timeout := time.NewTimer(4 * time.Second)
 
 	for {
 		select {


### PR DESCRIPTION
## Description

This PR attempts to prevent some random test failures in the network module by increasing the receive timeout. An example of this random failure can be found here: [https://github.com/pactus-project/pactus/actions/runs/7773841154/job/21197991877?pr=1044](https://github.com/pactus-project/pactus/actions/runs/7773841154/job/21197991877?pr=1044).