### PR TITLE
fix(network): prevent adding connections with unknown direction to peer manager

### DIFF
--- a/network/notifee.go
+++ b/network/notifee.go
@@ -91,6 +91,12 @@ func (s *NotifeeService) Connected(_ lp2pnetwork.Network, conn lp2pnetwork.Conn)
 	pid := conn.RemotePeer()
 	s.logger.Info("connected to peer", "pid", pid, "direction", conn.Stat().Direction, "addr", conn.RemoteMultiaddr())
 
+	if conn.Stat().Direction == lp2pnetwork.DirUnknown {
+		_ = conn.Close()
+
+		return
+	}
+
 	s.peerMgr.AddPeer(pid, conn.RemoteMultiaddr(), conn.Stat().Direction)
 	s.sendConnectEvent(pid, conn.RemoteMultiaddr(), conn.Stat().Direction)
 }

--- a/network/peermgr.go
+++ b/network/peermgr.go
@@ -84,9 +84,6 @@ func (mgr *peerMgr) AddPeer(pid lp2ppeer.ID, ma multiaddr.Multiaddr,
 
 	case lp2pnet.DirOutbound:
 		mgr.numOutbound++
-
-	case lp2pnet.DirUnknown:
-		return
 	}
 
 	mgr.peers[pid] = &peerInfo{


### PR DESCRIPTION
## Description

We have an unknown direction in lp2ppeer and we need to prevent adding them in connections.

## Related issue(s)

If this Pull Request is related to an issue, mention it here.
- Related #1108 