### PR TITLE
fix(cmd): ignore error on balance query

### DIFF
--- a/cmd/wallet/address.go
+++ b/cmd/wallet/address.go
@@ -117,12 +117,9 @@ func buildBalanceCmd(parentCmd *cobra.Command) {
 		cmd.FatalErrorCheck(err)
 
 		cmd.PrintLine()
-		balance, err := wlt.Balance(addr)
-		cmd.FatalErrorCheck(err)
 
-		stake, err := wlt.Stake(addr)
-		cmd.FatalErrorCheck(err)
-
+		balance, _ := wlt.Balance(addr)
+		stake, _ := wlt.Stake(addr)
 		cmd.PrintInfoMsgf("balance: %s\tstake: %s",
 			balance.String(), stake.String())
 	}


### PR DESCRIPTION
## Description

This PR ignores errors in balance and stake queries on an address.