### PR TITLE
refactor: move fee calculation logic to execution package 

### DIFF
--- a/execution/errors.go
+++ b/execution/errors.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"fmt"
 
+	"github.com/pactus-project/pactus/types/amount"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 )
@@ -39,7 +40,7 @@ type PastLockTimeError struct {
 }
 
 func (e PastLockTimeError) Error() string {
-	return fmt.Sprintf("Transaction's lock time is in the past: %v", e.LockTime)
+	return fmt.Sprintf("lock time is in the past: %v", e.LockTime)
 }
 
 // FutureLockTimeError is returned when the lock time of a transaction
@@ -50,5 +51,15 @@ type FutureLockTimeError struct {
 }
 
 func (e FutureLockTimeError) Error() string {
-	return fmt.Sprintf("Transaction's lock time is in the future: %v", e.LockTime)
+	return fmt.Sprintf("lock time is in the future: %v", e.LockTime)
+}
+
+// InvalidFeeError is returned when the transaction fee is not valid.
+type InvalidFeeError struct {
+	Fee      amount.Amount
+	Expected amount.Amount
+}
+
+func (e InvalidFeeError) Error() string {
+	return fmt.Sprintf("fee is invalid, expected: %s, got: %s", e.Expected, e.Fee)
 }

--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -235,7 +235,7 @@ func TestFee(t *testing.T) {
 		amount      amount.Amount
 		fee         amount.Amount
 		expectedFee amount.Amount
-		expectedErr bool
+		expectErr   bool
 	}{
 		{1, 1, sb.TestParams.MinimumFee, true},
 		{1, 1002, sb.TestParams.MinimumFee, true},
@@ -269,7 +269,7 @@ func TestFee(t *testing.T) {
 			"testing fee")
 		err := exe.checkFee(trx, sb)
 
-		if test.expectedErr {
+		if test.expectErr {
 			assert.Error(t, err, "test %v failed. expected error", i)
 		} else {
 			assert.NoError(t, err, "test %v failed. unexpected error", i)

--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pactus-project/pactus/sandbox"
 	"github.com/pactus-project/pactus/types/amount"
 	"github.com/pactus-project/pactus/types/tx"
+	"github.com/pactus-project/pactus/types/tx/payload"
 	"github.com/pactus-project/pactus/util/errors"
 	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
@@ -137,29 +138,35 @@ func TestExecution(t *testing.T) {
 	t.Run("Invalid fee, Should returns error", func(t *testing.T) {
 		trx := tx.NewTransferTx(lockTime, rndAccAddr, ts.RandAccAddress(), 1000, 1, "invalid fee")
 		ts.HelperSignTransaction(rndPrvKey, trx)
-		err := exe.Execute(trx, sb)
-		assert.Equal(t, errors.Code(err), errors.ErrInvalidFee)
+
+		expectedErr := InvalidFeeError{Fee: 1, Expected: sb.TestParams.MinimumFee}
+		assert.ErrorIs(t, exe.Execute(trx, sb), expectedErr)
+		assert.ErrorIs(t, exe.checkFee(trx, sb), expectedErr)
 	})
 
 	t.Run("Invalid fee, Should returns error", func(t *testing.T) {
 		trx := tx.NewTransferTx(lockTime, rndAccAddr, ts.RandAccAddress(), 1000, 1002, "invalid fee")
 		ts.HelperSignTransaction(rndPrvKey, trx)
-		err := exe.Execute(trx, sb)
-		assert.Equal(t, errors.Code(err), errors.ErrInvalidFee)
+
+		expectedErr := InvalidFeeError{Fee: 1002, Expected: sb.TestParams.MinimumFee}
+		assert.ErrorIs(t, exe.Execute(trx, sb), expectedErr)
+		assert.ErrorIs(t, exe.checkFee(trx, sb), expectedErr)
 	})
 
 	t.Run("Invalid fee (subsidy tx), Should returns error", func(t *testing.T) {
 		trx := tx.NewTransferTx(lockTime, crypto.TreasuryAddress, ts.RandAccAddress(), 1000, 1, "invalid fee")
-		err := exe.Execute(trx, sb)
-		assert.Equal(t, errors.Code(err), errors.ErrInvalidFee)
-		assert.Error(t, exe.checkFee(trx, sb))
+
+		expectedErr := InvalidFeeError{Fee: 1, Expected: 0}
+		assert.ErrorIs(t, exe.Execute(trx, sb), expectedErr)
+		assert.ErrorIs(t, exe.checkFee(trx, sb), expectedErr)
 	})
 
-	t.Run("Invalid fee (send tx), Should returns error", func(t *testing.T) {
+	t.Run("Invalid fee (transfer tx), Should returns error", func(t *testing.T) {
 		trx := tx.NewTransferTx(lockTime, rndAccAddr, ts.RandAccAddress(), 1000, 0, "invalid fee")
-		err := exe.Execute(trx, sb)
-		assert.Equal(t, errors.Code(err), errors.ErrInvalidFee)
-		assert.Error(t, exe.checkFee(trx, sb))
+
+		expectedErr := InvalidFeeError{Fee: 0, Expected: sb.TestParams.MinimumFee}
+		assert.ErrorIs(t, exe.Execute(trx, sb), expectedErr)
+		assert.ErrorIs(t, exe.checkFee(trx, sb), expectedErr)
 	})
 
 	t.Run("Execution failed", func(t *testing.T) {
@@ -225,33 +232,34 @@ func TestFee(t *testing.T) {
 	sb := sandbox.MockingSandbox(ts)
 
 	tests := []struct {
-		amount          amount.Amount
-		fee             amount.Amount
-		expectedFee     amount.Amount
-		expectedErrCode int
+		amount      amount.Amount
+		fee         amount.Amount
+		expectedFee amount.Amount
+		expectedErr bool
 	}{
-		{1, 1, sb.TestParams.MinimumFee, errors.ErrInvalidFee},
-		{1, 1002, sb.TestParams.MinimumFee, errors.ErrInvalidFee},
-		{1, 998, sb.TestParams.MinimumFee, errors.ErrInvalidFee},
-		{1, 1001, sb.TestParams.MinimumFee, errors.ErrNone},
-		{1, 1000, sb.TestParams.MinimumFee, errors.ErrNone},
-		{1, 999, sb.TestParams.MinimumFee, errors.ErrNone},
+		{1, 1, sb.TestParams.MinimumFee, true},
+		{1, 1002, sb.TestParams.MinimumFee, true},
+		{1, 998, sb.TestParams.MinimumFee, true},
 
-		{1 * 1e9, 1, 100000, errors.ErrInvalidFee},
-		{1 * 1e9, 100002, 100000, errors.ErrInvalidFee},
-		{1 * 1e9, 99998, 100000, errors.ErrInvalidFee},
-		{1 * 1e9, 100001, 100000, errors.ErrNone},
-		{1 * 1e9, 100000, 100000, errors.ErrNone},
-		{1 * 1e9, 99999, 100000, errors.ErrNone},
+		{1, 1001, sb.TestParams.MinimumFee, false},
+		{1, 1000, sb.TestParams.MinimumFee, false},
+		{1, 999, sb.TestParams.MinimumFee, false},
 
-		{1 * 1e12, 1, sb.TestParams.MaximumFee, errors.ErrInvalidFee},
-		{1 * 1e12, 1000002, sb.TestParams.MaximumFee, errors.ErrInvalidFee},
-		{1 * 1e12, 999998, sb.TestParams.MaximumFee, errors.ErrInvalidFee},
-		{1 * 1e12, 1000001, sb.TestParams.MaximumFee, errors.ErrNone},
-		{1 * 1e12, 1000000, sb.TestParams.MaximumFee, errors.ErrNone},
-		{1 * 1e12, 999999, sb.TestParams.MaximumFee, errors.ErrNone},
+		{2 * 1e9, 100002, 200000, true},
+		{2 * 1e9, 99998, 200000, true},
 
-		{9_999_299_000, 999929, 999930, errors.ErrNone}, // Block 66679
+		{2 * 1e9, 200001, 200000, false},
+		{2 * 1e9, 200000, 200000, false},
+		{2 * 1e9, 199999, 200000, false},
+
+		{1 * 1e12, 1000002, sb.TestParams.MaximumFee, true},
+		{1 * 1e12, 999998, sb.TestParams.MaximumFee, true},
+
+		{1 * 1e12, 1000001, sb.TestParams.MaximumFee, false},
+		{1 * 1e12, 1000000, sb.TestParams.MaximumFee, false},
+		{1 * 1e12, 999999, sb.TestParams.MaximumFee, false},
+
+		{9_999_299_000, 999929, 999930, false}, // Block 66679
 	}
 
 	sender := ts.RandAccAddress()
@@ -261,10 +269,13 @@ func TestFee(t *testing.T) {
 			"testing fee")
 		err := exe.checkFee(trx, sb)
 
-		assert.Equal(t, errors.Code(err), test.expectedErrCode,
-			"test %v failed. unexpected error", i)
+		if test.expectedErr {
+			assert.Error(t, err, "test %v failed. expected error", i)
+		} else {
+			assert.NoError(t, err, "test %v failed. unexpected error", i)
+		}
 
-		assert.Equal(t, CalculateFee(test.amount, sb.Params()), test.expectedFee,
-			"test %v failed. invalid fee", i)
+		expectedFee := CalculateFee(test.amount, payload.TypeTransfer, sb.Params())
+		assert.Equal(t, expectedFee, test.expectedFee, "test %v failed. invalid fee", i)
 	}
 }

--- a/state/mock.go
+++ b/state/mock.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/bls"
 	"github.com/pactus-project/pactus/crypto/hash"
+	"github.com/pactus-project/pactus/execution"
 	"github.com/pactus-project/pactus/genesis"
 	"github.com/pactus-project/pactus/store"
 	"github.com/pactus-project/pactus/txpool"
@@ -254,8 +255,8 @@ func (m *MockState) Params() *param.Params {
 	return m.TestParams
 }
 
-func (m *MockState) CalculateFee(amt amount.Amount, _ payload.Type) amount.Amount {
-	return amt.MulF64(m.TestParams.FeeFraction)
+func (m *MockState) CalculateFee(amt amount.Amount, payloadType payload.Type) amount.Amount {
+	return execution.CalculateFee(amt, payloadType, m.TestParams)
 }
 
 func (m *MockState) PublicKey(addr crypto.Address) (crypto.PublicKey, error) {

--- a/state/state.go
+++ b/state/state.go
@@ -773,21 +773,7 @@ func (st *state) publishEvents(height uint32, blk *block.Block) {
 }
 
 func (st *state) CalculateFee(amt amount.Amount, payloadType payload.Type) amount.Amount {
-	switch payloadType {
-	case payload.TypeTransfer,
-		payload.TypeBond,
-		payload.TypeWithdraw:
-
-		return execution.CalculateFee(amt, st.params)
-
-	case payload.TypeUnbond,
-		payload.TypeSortition:
-
-		return 0
-
-	default:
-		return 0
-	}
+	return execution.CalculateFee(amt, payloadType, st.params)
 }
 
 func (st *state) PublicKey(addr crypto.Address) (crypto.PublicKey, error) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pactus-project/pactus/store"
 	"github.com/pactus-project/pactus/txpool"
 	"github.com/pactus-project/pactus/types/account"
-	"github.com/pactus-project/pactus/types/amount"
 	"github.com/pactus-project/pactus/types/block"
 	"github.com/pactus-project/pactus/types/certificate"
 	"github.com/pactus-project/pactus/types/param"
@@ -598,39 +597,6 @@ func TestIsValidator(t *testing.T) {
 	assert.False(t, td.state.IsProposer(addr, 0))
 	assert.False(t, td.state.IsInCommittee(addr))
 	assert.False(t, td.state.IsValidator(addr))
-}
-
-func TestCalcFee(t *testing.T) {
-	td := setup(t)
-
-	tests := []struct {
-		amt         amount.Amount
-		pldType     payload.Type
-		expectedFee amount.Amount
-	}{
-		{0, payload.TypeTransfer, td.state.params.MinimumFee},
-		{0, payload.TypeWithdraw, td.state.params.MinimumFee},
-		{0, payload.TypeBond, td.state.params.MinimumFee},
-
-		{1, payload.TypeTransfer, td.state.params.MinimumFee},
-		{1, payload.TypeWithdraw, td.state.params.MinimumFee},
-		{1, payload.TypeBond, td.state.params.MinimumFee},
-
-		{1 * 1e9, payload.TypeTransfer, 100000},
-		{1 * 1e9, payload.TypeWithdraw, 100000},
-		{1 * 1e9, payload.TypeBond, 100000},
-
-		{1 * 1e12, payload.TypeTransfer, 1000000},
-		{1 * 1e12, payload.TypeWithdraw, 1000000},
-		{1 * 1e12, payload.TypeBond, 1000000},
-
-		{1 * 1e12, payload.TypeSortition, 0},
-		{1 * 1e12, payload.TypeUnbond, 0},
-	}
-	for _, test := range tests {
-		fee := td.state.CalculateFee(test.amt, test.pldType)
-		assert.Equal(t, test.expectedFee, fee)
-	}
 }
 
 func TestInvalidPayloadFee(t *testing.T) {

--- a/types/tx/tx.go
+++ b/types/tx/tx.go
@@ -422,11 +422,6 @@ func (tx *Tx) IsWithdrawTx() bool {
 	return tx.Payload().Type() == payload.TypeWithdraw
 }
 
-// IsFreeTx will checks if transaction fee is 0.
-func (tx *Tx) IsFreeTx() bool {
-	return tx.IsSubsidyTx() || tx.IsSortitionTx() || tx.IsUnbondTx()
-}
-
 // StripPublicKey removes the public key from the transaction.
 // It is an alias function for `SetPublicKey(nil)`.
 func (tx *Tx) StripPublicKey() {

--- a/types/tx/tx_test.go
+++ b/types/tx/tx_test.go
@@ -44,12 +44,6 @@ func TestEncodingTx(t *testing.T) {
 	assert.True(t, trx4.IsWithdrawTx())
 	assert.True(t, trx5.IsSortitionTx())
 
-	assert.False(t, trx1.IsFreeTx())
-	assert.False(t, trx2.IsFreeTx())
-	assert.True(t, trx3.IsFreeTx())
-	assert.False(t, trx4.IsFreeTx())
-	assert.True(t, trx5.IsFreeTx())
-
 	tests := []*tx.Tx{trx1, trx2, trx3, trx4, trx5}
 	for _, trx := range tests {
 		assert.NoError(t, trx.BasicCheck())

--- a/types/vote/errors.go
+++ b/types/vote/errors.go
@@ -23,6 +23,6 @@ type InvalidSignerError struct {
 }
 
 func (e InvalidSignerError) Error() string {
-	return fmt.Sprintf("invalid signer: expected: %s, got: %s",
+	return fmt.Sprintf("invalid signer, expected: %s, got: %s",
 		e.Expected.String(), e.Got.String())
 }

--- a/util/errors/errors.go
+++ b/util/errors/errors.go
@@ -9,13 +9,11 @@ const (
 	ErrGeneric
 	ErrInvalidBlock
 	ErrInvalidAmount
-	ErrInvalidFee
 	ErrInvalidAddress
 	ErrInvalidPublicKey
 	ErrInvalidPrivateKey
 	ErrInvalidSignature
 	ErrInvalidTx
-	ErrInvalidMemo
 	ErrInvalidProof
 	ErrInvalidHeight
 	ErrInvalidRound
@@ -32,13 +30,11 @@ var messages = map[int]string{
 	ErrGeneric:           "generic error",
 	ErrInvalidBlock:      "invalid block",
 	ErrInvalidAmount:     "invalid amount",
-	ErrInvalidFee:        "invalid fee",
 	ErrInvalidAddress:    "invalid address",
 	ErrInvalidPublicKey:  "invalid public key",
 	ErrInvalidPrivateKey: "invalid private key",
 	ErrInvalidSignature:  "invalid signature",
 	ErrInvalidTx:         "invalid transaction",
-	ErrInvalidMemo:       "invalid memo",
 	ErrInvalidProof:      "invalid proof",
 	ErrInvalidHeight:     "invalid height",
 	ErrInvalidRound:      "invalid round",

--- a/www/grpc/transaction.go
+++ b/www/grpc/transaction.go
@@ -83,11 +83,7 @@ func (s *transactionServer) BroadcastTransaction(_ context.Context,
 func (s *transactionServer) CalculateFee(_ context.Context,
 	req *pactus.CalculateFeeRequest,
 ) (*pactus.CalculateFeeResponse, error) {
-	amt, err := s.getAmount(req.Amount)
-	if err != nil {
-		return nil, err
-	}
-
+	amt := amount.Amount(req.Amount)
 	fee := s.state.CalculateFee(amt, payload.Type(req.PayloadType))
 
 	if req.FixedAmount {

--- a/www/grpc/transaction.go
+++ b/www/grpc/transaction.go
@@ -109,11 +109,7 @@ func (s *transactionServer) GetRawTransferTransaction(_ context.Context,
 		return nil, err
 	}
 
-	amt, err := s.getAmount(req.Amount)
-	if err != nil {
-		return nil, err
-	}
-
+	amt := amount.Amount(req.Amount)
 	fee := s.getFee(req.Fee, amt)
 	lockTime := s.getLockTime(req.LockTime)
 
@@ -151,11 +147,7 @@ func (s *transactionServer) GetRawBondTransaction(_ context.Context,
 		publicKey = nil
 	}
 
-	amt, err := s.getAmount(req.Stake)
-	if err != nil {
-		return nil, err
-	}
-
+	amt := amount.Amount(req.Stake)
 	fee := s.getFee(req.Fee, amt)
 	lockTime := s.getLockTime(req.LockTime)
 
@@ -204,11 +196,7 @@ func (s *transactionServer) GetRawWithdrawTransaction(_ context.Context,
 		return nil, err
 	}
 
-	amt, err := s.getAmount(req.Amount)
-	if err != nil {
-		return nil, err
-	}
-
+	amt := amount.Amount(req.Amount)
 	fee := s.getFee(req.Fee, amt)
 	lockTime := s.getLockTime(req.LockTime)
 
@@ -221,15 +209,6 @@ func (s *transactionServer) GetRawWithdrawTransaction(_ context.Context,
 	return &pactus.GetRawTransactionResponse{
 		RawTransaction: rawTx,
 	}, nil
-}
-
-func (s *transactionServer) getAmount(a int64) (amount.Amount, error) {
-	amt := amount.Amount(a)
-	if amt == 0 {
-		return 0, status.Errorf(codes.InvalidArgument, "amount is zero")
-	}
-
-	return amt, nil
 }
 
 func (s *transactionServer) getFee(f int64, amt amount.Amount) amount.Amount {

--- a/www/grpc/transaction_test.go
+++ b/www/grpc/transaction_test.go
@@ -257,6 +257,17 @@ func TestCalculateFee(t *testing.T) {
 		assert.Less(t, res.Amount, amt.ToNanoPAC())
 	})
 
+	t.Run("Unbond fee should be zero", func(t *testing.T) {
+		res, err := client.CalculateFee(context.Background(),
+			&pactus.CalculateFeeRequest{
+				Amount:      0,
+				PayloadType: pactus.PayloadType_UNBOND_PAYLOAD,
+				FixedAmount: true,
+			})
+		assert.NoError(t, err)
+		assert.Zero(t, res.Amount)
+	})
+
 	assert.Nil(t, conn.Close(), "Error closing connection")
 	td.StopServer()
 }


### PR DESCRIPTION
## Description

This PR includes changes related to fee calculation:

1. Fixed an issue with calculating unbonding fees, which should be set to zero.
2. No longer returns an error on zero amounts.
3. Moved the fee calculation logic to the execution package.