### PR TITLE
fix(network): prune connections on bootstrap nodes

### DIFF
--- a/network/peermgr.go
+++ b/network/peermgr.go
@@ -148,8 +148,8 @@ func (mgr *peerMgr) CheckConnectivity() {
 				"prune", mgr.pruneLimit)
 
 			network := mgr.host.Network()
-			for peerId := range mgr.peers {
-				_ = network.ClosePeer(peerId)
+			for peerID := range mgr.peers {
+				_ = network.ClosePeer(peerID)
 				num--
 
 				if num < mgr.pruneLimit {


### PR DESCRIPTION
## Description

This PR attempts to free up some connections in bootstrap nodes when the node reaches its limit.
This issue is discussed here: https://github.com/libp2p/go-libp2p/issues/2616