### PR TITLE
fix: save Mainnet config with inline comments

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -314,8 +314,8 @@ func CreateNode(numValidators int, chain genesis.ChainType, workingDir string,
 		if err := genDoc.SaveToFile(genPath); err != nil {
 			return nil, nil, err
 		}
-		conf := config.DefaultConfigMainnet()
-		if err := conf.Save(confPath); err != nil {
+		err := config.SaveMainnetConfig(confPath)
+		if err != nil {
 			return nil, nil, err
 		}
 	case genesis.Testnet:

--- a/config/example_config.toml
+++ b/config/example_config.toml
@@ -80,9 +80,9 @@
   # `moniker` is a custom human-readable name for this node.
  ## moniker = ""
 
-  # `session_timeout` is a timeout for a download session to keep open.
-  # By sending a block download request, this timer starts and if there is no activity from the Node
-  # the session will get closed and try to get the block from another Node.
+  # `session_timeout` is a timeout for a download session to remain open.
+  # When a block download request is sent, this timer starts. If there is no activity from the target Node,
+  # the session will be closed after the timeout and try to get the block from another Node.
   # Default is `10s`.
  ## session_timeout = "10s"
 

--- a/config/example_config.toml
+++ b/config/example_config.toml
@@ -80,7 +80,9 @@
   # `moniker` is a custom human-readable name for this node.
  ## moniker = ""
 
-  # `session_timeout` is a timeout for a session to be opened.
+  # `session_timeout` is a timeout for a download session to keep open.
+  # By sending a block download request, this timer starts and if there is no activity from the Node
+  # the session will get closed and try to get the block from another Node.
   # Default is `10s`.
  ## session_timeout = "10s"
 
@@ -141,7 +143,7 @@
 [grpc]
 
   # `enable` indicates whether gRPC service should be enabled or not.
-  # Default is `false`.
+  # Default is `true`.
  ## enable = true
 
   # `enable_wallet` indicates whether Wallet service should be enabled or not.


### PR DESCRIPTION
## Description

This PR saves the Mainet configs with the in-line comments upon creating the node.