### PR TITLE
feat(GUI): memo field for transactions on GUI wallet

### DIFF
--- a/cmd/gtk/assets/ui/dialog_transaction_bond.ui
+++ b/cmd/gtk/assets/ui/dialog_transaction_bond.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkDialog" id="id_dialog_transaction_bond">
@@ -220,12 +220,51 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Amount:</property>
+                <property name="label" translatable="yes">Memo:</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">11</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="id_entry_memo">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="width-chars">32</property>
+                <property name="caps-lock-warning">False</property>
+                <property name="input-purpose">number</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">12</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">13</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Amount:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">14</property>
               </packing>
             </child>
             <child>
@@ -241,7 +280,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">12</property>
+                <property name="position">15</property>
               </packing>
             </child>
             <child>
@@ -254,7 +293,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">13</property>
+                <property name="position">16</property>
               </packing>
             </child>
           </object>

--- a/cmd/gtk/assets/ui/dialog_transaction_transfer.ui
+++ b/cmd/gtk/assets/ui/dialog_transaction_transfer.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkDialog" id="id_dialog_transaction_transfer">
@@ -180,12 +180,50 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Amount:</property>
+                <property name="label" translatable="yes">Memo:</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">8</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="id_entry_memo">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="width-chars">32</property>
+                <property name="caps-lock-warning">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">9</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">10</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Amount:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">11</property>
               </packing>
             </child>
             <child>
@@ -201,7 +239,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">9</property>
+                <property name="position">12</property>
               </packing>
             </child>
             <child>
@@ -214,7 +252,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">10</property>
+                <property name="position">13</property>
               </packing>
             </child>
           </object>

--- a/cmd/gtk/assets/ui/dialog_transaction_unbond.ui
+++ b/cmd/gtk/assets/ui/dialog_transaction_unbond.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkDialog" id="id_dialog_transaction_unbond">
@@ -105,7 +105,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">5</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -117,7 +117,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">6</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -128,7 +128,47 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">7</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Memo:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="id_entry_memo">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="width-chars">32</property>
+                <property name="caps-lock-warning">False</property>
+                <property name="input-purpose">number</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">start</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">6</property>
               </packing>
             </child>
           </object>

--- a/cmd/gtk/assets/ui/dialog_transaction_withdraw.ui
+++ b/cmd/gtk/assets/ui/dialog_transaction_withdraw.ui
@@ -1,7 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
+  <object class="GtkRecentChooserDialog">
+    <property name="can-focus">False</property>
+    <property name="type-hint">dialog</property>
+    <property name="limit">20</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
   <object class="GtkDialog" id="id_dialog_transaction_withdraw">
     <property name="width-request">600</property>
     <property name="can-focus">False</property>
@@ -173,11 +202,39 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Memo:</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="id_entry_memo">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="width-chars">32</property>
+                <property name="caps-lock-warning">False</property>
+                <property name="input-purpose">number</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">8</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">9</property>
               </packing>
             </child>
             <child>
@@ -190,7 +247,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">8</property>
+                <property name="position">10</property>
               </packing>
             </child>
             <child>
@@ -206,7 +263,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">9</property>
+                <property name="position">11</property>
               </packing>
             </child>
             <child>
@@ -219,7 +276,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">10</property>
+                <property name="position">12</property>
               </packing>
             </child>
           </object>

