### PR TITLE
chore: adding pre-commit rule to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,12 @@ fmt:
 check:
 	golangci-lint run --build-tags "${BUILD_TAG}" --timeout=20m0s
 
+check_gui:
+	BUILD_TAG=gtk make check
+
+pre_commit: fmt unit_test build check check_gui
+	@echo "pre-commit commands execution done; let's launch the rocket!"
+
 # To avoid unintended conflicts with file names, always add to .PHONY
 # unless there is a reason not to.
 # https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html


### PR DESCRIPTION
## Description

We can use this MakeFile rule to avoid issues caused by forgetting to run these commands before making a PR.