### PR TITLE
fix: add error type for invalid configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/pactus-project/pactus/consensus"
@@ -13,7 +14,6 @@ import (
 	"github.com/pactus-project/pactus/sync"
 	"github.com/pactus-project/pactus/txpool"
 	"github.com/pactus-project/pactus/util"
-	"github.com/pactus-project/pactus/util/errors"
 	"github.com/pactus-project/pactus/util/logger"
 	"github.com/pactus-project/pactus/www/grpc"
 	"github.com/pactus-project/pactus/www/http"
@@ -62,11 +62,15 @@ func (conf *NodeConfig) BasicCheck() error {
 	for _, addrStr := range conf.RewardAddresses {
 		addr, err := crypto.AddressFromString(addrStr)
 		if err != nil {
-			return errors.Errorf(errors.ErrInvalidConfig, "invalid reward address: %v", err.Error())
+			return ConfigError{
+				Reason: fmt.Sprintf("invalid reward address: %v", err.Error()),
+			}
 		}
 
 		if !addr.IsAccountAddress() {
-			return errors.Errorf(errors.ErrInvalidConfig, "reward address is not an account address: %s", addrStr)
+			return ConfigError{
+				Reason: fmt.Sprintf("reward address is not an account address: %s", addrStr),
+			}
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -62,13 +62,13 @@ func (conf *NodeConfig) BasicCheck() error {
 	for _, addrStr := range conf.RewardAddresses {
 		addr, err := crypto.AddressFromString(addrStr)
 		if err != nil {
-			return ConfigError{
+			return Error{
 				Reason: fmt.Sprintf("invalid reward address: %v", err.Error()),
 			}
 		}
 
 		if !addr.IsAccountAddress() {
-			return ConfigError{
+			return Error{
 				Reason: fmt.Sprintf("reward address is not an account address: %s", addrStr),
 			}
 		}

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,6 +1,6 @@
 package config
 
-// ConfigError is returned when the store configuration is invalid.
+// ConfigError is returned when the config configuration is invalid.
 type ConfigError struct {
 	Reason string
 }

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,10 +1,10 @@
 package config
 
-// ConfigError is returned when the config configuration is invalid.
-type ConfigError struct {
+// Error is returned when the config configuration is invalid.
+type Error struct {
 	Reason string
 }
 
-func (e ConfigError) Error() string {
+func (e Error) Error() string {
 	return e.Reason
 }

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,0 +1,10 @@
+package config
+
+// ConfigError is returned when the store configuration is invalid.
+type ConfigError struct {
+	Reason string
+}
+
+func (e ConfigError) Error() string {
+	return e.Reason
+}

--- a/store/config.go
+++ b/store/config.go
@@ -37,7 +37,7 @@ func (conf *Config) StorePath() string {
 // BasicCheck performs basic checks on the configuration.
 func (conf *Config) BasicCheck() error {
 	if !util.IsValidDirPath(conf.Path) {
-		return InvalidConfigError{
+		return ConfigError{
 			Reason: "path is not valid",
 		}
 	}
@@ -46,7 +46,7 @@ func (conf *Config) BasicCheck() error {
 		conf.SortitionCacheSize == 0 ||
 		conf.AccountCacheSize == 0 ||
 		conf.PublicKeyCacheSize == 0 {
-		return InvalidConfigError{
+		return ConfigError{
 			Reason: "cache size set to zero",
 		}
 	}

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -13,7 +13,7 @@ func TestDefaultConfigCheck(t *testing.T) {
 
 	conf.TxCacheSize = 0
 	err := conf.BasicCheck()
-	assert.ErrorIs(t, InvalidConfigError{"cache size set to zero"}, err)
+	assert.ErrorIs(t, ConfigError{"cache size set to zero"}, err)
 
 	conf.TxCacheSize = 1
 	err = conf.BasicCheck()

--- a/store/errors.go
+++ b/store/errors.go
@@ -6,12 +6,12 @@ import (
 	"github.com/pactus-project/pactus/crypto"
 )
 
-// InvalidConfigError is returned when the store configuration is invalid.
-type InvalidConfigError struct {
+// ConfigError is returned when the store configuration is invalid.
+type ConfigError struct {
 	Reason string
 }
 
-func (e InvalidConfigError) Error() string {
+func (e ConfigError) Error() string {
 	return e.Reason
 }
 

--- a/txpool/config.go
+++ b/txpool/config.go
@@ -17,6 +17,7 @@ func (conf *Config) BasicCheck() error {
 			Reason: "maxSize can't be negative or zero",
 		}
 	}
+	
 	return nil
 }
 

--- a/txpool/config.go
+++ b/txpool/config.go
@@ -17,7 +17,7 @@ func (conf *Config) BasicCheck() error {
 			Reason: "maxSize can't be negative or zero",
 		}
 	}
-	
+
 	return nil
 }
 

--- a/txpool/config.go
+++ b/txpool/config.go
@@ -1,9 +1,5 @@
 package txpool
 
-import (
-	"github.com/pactus-project/pactus/util/errors"
-)
-
 type Config struct {
 	MaxSize int `toml:"max_size"`
 }
@@ -17,9 +13,10 @@ func DefaultConfig() *Config {
 // BasicCheck performs basic checks on the configuration.
 func (conf *Config) BasicCheck() error {
 	if conf.MaxSize == 0 {
-		return errors.Errorf(errors.ErrInvalidConfig, "maxSize can't be negative or zero")
+		return ConfigError{
+			Reason: "maxSize can't be negative or zero",
+		}
 	}
-
 	return nil
 }
 

--- a/txpool/errors.go
+++ b/txpool/errors.go
@@ -1,6 +1,6 @@
 package txpool
 
-// ConfigError is returned when the store configuration is invalid.
+// ConfigError is returned when the txpool configuration is invalid.
 type ConfigError struct {
 	Reason string
 }

--- a/txpool/errors.go
+++ b/txpool/errors.go
@@ -1,0 +1,10 @@
+package txpool
+
+// ConfigError is returned when the store configuration is invalid.
+type ConfigError struct {
+	Reason string
+}
+
+func (e ConfigError) Error() string {
+	return e.Reason
+}

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -22,7 +22,6 @@ const (
 	ErrInvalidProposal
 	ErrInvalidVote
 	ErrInvalidMessage
-	ErrInvalidConfig
 	ErrDuplicateVote
 
 	ErrCount
@@ -46,7 +45,6 @@ var messages = map[int]string{
 	ErrInvalidProposal:   "invalid proposal",
 	ErrInvalidVote:       "invalid vote",
 	ErrInvalidMessage:    "invalid message",
-	ErrInvalidConfig:     "invalid config",
 	ErrDuplicateVote:     "duplicate vote",
 }
 


### PR DESCRIPTION
## Description

This PR defines `ConfigError` type for internal modules.

## Related issue(s)
It partially fixes issue #315 
