### PR TITLE
feat(GUI): showing transaction hash after broadcasting transaction

### DIFF
--- a/cmd/gtk/utils.go
+++ b/cmd/gtk/utils.go
@@ -202,7 +202,7 @@ func signAndBroadcastTransaction(parent *gtk.Dialog, msg string, w *wallet.Walle
 
 			return
 		}
-		_, err = w.BroadcastTransaction(trx)
+		txID, err := w.BroadcastTransaction(trx)
 		if err != nil {
 			errorCheck(err)
 
@@ -215,6 +215,8 @@ func signAndBroadcastTransaction(parent *gtk.Dialog, msg string, w *wallet.Walle
 
 			return
 		}
+
+		showInfoDialog(parent, fmt.Sprintf("Your transaction Hash: %s", txID))
 	}
 }
 


### PR DESCRIPTION
## Description

The GUI Users can see the transaction hash while it sent to the network and they can track it on Explorer or their node.
 