### PR TITLE
fix(gRPC): pactus swagger not found

### DIFF
--- a/www/grpc/gateway.go
+++ b/www/grpc/gateway.go
@@ -80,7 +80,7 @@ func (s *Server) startGateway(grpcAddr string) error {
 		Addr:              s.config.Gateway.Listen,
 		ReadHeaderTimeout: 3 * time.Second,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, "/pactus") {
+			if strings.HasPrefix(r.URL.Path, "/pactus/") {
 				gwMux.ServeHTTP(w, r)
 
 				return


### PR DESCRIPTION
## Description

This PR fixs `pactus.swagger.json` no found issue on gRPC gateway.