### PR TITLE
chore: bumping version to 1.0.3

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -11,8 +11,8 @@ import (
 const (
 	major           uint   = 1
 	minor           uint   = 0
-	patch           uint   = 2
-	meta            string = ""
+	patch           uint   = 3
+	meta            string = "beta"
 	protocolVersion uint   = 1
 )
 


### PR DESCRIPTION
Bumping version to 1.0.3