--- a/cmd/gtk/dialog_transaction_bond.go
+++ b/cmd/gtk/dialog_transaction_bond.go
@@ -28,6 +28,7 @@ func broadcastTransactionBond(wlt *wallet.Wallet) {
 	publicKeyEntry := getEntryObj(builder, "id_entry_public_key")
 	amountEntry := getEntryObj(builder, "id_entry_amount")
 	amountHint := getLabelObj(builder, "id_hint_amount")
+	memoEntry := getEntryObj(builder, "id_entry_memo")
 	getButtonObj(builder, "id_button_cancel").SetImage(CancelIcon())
 	getButtonObj(builder, "id_button_send").SetImage(SendIcon())
 
@@ -63,6 +64,7 @@ func broadcastTransactionBond(wlt *wallet.Wallet) {
 		receiver, _ := receiverEntry.GetText()
 		publicKey, _ := publicKeyEntry.GetText()
 		amountStr, _ := amountEntry.GetText()
+		memo, _ := memoEntry.GetText()
 
 		amt, err := amount.FromString(amountStr)
 		if err != nil {
@@ -71,7 +73,11 @@ func broadcastTransactionBond(wlt *wallet.Wallet) {
 			return
 		}
 
-		trx, err := wlt.MakeBondTx(sender, receiver, publicKey, amt)
+		opts := []wallet.TxOption{
+			wallet.OptionMemo(memo),
+		}
+
+		trx, err := wlt.MakeBondTx(sender, receiver, publicKey, amt, opts...)
 		if err != nil {
 			errorCheck(err)
 
@@ -83,10 +89,11 @@ You are going to sign and broadcast this transaction:
 From:   %s
 To:     %s
 Amount: %s
+Memo:   %s
 Fee:    %s
 
 THIS ACTION IS NOT REVERSIBLE. Do you want to continue?`,
-			sender, receiver, amt, trx.Fee())
+			sender, receiver, amt, trx.Memo(), trx.Fee())
 
 		signAndBroadcastTransaction(dlg, msg, wlt, trx)
 

--- a/cmd/gtk/dialog_transaction_transfer.go
+++ b/cmd/gtk/dialog_transaction_transfer.go
@@ -27,6 +27,7 @@ func broadcastTransactionTransfer(wlt *wallet.Wallet) {
 	receiverHint := getLabelObj(builder, "id_hint_receiver")
 	amountEntry := getEntryObj(builder, "id_entry_amount")
 	amountHint := getLabelObj(builder, "id_hint_amount")
+	memoEntry := getEntryObj(builder, "id_entry_memo")
 	getButtonObj(builder, "id_button_cancel").SetImage(CancelIcon())
 	getButtonObj(builder, "id_button_send").SetImage(SendIcon())
 
@@ -54,6 +55,7 @@ func broadcastTransactionTransfer(wlt *wallet.Wallet) {
 		sender := senderEntry.GetActiveID()
 		receiver, _ := receiverEntry.GetText()
 		amountStr, _ := amountEntry.GetText()
+		memo, _ := memoEntry.GetText()
 
 		amt, err := amount.FromString(amountStr)
 		if err != nil {
@@ -62,7 +64,11 @@ func broadcastTransactionTransfer(wlt *wallet.Wallet) {
 			return
 		}
 
-		trx, err := wlt.MakeTransferTx(sender, receiver, amt)
+		opts := []wallet.TxOption{
+			wallet.OptionMemo(memo),
+		}
+
+		trx, err := wlt.MakeTransferTx(sender, receiver, amt, opts...)
 		if err != nil {
 			errorCheck(err)
 
@@ -74,10 +80,11 @@ You are going to sign and broadcast this transaction:
 From:   %s
 To:     %s
 Amount: %s
+Memo:   %s
 Fee:    %s
 
 THIS ACTION IS NOT REVERSIBLE. Do you want to continue?`,
-			sender, receiver, amt, trx.Fee())
+			sender, receiver, amt, trx.Memo(), trx.Fee())
 
 		signAndBroadcastTransaction(dlg, msg, wlt, trx)
 

--- a/cmd/gtk/dialog_transaction_unbond.go
+++ b/cmd/gtk/dialog_transaction_unbond.go
@@ -21,6 +21,7 @@ func broadcastTransactionUnbond(wlt *wallet.Wallet) {
 
 	validatorCombo := getComboBoxTextObj(builder, "id_combo_validator")
 	validatorHint := getLabelObj(builder, "id_hint_validator")
+	memoEntry := getEntryObj(builder, "id_entry_memo")
 	getButtonObj(builder, "id_button_cancel").SetImage(CancelIcon())
 	getButtonObj(builder, "id_button_send").SetImage(SendIcon())
 
@@ -37,8 +38,13 @@ func broadcastTransactionUnbond(wlt *wallet.Wallet) {
 	onSend := func() {
 		validatorEntry, _ := validatorCombo.GetEntry()
 		validator, _ := validatorEntry.GetText()
+		memo, _ := memoEntry.GetText()
 
-		trx, err := wlt.MakeUnbondTx(validator)
+		opts := []wallet.TxOption{
+			wallet.OptionMemo(memo),
+		}
+
+		trx, err := wlt.MakeUnbondTx(validator, opts...)
 		if err != nil {
 			errorCheck(err)
 
@@ -48,8 +54,9 @@ func broadcastTransactionUnbond(wlt *wallet.Wallet) {
 You are going to sign and broadcast this transaction:
 
 Validator: %s
+Memo:      %s
 
-THIS ACTION IS NOT REVERSIBLE. Do you want to continue?`, validator)
+THIS ACTION IS NOT REVERSIBLE. Do you want to continue?`, validator, trx.Memo())
 
 		signAndBroadcastTransaction(dlg, msg, wlt, trx)
 


### PR DESCRIPTION
## Description

With these changes, users can use the memo option in the GUI wallet. so, the applications that use memos for any reason can be able for GUI wallet users too.


> @b00f, I've just made this PR and closed the previous one.