### PR TITLE
chore: bumping version to 1.0.2

### DIFF
--- a/docs/patching.md
+++ b/docs/patching.md
@@ -46,9 +46,9 @@ create environment variables for the release version, which will be used in subs
 Keep your terminal open for further steps.
 
 ```bash
-PRV_VER="1.0.0"
-CUR_VER="1.0.1"
-NEXT_VER="1.0.2"
+PRV_VER="1.0.1"
+CUR_VER="1.0.2"
+NEXT_VER="1.0.3"
 TAG_NAME="v${CUR_VER}"
 TAG_MSG="Version ${CUR_VER}"
 BASE_BRANCH="1.0.x"

--- a/version/version.go
+++ b/version/version.go
@@ -11,8 +11,8 @@ import (
 const (
 	major           uint   = 1
 	minor           uint   = 0
-	patch           uint   = 1
-	meta            string = ""
+	patch           uint   = 2
+	meta            string = "beta"
 	protocolVersion uint   = 1
 )
 


### PR DESCRIPTION
Bumping version to 1.0.2