### PR TITLE
Fix grpc get block

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -465,6 +465,7 @@ func (sync *synchronizer) sendBlockRequestToRandomPeer(from, count uint32, onlyN
 		// We haven't completed the handshake with this peer.
 		if !p.IsKnownOrTrusty() {
 			if onlyNodeNetwork {
+				fmt.Println("=================== close" + p.PeerID.String())
 				sync.network.CloseConnection(p.PeerID)
 			}
 
@@ -473,6 +474,7 @@ func (sync *synchronizer) sendBlockRequestToRandomPeer(from, count uint32, onlyN
 
 		if onlyNodeNetwork && !p.HasNetworkService() {
 			if onlyNodeNetwork {
+				fmt.Println("===================++++++ close" + p.PeerID.String())
 				sync.network.CloseConnection(p.PeerID)
 			}
 

--- a/www/grpc/blockchain.go
+++ b/www/grpc/blockchain.go
@@ -155,7 +155,11 @@ func (s *blockchainServer) GetBlock(_ context.Context,
 		trxs := make([]*pactus.TransactionInfo, 0, block.Transactions().Len())
 		for _, trx := range block.Transactions() {
 			if req.Verbosity == pactus.BlockVerbosity_BLOCK_INFO {
-				trxs = append(trxs, &pactus.TransactionInfo{Id: trx.ID().Bytes()})
+				data, _ := trx.Bytes()
+				trxs = append(trxs, &pactus.TransactionInfo{
+					Id:   trx.ID().Bytes(),
+					Data: data,
+				})
 			} else {
 				trxs = append(trxs, transactionToProto(trx))
 			}

--- a/www/grpc/blockchain.go
+++ b/www/grpc/blockchain.go
@@ -110,10 +110,14 @@ func (s *blockchainServer) GetBlock(_ context.Context,
 	res := &pactus.GetBlockResponse{
 		Height: committedBlock.Height,
 		Hash:   committedBlock.BlockHash.Bytes(),
-		Data:   committedBlock.Data,
 	}
 
-	if req.Verbosity > pactus.BlockVerbosity_BLOCK_DATA {
+	switch req.Verbosity {
+	case pactus.BlockVerbosity_BLOCK_DATA:
+		res.Data = committedBlock.Data
+
+	case pactus.BlockVerbosity_BLOCK_INFO,
+		pactus.BlockVerbosity_BLOCK_TRANSACTIONS:
 		block, err := committedBlock.ToBlock()
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, err.Error())

--- a/www/grpc/blockchain_test.go
+++ b/www/grpc/blockchain_test.go
@@ -47,11 +47,19 @@ func TestGetBlock(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, res.Height, height)
 		assert.Equal(t, res.Hash, b.Hash().Bytes())
-		assert.Equal(t, res.Data, data)
+		assert.Empty(t, res.Data)
 		assert.NotEmpty(t, res.Header)
-		assert.NotEmpty(t, res.Txs)
 		assert.Equal(t, res.PrevCert.Committers, b.PrevCertificate().Committers())
 		assert.Equal(t, res.PrevCert.Absentees, b.PrevCertificate().Absentees())
+		for i, trx := range res.Txs {
+			blockTrx := b.Transactions()[i]
+
+			assert.Equal(t, blockTrx.ID().Bytes(), trx.Id)
+			assert.Empty(t, trx.Data)
+			assert.Zero(t, trx.LockTime)
+			assert.Empty(t, trx.Signature)
+			assert.Empty(t, trx.PublicKey)
+		}
 	})
 
 	t.Run("Should return object with  (verbosity: 2)", func(t *testing.T) {
@@ -62,14 +70,18 @@ func TestGetBlock(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, res.Height, height)
 		assert.Equal(t, res.Hash, b.Hash().Bytes())
-		assert.Equal(t, res.Data, data)
+		assert.Empty(t, res.Data)
 		assert.NotEmpty(t, res.Header)
 		assert.NotEmpty(t, res.Txs)
 		for i, trx := range res.Txs {
-			data, _ := b.Transactions()[i].Bytes()
-			assert.Equal(t, b.Transactions()[i].ID().Bytes(), trx.Id)
-			assert.Equal(t, b.Transactions()[i].Signature().Bytes(), trx.Signature)
+			blockTrx := b.Transactions()[i]
+			data, _ := blockTrx.Bytes()
+
+			assert.Equal(t, blockTrx.ID().Bytes(), trx.Id)
 			assert.Equal(t, data, trx.Data)
+			assert.Equal(t, blockTrx.LockTime(), trx.LockTime)
+			assert.Equal(t, blockTrx.Signature().Bytes(), trx.Signature)
+			assert.Equal(t, blockTrx.PublicKey().String(), trx.PublicKey)
 		}
 	})
 

--- a/www/grpc/blockchain_test.go
+++ b/www/grpc/blockchain_test.go
@@ -53,9 +53,10 @@ func TestGetBlock(t *testing.T) {
 		assert.Equal(t, res.PrevCert.Absentees, b.PrevCertificate().Absentees())
 		for i, trx := range res.Txs {
 			blockTrx := b.Transactions()[i]
+			data, _ := blockTrx.Bytes()
 
 			assert.Equal(t, blockTrx.ID().Bytes(), trx.Id)
-			assert.Empty(t, trx.Data)
+			assert.Equal(t, data, trx.Data)
 			assert.Zero(t, trx.LockTime)
 			assert.Empty(t, trx.Signature)
 			assert.Empty(t, trx.PublicKey)
@@ -75,10 +76,9 @@ func TestGetBlock(t *testing.T) {
 		assert.NotEmpty(t, res.Txs)
 		for i, trx := range res.Txs {
 			blockTrx := b.Transactions()[i]
-			data, _ := blockTrx.Bytes()
 
 			assert.Equal(t, blockTrx.ID().Bytes(), trx.Id)
-			assert.Equal(t, data, trx.Data)
+			assert.Empty(t, trx.Data)
 			assert.Equal(t, blockTrx.LockTime(), trx.LockTime)
 			assert.Equal(t, blockTrx.Signature().Bytes(), trx.Signature)
 			assert.Equal(t, blockTrx.PublicKey().String(), trx.PublicKey)

--- a/www/grpc/gen/docs/index.html
+++ b/www/grpc/gen/docs/index.html
@@ -1350,13 +1350,13 @@ If not explicitly set, it is calculated based on the amount. </p></td>
               <tr>
                 <td>TRANSACTION_DATA</td>
                 <td>0</td>
-                <td><p>Request only transaction data.</p></td>
+                <td><p>Request transaction data only.</p></td>
               </tr>
             
               <tr>
                 <td>TRANSACTION_INFO</td>
                 <td>1</td>
-                <td><p>Request detailed transaction information.</p></td>
+                <td><p>Request transaction details.</p></td>
               </tr>
             
           </tbody>

--- a/www/grpc/gen/docs/index.html
+++ b/www/grpc/gen/docs/index.html
@@ -1848,7 +1848,7 @@ and payload type.</p></td>
                   <td>data</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
-                  <td><p>Block data. </p></td>
+                  <td><p>Block data, only available if the verbosity level is set to BLOCK_DATA. </p></td>
                 </tr>
               
                 <tr>
@@ -1876,7 +1876,8 @@ and payload type.</p></td>
                   <td>txs</td>
                   <td><a href="#pactus.TransactionInfo">TransactionInfo</a></td>
                   <td>repeated</td>
-                  <td><p>List of transactions in the block. </p></td>
+                  <td><p>List of transactions in the block.
+Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS. </p></td>
                 </tr>
               
             </tbody>
@@ -2306,13 +2307,13 @@ and payload type.</p></td>
               <tr>
                 <td>BLOCK_INFO</td>
                 <td>1</td>
-                <td><p>Request block information only.</p></td>
+                <td><p>Request block information and transaction IDs.</p></td>
               </tr>
             
               <tr>
                 <td>BLOCK_TRANSACTIONS</td>
                 <td>2</td>
-                <td><p>Request block transactions only.</p></td>
+                <td><p>Request block information and transaction details.</p></td>
               </tr>
             
           </tbody>

--- a/www/grpc/gen/docs/index.md
+++ b/www/grpc/gen/docs/index.md
@@ -436,8 +436,8 @@ Enumeration for verbosity level when requesting transaction details.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| TRANSACTION_DATA | 0 | Request only transaction data. |
-| TRANSACTION_INFO | 1 | Request detailed transaction information. |
+| TRANSACTION_DATA | 0 | Request transaction data only. |
+| TRANSACTION_INFO | 1 | Request transaction details. |
 
 
  

--- a/www/grpc/gen/docs/index.md
+++ b/www/grpc/gen/docs/index.md
@@ -664,11 +664,11 @@ Message containing the response with block information.
 | ----- | ---- | ----- | ----------- |
 | height | [uint32](#uint32) |  | Height of the block. |
 | hash | [bytes](#bytes) |  | Hash of the block. |
-| data | [bytes](#bytes) |  | Block data. |
+| data | [bytes](#bytes) |  | Block data, only available if the verbosity level is set to BLOCK_DATA. |
 | block_time | [uint32](#uint32) |  | Block timestamp. |
 | header | [BlockHeaderInfo](#pactus-BlockHeaderInfo) |  | Block header information. |
 | prev_cert | [CertificateInfo](#pactus-CertificateInfo) |  | Certificate information of the previous block. |
-| txs | [TransactionInfo](#pactus-TransactionInfo) | repeated | List of transactions in the block. |
+| txs | [TransactionInfo](#pactus-TransactionInfo) | repeated | List of transactions in the block. Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS. |
 
 
 
@@ -885,8 +885,8 @@ Enumeration for verbosity level when requesting block information.
 | Name | Number | Description |
 | ---- | ------ | ----------- |
 | BLOCK_DATA | 0 | Request block data only. |
-| BLOCK_INFO | 1 | Request block information only. |
-| BLOCK_TRANSACTIONS | 2 | Request block transactions only. |
+| BLOCK_INFO | 1 | Request block information and transaction IDs. |
+| BLOCK_TRANSACTIONS | 2 | Request block information and transaction details. |
 
 
 

--- a/www/grpc/gen/docs/website.md
+++ b/www/grpc/gen/docs/website.md
@@ -1710,7 +1710,7 @@ GetBlockResponse
       <td>
         <a href="#bytes">bytes</a>
       </td>
-      <td>Block data. </td>
+      <td>Block data, only available if the verbosity level is set to BLOCK_DATA. </td>
     </tr>
     <tr>
       <td class="fw-bold">block_time</td>
@@ -1738,7 +1738,8 @@ GetBlockResponse
       <td>repeated
         <a href="#pactus.TransactionInfo">TransactionInfo</a>
       </td>
-      <td>List of transactions in the block. </td>
+      <td>List of transactions in the block.
+Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS. </td>
     </tr>
   </tbody>
 </table>  
@@ -3186,13 +3187,13 @@ BlockVerbosity
       <tr>
         <td class="fw-bold">BLOCK_INFO</td>
         <td>1</td>
-        <td>Request block information only.</td>
+        <td>Request block information and transaction IDs.</td>
       </tr>
     
       <tr>
         <td class="fw-bold">BLOCK_TRANSACTIONS</td>
         <td>2</td>
-        <td>Request block transactions only.</td>
+        <td>Request block information and transaction details.</td>
       </tr>
     
   </tbody>

--- a/www/grpc/gen/docs/website.md
+++ b/www/grpc/gen/docs/website.md
@@ -3156,13 +3156,13 @@ TransactionVerbosity
       <tr>
         <td class="fw-bold">TRANSACTION_DATA</td>
         <td>0</td>
-        <td>Request only transaction data.</td>
+        <td>Request transaction data only.</td>
       </tr>
     
       <tr>
         <td class="fw-bold">TRANSACTION_INFO</td>
         <td>1</td>
-        <td>Request detailed transaction information.</td>
+        <td>Request transaction details.</td>
       </tr>
     
   </tbody>

--- a/www/grpc/gen/go/blockchain.pb.go
+++ b/www/grpc/gen/go/blockchain.pb.go
@@ -26,9 +26,9 @@ type BlockVerbosity int32
 const (
 	// Request block data only.
 	BlockVerbosity_BLOCK_DATA BlockVerbosity = 0
-	// Request block information only.
+	// Request block information and transaction IDs.
 	BlockVerbosity_BLOCK_INFO BlockVerbosity = 1
-	// Request block transactions only.
+	// Request block information and transaction details.
 	BlockVerbosity_BLOCK_TRANSACTIONS BlockVerbosity = 2
 )
 
@@ -629,7 +629,7 @@ type GetBlockResponse struct {
 	Height uint32 `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
 	// Hash of the block.
 	Hash []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
-	// Block data.
+	// Block data, only available if the verbosity level is set to BLOCK_DATA.
 	Data []byte `protobuf:"bytes,3,opt,name=data,proto3" json:"data,omitempty"`
 	// Block timestamp.
 	BlockTime uint32 `protobuf:"varint,4,opt,name=block_time,json=blockTime,proto3" json:"block_time,omitempty"`
@@ -638,6 +638,7 @@ type GetBlockResponse struct {
 	// Certificate information of the previous block.
 	PrevCert *CertificateInfo `protobuf:"bytes,6,opt,name=prev_cert,json=prevCert,proto3" json:"prev_cert,omitempty"`
 	// List of transactions in the block.
+	// Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
 	Txs []*TransactionInfo `protobuf:"bytes,7,rep,name=txs,proto3" json:"txs,omitempty"`
 }
 

--- a/www/grpc/gen/go/transaction.pb.go
+++ b/www/grpc/gen/go/transaction.pb.go
@@ -89,9 +89,9 @@ func (PayloadType) EnumDescriptor() ([]byte, []int) {
 type TransactionVerbosity int32
 
 const (
-	// Request only transaction data.
+	// Request transaction data only.
 	TransactionVerbosity_TRANSACTION_DATA TransactionVerbosity = 0
-	// Request detailed transaction information.
+	// Request transaction details.
 	TransactionVerbosity_TRANSACTION_INFO TransactionVerbosity = 1
 )
 

--- a/www/grpc/gen/java/pactus/blockchain/BlockchainOuterClass.java
+++ b/www/grpc/gen/java/pactus/blockchain/BlockchainOuterClass.java
@@ -33,7 +33,7 @@ public final class BlockchainOuterClass {
     BLOCK_DATA(0),
     /**
      * <pre>
-     * Request block information only.
+     * Request block information and transaction IDs.
      * </pre>
      *
      * <code>BLOCK_INFO = 1;</code>
@@ -41,7 +41,7 @@ public final class BlockchainOuterClass {
     BLOCK_INFO(1),
     /**
      * <pre>
-     * Request block transactions only.
+     * Request block information and transaction details.
      * </pre>
      *
      * <code>BLOCK_TRANSACTIONS = 2;</code>
@@ -60,7 +60,7 @@ public final class BlockchainOuterClass {
     public static final int BLOCK_DATA_VALUE = 0;
     /**
      * <pre>
-     * Request block information only.
+     * Request block information and transaction IDs.
      * </pre>
      *
      * <code>BLOCK_INFO = 1;</code>
@@ -68,7 +68,7 @@ public final class BlockchainOuterClass {
     public static final int BLOCK_INFO_VALUE = 1;
     /**
      * <pre>
-     * Request block transactions only.
+     * Request block information and transaction details.
      * </pre>
      *
      * <code>BLOCK_TRANSACTIONS = 2;</code>
@@ -6284,7 +6284,7 @@ public final class BlockchainOuterClass {
 
     /**
      * <pre>
-     * Block data.
+     * Block data, only available if the verbosity level is set to BLOCK_DATA.
      * </pre>
      *
      * <code>bytes data = 3 [json_name = "data"];</code>
@@ -6359,6 +6359,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -6368,6 +6369,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -6376,6 +6378,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -6384,6 +6387,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -6393,6 +6397,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -6481,7 +6486,7 @@ public final class BlockchainOuterClass {
     private com.google.protobuf.ByteString data_;
     /**
      * <pre>
-     * Block data.
+     * Block data, only available if the verbosity level is set to BLOCK_DATA.
      * </pre>
      *
      * <code>bytes data = 3 [json_name = "data"];</code>
@@ -6588,6 +6593,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -6599,6 +6605,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -6611,6 +6618,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -6622,6 +6630,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -6633,6 +6642,7 @@ public final class BlockchainOuterClass {
     /**
      * <pre>
      * List of transactions in the block.
+     * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
      * </pre>
      *
      * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7264,7 +7274,7 @@ public final class BlockchainOuterClass {
       private com.google.protobuf.ByteString data_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <pre>
-       * Block data.
+       * Block data, only available if the verbosity level is set to BLOCK_DATA.
        * </pre>
        *
        * <code>bytes data = 3 [json_name = "data"];</code>
@@ -7276,7 +7286,7 @@ public final class BlockchainOuterClass {
       }
       /**
        * <pre>
-       * Block data.
+       * Block data, only available if the verbosity level is set to BLOCK_DATA.
        * </pre>
        *
        * <code>bytes data = 3 [json_name = "data"];</code>
@@ -7294,7 +7304,7 @@ public final class BlockchainOuterClass {
       }
       /**
        * <pre>
-       * Block data.
+       * Block data, only available if the verbosity level is set to BLOCK_DATA.
        * </pre>
        *
        * <code>bytes data = 3 [json_name = "data"];</code>
@@ -7675,6 +7685,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7689,6 +7700,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7703,6 +7715,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7717,6 +7730,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7738,6 +7752,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7756,6 +7771,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7776,6 +7792,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7797,6 +7814,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7815,6 +7833,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7833,6 +7852,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7852,6 +7872,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7869,6 +7890,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7886,6 +7908,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7897,6 +7920,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7911,6 +7935,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7926,6 +7951,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7937,6 +7963,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>
@@ -7949,6 +7976,7 @@ public final class BlockchainOuterClass {
       /**
        * <pre>
        * List of transactions in the block.
+       * Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
        * </pre>
        *
        * <code>repeated .pactus.TransactionInfo txs = 7 [json_name = "txs"];</code>

--- a/www/grpc/gen/java/pactus/transaction/TransactionOuterClass.java
+++ b/www/grpc/gen/java/pactus/transaction/TransactionOuterClass.java
@@ -221,7 +221,7 @@ public final class TransactionOuterClass {
       implements com.google.protobuf.ProtocolMessageEnum {
     /**
      * <pre>
-     * Request only transaction data.
+     * Request transaction data only.
      * </pre>
      *
      * <code>TRANSACTION_DATA = 0;</code>
@@ -229,7 +229,7 @@ public final class TransactionOuterClass {
     TRANSACTION_DATA(0),
     /**
      * <pre>
-     * Request detailed transaction information.
+     * Request transaction details.
      * </pre>
      *
      * <code>TRANSACTION_INFO = 1;</code>
@@ -240,7 +240,7 @@ public final class TransactionOuterClass {
 
     /**
      * <pre>
-     * Request only transaction data.
+     * Request transaction data only.
      * </pre>
      *
      * <code>TRANSACTION_DATA = 0;</code>
@@ -248,7 +248,7 @@ public final class TransactionOuterClass {
     public static final int TRANSACTION_DATA_VALUE = 0;
     /**
      * <pre>
-     * Request detailed transaction information.
+     * Request transaction details.
      * </pre>
      *
      * <code>TRANSACTION_INFO = 1;</code>

--- a/www/grpc/gen/rust/pactus.rs
+++ b/www/grpc/gen/rust/pactus.rs
@@ -338,9 +338,9 @@ impl PayloadType {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum TransactionVerbosity {
-    /// Request only transaction data.
+    /// Request transaction data only.
     TransactionData = 0,
-    /// Request detailed transaction information.
+    /// Request transaction details.
     TransactionInfo = 1,
 }
 impl TransactionVerbosity {

--- a/www/grpc/gen/rust/pactus.rs
+++ b/www/grpc/gen/rust/pactus.rs
@@ -453,7 +453,7 @@ pub struct GetBlockResponse {
     /// Hash of the block.
     #[prost(bytes="vec", tag="2")]
     pub hash: ::prost::alloc::vec::Vec<u8>,
-    /// Block data.
+    /// Block data, only available if the verbosity level is set to BLOCK_DATA.
     #[prost(bytes="vec", tag="3")]
     pub data: ::prost::alloc::vec::Vec<u8>,
     /// Block timestamp.
@@ -466,6 +466,7 @@ pub struct GetBlockResponse {
     #[prost(message, optional, tag="6")]
     pub prev_cert: ::core::option::Option<CertificateInfo>,
     /// List of transactions in the block.
+    /// Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
     #[prost(message, repeated, tag="7")]
     pub txs: ::prost::alloc::vec::Vec<TransactionInfo>,
 }
@@ -689,9 +690,9 @@ pub struct ConsensusInfo {
 pub enum BlockVerbosity {
     /// Request block data only.
     BlockData = 0,
-    /// Request block information only.
+    /// Request block information and transaction IDs.
     BlockInfo = 1,
-    /// Request block transactions only.
+    /// Request block information and transaction details.
     BlockTransactions = 2,
 }
 impl BlockVerbosity {

--- a/www/grpc/proto/blockchain.proto
+++ b/www/grpc/proto/blockchain.proto
@@ -113,7 +113,7 @@ message GetBlockResponse {
   uint32 height = 1;
   // Hash of the block.
   bytes hash = 2;
-  // Block data.
+  // Block data, only available if the verbosity level is set to BLOCK_DATA.
   bytes data = 3;
   // Block timestamp.
   uint32 block_time = 4;
@@ -122,6 +122,7 @@ message GetBlockResponse {
   // Certificate information of the previous block.
   CertificateInfo prev_cert = 6;
   // List of transactions in the block.
+  // Transaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS.
   repeated TransactionInfo txs = 7;
 }
 
@@ -279,9 +280,9 @@ message ConsensusInfo {
 enum BlockVerbosity {
   // Request block data only.
   BLOCK_DATA = 0;
-  // Request block information only.
+  // Request block information and transaction IDs.
   BLOCK_INFO = 1;
-  // Request block transactions only.
+  // Request block information and transaction details.
   BLOCK_TRANSACTIONS = 2;
 }
 

--- a/www/grpc/proto/transaction.proto
+++ b/www/grpc/proto/transaction.proto
@@ -257,8 +257,8 @@ enum PayloadType {
 
 // Enumeration for verbosity level when requesting transaction details.
 enum TransactionVerbosity {
-  // Request only transaction data.
+  // Request transaction data only.
   TRANSACTION_DATA = 0;
-  // Request detailed transaction information.
+  // Request transaction details.
   TRANSACTION_INFO = 1;
 }

--- a/www/grpc/swagger-ui/pactus.swagger.json
+++ b/www/grpc/swagger-ui/pactus.swagger.json
@@ -741,7 +741,7 @@
           },
           {
             "name": "verbosity",
-            "description": "Verbosity level for transaction details.\n\n - TRANSACTION_DATA: Request only transaction data.\n - TRANSACTION_INFO: Request detailed transaction information.",
+            "description": "Verbosity level for transaction details.\n\n - TRANSACTION_DATA: Request transaction data only.\n - TRANSACTION_INFO: Request transaction details.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -2030,7 +2030,7 @@
         "TRANSACTION_INFO"
       ],
       "default": "TRANSACTION_DATA",
-      "description": "Enumeration for verbosity level when requesting transaction details.\n\n - TRANSACTION_DATA: Request only transaction data.\n - TRANSACTION_INFO: Request detailed transaction information."
+      "description": "Enumeration for verbosity level when requesting transaction details.\n\n - TRANSACTION_DATA: Request transaction data only.\n - TRANSACTION_INFO: Request transaction details."
     },
     "pactusUnloadWalletResponse": {
       "type": "object",

--- a/www/grpc/swagger-ui/pactus.swagger.json
+++ b/www/grpc/swagger-ui/pactus.swagger.json
@@ -87,7 +87,7 @@
           },
           {
             "name": "verbosity",
-            "description": "Verbosity level for block information.\n\n - BLOCK_DATA: Request block data only.\n - BLOCK_INFO: Request block information only.\n - BLOCK_TRANSACTIONS: Request block transactions only.",
+            "description": "Verbosity level for block information.\n\n - BLOCK_DATA: Request block data only.\n - BLOCK_INFO: Request block information and transaction IDs.\n - BLOCK_TRANSACTIONS: Request block information and transaction details.",
             "in": "query",
             "required": false,
             "type": "string",
@@ -1214,7 +1214,7 @@
         "BLOCK_TRANSACTIONS"
       ],
       "default": "BLOCK_DATA",
-      "description": "Enumeration for verbosity level when requesting block information.\n\n - BLOCK_DATA: Request block data only.\n - BLOCK_INFO: Request block information only.\n - BLOCK_TRANSACTIONS: Request block transactions only."
+      "description": "Enumeration for verbosity level when requesting block information.\n\n - BLOCK_DATA: Request block data only.\n - BLOCK_INFO: Request block information and transaction IDs.\n - BLOCK_TRANSACTIONS: Request block information and transaction details."
     },
     "pactusBroadcastTransactionResponse": {
       "type": "object",
@@ -1384,7 +1384,7 @@
         "data": {
           "type": "string",
           "format": "byte",
-          "description": "Block data."
+          "description": "Block data, only available if the verbosity level is set to BLOCK_DATA."
         },
         "blockTime": {
           "type": "integer",
@@ -1405,7 +1405,7 @@
             "type": "object",
             "$ref": "#/definitions/pactusTransactionInfo"
           },
-          "description": "List of transactions in the block."
+          "description": "List of transactions in the block.\nTransaction information is available when the verbosity level is set to BLOCK_TRANSACTIONS."
         }
       },
       "description": "Message containing the response with block information."

--- a/www/grpc/transaction.go
+++ b/www/grpc/transaction.go
@@ -43,12 +43,14 @@ func (s *transactionServer) GetTransaction(_ context.Context,
 		BlockTime:   committedTx.BlockTime,
 	}
 
-	if req.Verbosity == pactus.TransactionVerbosity_TRANSACTION_DATA {
+	switch req.Verbosity {
+	case pactus.TransactionVerbosity_TRANSACTION_DATA:
 		res.Transaction = &pactus.TransactionInfo{
-			Data: committedTx.Data,
 			Id:   committedTx.TxID.Bytes(),
+			Data: committedTx.Data,
 		}
-	} else {
+
+	case pactus.TransactionVerbosity_TRANSACTION_INFO:
 		trx, err := committedTx.ToTx()
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, err.Error())
@@ -229,10 +231,8 @@ func (s *transactionServer) getLockTime(lockTime uint32) uint32 {
 }
 
 func transactionToProto(trx *tx.Tx) *pactus.TransactionInfo {
-	data, _ := trx.Bytes()
 	transaction := &pactus.TransactionInfo{
 		Id:          trx.ID().Bytes(),
-		Data:        data,
 		Version:     int32(trx.Version()),
 		LockTime:    trx.LockTime(),
 		Fee:         trx.Fee().ToNanoPAC(),

--- a/www/grpc/transaction_test.go
+++ b/www/grpc/transaction_test.go
@@ -46,6 +46,7 @@ func TestGetTransaction(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		assert.NotEmpty(t, res.Transaction)
+		assert.Empty(t, res.Transaction.Data)
 		assert.Equal(t, uint32(0x1), res.BlockHeight)
 		assert.Equal(t, testBlock.Header().UnixTime(), res.BlockTime)
 		assert.Equal(t, trx1.ID().Bytes(), res.Transaction.Id)


### PR DESCRIPTION
## Description

Block data and transaction data are omitted when the verbosity level is set to "information."
