### PR TITLE
fix: prevent zero stake for bond transactions

### DIFF
--- a/execution/executor/bond.go
+++ b/execution/executor/bond.go
@@ -30,6 +30,7 @@ func (e *BondExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 			return errors.Errorf(errors.ErrInvalidPublicKey,
 				"public key is not set")
 		}
+		// TODO: remove me in future
 		if pld.Stake < sb.Params().MinimumStake {
 			return errors.Errorf(errors.ErrInvalidTx,
 				"validator's stake can't be less than %v", sb.Params().MinimumStake)
@@ -68,6 +69,18 @@ func (e *BondExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 	if receiverVal.Stake()+pld.Stake > sb.Params().MaximumStake {
 		return errors.Errorf(errors.ErrInvalidAmount,
 			"validator's stake can't be more than %v", sb.Params().MaximumStake)
+	}
+
+	// TODO: remove me in future
+	// We can have a level for committing blocks even if they are not fully compatible with the current rules.
+	// However, since they were committed in the past, they should be accepted by new nodes.
+	if sb.CurrentHeight() > 752000 {
+		if pld.Stake < sb.Params().MinimumStake {
+			if pld.Stake == 0 || receiverVal.Stake()+pld.Stake != sb.Params().MaximumStake {
+				return errors.Errorf(errors.ErrInvalidTx,
+					"stake amount should not be less than %v", sb.Params().MinimumStake)
+			}
+		}
 	}
 
 	senderAcc.SubtractFromBalance(pld.Stake + trx.Fee())

--- a/execution/executor/bond.go
+++ b/execution/executor/bond.go
@@ -74,7 +74,7 @@ func (e *BondExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 	// TODO: remove me in future
 	// We can have a level for committing blocks even if they are not fully compatible with the current rules.
 	// However, since they were committed in the past, they should be accepted by new nodes.
-	if sb.CurrentHeight() > 752000 {
+	if sb.CurrentHeight() > 740_000 {
 		if pld.Stake < sb.Params().MinimumStake {
 			if pld.Stake == 0 || receiverVal.Stake()+pld.Stake != sb.Params().MaximumStake {
 				return errors.Errorf(errors.ErrInvalidTx,

--- a/execution/executor/sortition.go
+++ b/execution/executor/sortition.go
@@ -27,11 +27,9 @@ func (e *SortitionExecutor) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 			"unable to retrieve validator")
 	}
 
-	if val.LastSortitionHeight() == 0 {
-		if sb.CurrentHeight()-val.LastBondingHeight() < sb.Params().BondInterval {
-			return errors.Errorf(errors.ErrInvalidHeight,
-				"validator has bonded at height %v", val.LastBondingHeight())
-		}
+	if sb.CurrentHeight()-val.LastBondingHeight() < sb.Params().BondInterval {
+		return errors.Errorf(errors.ErrInvalidHeight,
+			"validator has bonded at height %v", val.LastBondingHeight())
 	}
 
 	sortitionHeight := trx.LockTime()

--- a/execution/executor/transfer_test.go
+++ b/execution/executor/transfer_test.go
@@ -14,8 +14,7 @@ import (
 type testData struct {
 	*testsuite.TestSuite
 
-	sandbox    *sandbox.MockSandbox
-	randHeight uint32
+	sandbox *sandbox.MockSandbox
 }
 
 func setup(t *testing.T) *testData {
@@ -28,9 +27,8 @@ func setup(t *testing.T) *testData {
 	_ = sb.TestStore.AddTestBlock(randHeight)
 
 	return &testData{
-		TestSuite:  ts,
-		sandbox:    sb,
-		randHeight: randHeight,
+		TestSuite: ts,
+		sandbox:   sb,
 	}
 }
 

--- a/execution/executor/unbond_test.go
+++ b/execution/executor/unbond_test.go
@@ -94,8 +94,9 @@ func TestUnbondJoiningCommittee(t *testing.T) {
 	exe2 := NewUnbondExecutor(false)
 	pub, _ := td.RandBLSKeyPair()
 
+	curHeight := td.sandbox.CurrentHeight()
 	val := td.sandbox.MakeNewValidator(pub)
-	val.UpdateLastSortitionHeight(td.randHeight)
+	val.UpdateLastSortitionHeight(curHeight)
 	td.sandbox.UpdateValidator(val)
 	td.sandbox.JoinedToCommittee(val.Address())
 	lockTime := td.sandbox.CurrentHeight()
@@ -105,7 +106,7 @@ func TestUnbondJoiningCommittee(t *testing.T) {
 	assert.NoError(t, exe2.Execute(trx, td.sandbox))
 }
 
-func TestPwerDeltaUnbond(t *testing.T) {
+func TestPowerDeltaUnbond(t *testing.T) {
 	td := setup(t)
 	exe := NewUnbondExecutor(true)
 

--- a/execution/executor/withdraw_test.go
+++ b/execution/executor/withdraw_test.go
@@ -59,7 +59,8 @@ func TestExecuteWithdrawTx(t *testing.T) {
 		assert.Equal(t, errors.Code(err), errors.ErrInvalidHeight)
 	})
 
-	td.sandbox.TestStore.AddTestBlock(td.randHeight + 1)
+	curHeight := td.sandbox.CurrentHeight()
+	td.sandbox.TestStore.AddTestBlock(curHeight + 1)
 
 	t.Run("Should pass, Everything is Ok!", func(t *testing.T) {
 		trx := tx.NewWithdrawTx(lockTime, val.Address(), addr,

--- a/sandbox/mock.go
+++ b/sandbox/mock.go
@@ -45,7 +45,7 @@ func MockingSandbox(ts *testsuite.TestSuite) *MockSandbox {
 
 	for i, val := range cmt.Validators() {
 		acc := account.NewAccount(int32(i + 1))
-		acc.AddToBalance(100 * 1e9)
+		acc.AddToBalance(10000 * 1e9)
 		sb.UpdateAccount(val.Address(), acc)
 		sb.UpdateValidator(val)
 


### PR DESCRIPTION
## Description

This pull request prevents zero stakes and helps validators with amounts less than one to reach full stake.
