### PR TITLE
feat(gui): add connections and moniker fields to main windows

### DIFF
--- a/cmd/gtk/assets/ui/widget_node.ui
+++ b/cmd/gtk/assets/ui/widget_node.ui
@@ -48,7 +48,7 @@
                 <property name="label-xalign">0.019999999552965164</property>
                 <property name="shadow-type">in</property>
                 <child>
-                  <!-- n-columns=2 n-rows=9 -->
+                  <!-- n-columns=2 n-rows=10 -->
                   <object class="GtkGrid">
                     <property name="width-request">400</property>
                     <property name="visible">True</property>
@@ -104,7 +104,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">5</property>
+                        <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -118,7 +118,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">5</property>
+                        <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -133,7 +133,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">6</property>
+                        <property name="top-attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -147,7 +147,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">6</property>
+                        <property name="top-attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -162,7 +162,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">7</property>
+                        <property name="top-attach">8</property>
                       </packing>
                     </child>
                     <child>
@@ -176,7 +176,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">7</property>
+                        <property name="top-attach">8</property>
                       </packing>
                     </child>
                     <child>
@@ -191,7 +191,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">8</property>
+                        <property name="top-attach">9</property>
                       </packing>
                     </child>
                     <child>
@@ -204,7 +204,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">8</property>
+                        <property name="top-attach">9</property>
                       </packing>
                     </child>
                     <child>
@@ -325,6 +325,36 @@
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="label" translatable="yes">Reachability:</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="id_label_reachability">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="selectable">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">5</property>
                       </packing>
                     </child>
                   </object>

--- a/cmd/gtk/assets/ui/widget_node.ui
+++ b/cmd/gtk/assets/ui/widget_node.ui
@@ -48,7 +48,7 @@
                 <property name="label-xalign">0.019999999552965164</property>
                 <property name="shadow-type">in</property>
                 <child>
-                  <!-- n-columns=2 n-rows=6 -->
+                  <!-- n-columns=2 n-rows=9 -->
                   <object class="GtkGrid">
                     <property name="width-request">400</property>
                     <property name="visible">True</property>
@@ -104,7 +104,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">3</property>
+                        <property name="top-attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -118,7 +118,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">3</property>
+                        <property name="top-attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -133,7 +133,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">4</property>
+                        <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -147,7 +147,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">4</property>
+                        <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -162,7 +162,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">5</property>
+                        <property name="top-attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -176,7 +176,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">5</property>
+                        <property name="top-attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -191,7 +191,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">6</property>
+                        <property name="top-attach">8</property>
                       </packing>
                     </child>
                     <child>
@@ -204,7 +204,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">6</property>
+                        <property name="top-attach">8</property>
                       </packing>
                     </child>
                     <child>
@@ -265,6 +265,66 @@
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="label" translatable="yes">Connections</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="id_label_num_connections">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="selectable">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="label" translatable="yes">Moniker:</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="id_label_moniker">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="selectable">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
                       </packing>
                     </child>
                   </object>

--- a/cmd/gtk/widget_node.go
+++ b/cmd/gtk/widget_node.go
@@ -31,6 +31,7 @@ type widgetNode struct {
 	labelCommitteeStake  *gtk.Label
 	labelTotalStake      *gtk.Label
 	labelNumConnections  *gtk.Label
+	labelReachability    *gtk.Label
 	progressBarSynced    *gtk.ProgressBar
 }
 
@@ -69,6 +70,7 @@ func buildWidgetNode(model *nodeModel) (*widgetNode, error) {
 		labelCommitteeStake:  getLabelObj(builder, "id_label_committee_power"),
 		labelTotalStake:      getLabelObj(builder, "id_label_total_power"),
 		labelNumConnections:  getLabelObj(builder, "id_label_num_connections"),
+		labelReachability:    getLabelObj(builder, "id_label_reachability"),
 	}
 
 	signals := map[string]interface{}{}
