### PR TITLE
fix(wallet): checking args in history add

### DIFF
--- a/cmd/wallet/history.go
+++ b/cmd/wallet/history.go
@@ -25,6 +25,7 @@ func buildAddToHistoryCmd(parentCmd *cobra.Command) {
 	addToHistoryCmd := &cobra.Command{
 		Use:   "add [flags] <ID>",
 		Short: "adds a transaction to the wallet's history.",
+		Args:  cobra.ExactArgs(1),
 	}
 	parentCmd.AddCommand(addToHistoryCmd)
 


### PR DESCRIPTION
## Description

The history add sub-commands needs 1 argument which is the transaction ID. we have to make sure user provides it. otherwise we will panic, which is not a good practice.

## Related issue(s)

- Fixes #1140