### PR TITLE
chore: remove funlen from .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -127,10 +127,8 @@ linters-settings:
 
 issues:
   exclude-rules:
-    # disable funlen for all _test.go files
     - path: _test.go
       linters:
-        - funlen
         - maintidx
         - nestif
         - gocognit


### PR DESCRIPTION
## Description

Removing unused `funlen` from `.golangci.yml`