@@ -123,6 +125,7 @@ func (wn *widgetNode) timeout10() bool {
 		totalPower := wn.model.node.State().TotalPower()
 		validatorNum := wn.model.node.State().TotalValidators()
 		numConnections := wn.model.node.Network().NumConnectedPeers()
+		reachability := wn.model.node.Network().ReachabilityStatus()
 		isInCommittee := "No"
 		if wn.model.node.ConsManager().HasActiveInstance() {
 			isInCommittee = "Yes"
@@ -135,6 +138,7 @@ func (wn *widgetNode) timeout10() bool {
 			wn.labelTotalStake.SetText(util.ChangeToString(totalPower))
 			wn.labelInCommittee.SetText(isInCommittee)
 			wn.labelNumConnections.SetText(fmt.Sprintf("%v", numConnections))
+			wn.labelReachability.SetText(reachability)
 
 			return false
 		})

--- a/cmd/gtk/widget_node.go
+++ b/cmd/gtk/widget_node.go
@@ -140,7 +140,7 @@ func (wn *widgetNode) timeout10() bool {
 			wn.labelCommitteeStake.SetText(util.ChangeToString(committeePower))
 			wn.labelTotalStake.SetText(util.ChangeToString(totalPower))
 			wn.labelInCommittee.SetText(isInCommittee)
-			wn.labelNumConnections.SetText(fmt.Sprintf("%v", numConnections))
+			wn.labelNumConnections.SetText(numConnections)
 			wn.labelReachability.SetText(reachability)
 
 			return false

--- a/cmd/gtk/widget_node.go
+++ b/cmd/gtk/widget_node.go
@@ -124,7 +124,10 @@ func (wn *widgetNode) timeout10() bool {
 		committeePower := wn.model.node.State().CommitteePower()
 		totalPower := wn.model.node.State().TotalPower()
 		validatorNum := wn.model.node.State().TotalValidators()
-		numConnections := wn.model.node.Network().NumConnectedPeers()
+		numConnections := fmt.Sprintf("%v (Inbound: %v, Outbound %v)",
+			wn.model.node.Network().NumConnectedPeers(),
+			wn.model.node.Network().NumInbound(),
+			wn.model.node.Network().NumOutbound())
 		reachability := wn.model.node.Network().ReachabilityStatus()
 		isInCommittee := "No"
 		if wn.model.node.ConsManager().HasActiveInstance() {

--- a/cmd/gtk/widget_node.go
+++ b/cmd/gtk/widget_node.go
@@ -30,6 +30,7 @@ type widgetNode struct {
 	labelInCommittee     *gtk.Label
 	labelCommitteeStake  *gtk.Label
 	labelTotalStake      *gtk.Label
+	labelNumConnections  *gtk.Label
 	progressBarSynced    *gtk.ProgressBar
 }
 
@@ -43,6 +44,7 @@ func buildWidgetNode(model *nodeModel) (*widgetNode, error) {
 	labelLocation := getLabelObj(builder, "id_label_working_directory")
 	labelNetwork := getLabelObj(builder, "id_label_network")
 	labelNetworkID := getLabelObj(builder, "id_label_network_id")
+	labelMoniker := getLabelObj(builder, "id_label_moniker")
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -51,6 +53,7 @@ func buildWidgetNode(model *nodeModel) (*widgetNode, error) {
 	labelLocation.SetText(cwd)
 	labelNetwork.SetText(model.node.State().Genesis().ChainType().String())
 	labelNetworkID.SetText(model.node.Network().SelfID().String())
+	labelMoniker.SetText(model.node.Sync().Moniker())
 
 	w := &widgetNode{
 		Box:                  box,
@@ -65,6 +68,7 @@ func buildWidgetNode(model *nodeModel) (*widgetNode, error) {
 		labelInCommittee:     getLabelObj(builder, "id_label_in_committee"),
 		labelCommitteeStake:  getLabelObj(builder, "id_label_committee_power"),
 		labelTotalStake:      getLabelObj(builder, "id_label_total_power"),
+		labelNumConnections:  getLabelObj(builder, "id_label_num_connections"),
 	}
 
 	signals := map[string]interface{}{}
@@ -118,6 +122,7 @@ func (wn *widgetNode) timeout10() bool {
 		committeePower := wn.model.node.State().CommitteePower()
 		totalPower := wn.model.node.State().TotalPower()
 		validatorNum := wn.model.node.State().TotalValidators()
+		numConnections := wn.model.node.Network().NumConnectedPeers()
 		isInCommittee := "No"
 		if wn.model.node.ConsManager().HasActiveInstance() {
 			isInCommittee = "Yes"
@@ -129,6 +134,7 @@ func (wn *widgetNode) timeout10() bool {
 			wn.labelCommitteeStake.SetText(util.ChangeToString(committeePower))
 			wn.labelTotalStake.SetText(util.ChangeToString(totalPower))
 			wn.labelInCommittee.SetText(isInCommittee)
+			wn.labelNumConnections.SetText(fmt.Sprintf("%v", numConnections))
 
 			return false
 		})

--- a/network/interface.go
+++ b/network/interface.go
@@ -129,6 +129,8 @@ type Network interface {
 	CloseConnection(pid lp2pcore.PeerID)
 	SelfID() lp2pcore.PeerID
 	NumConnectedPeers() int
+	NumInbound() int
+	NumOutbound() int
 	ReachabilityStatus() string
 	HostAddrs() []string
 	Name() string

--- a/network/mock.go
+++ b/network/mock.go
@@ -142,3 +142,11 @@ func (mock *MockNetwork) Name() string {
 func (mock *MockNetwork) Protocols() []string {
 	return []string{"gossip"}
 }
+
+func (mock *MockNetwork) NumInbound() int {
+	return 0
+}
+
+func (mock *MockNetwork) NumOutbound() int {
+	return 0
+}

--- a/network/network.go
+++ b/network/network.go
@@ -490,3 +490,11 @@ func (n *network) Protocols() []string {
 
 	return protocols
 }
+
+func (n *network) NumInbound() int {
+	return n.peerMgr.NumInbound()
+}
+
+func (n *network) NumOutbound() int {
+	return n.peerMgr.NumOutbound()
+}

--- a/network/peermgr_test.go
+++ b/network/peermgr_test.go
@@ -50,4 +50,7 @@ func TestNumInboundOutbound(t *testing.T) {
 
 	assert.Equal(t, 0, net.peerMgr.NumInbound())
 	assert.Equal(t, 1, net.peerMgr.NumOutbound())
+
+	assert.Equal(t, net.NumInbound(), net.peerMgr.NumInbound())
+	assert.Equal(t, net.NumOutbound(), net.peerMgr.NumOutbound())
 }


### PR DESCRIPTION
## Description

This PR adds new fields to the main window on the GUI: Connections and Moniker. 
"Connections" shows the number of connected peers, and "Moniker" displays the moniker of the node.