### PR TITLE
chore: remove an address from banned list

### DIFF
--- a/config/banned.json
+++ b/config/banned.json
@@ -2,7 +2,6 @@
     "pc1p8slveave2zm9tgj7q260fgrdfu2ph8n7ezxhtt",
     "pc1prqnrscsgtcp25sqvwk6d2zj9p9m37wexu0x8z5",
     "pc1pd5mytehyrrgtcvhzjqnl7tkq2q0693w5raqjuz",
-    "pc1pfdtn220dvh0wf38q4j2nqjq264t0d7e8ep9ukx",
     "pc1ph9r2yxevtgqt9ehym3zlryvdk85lv3ss7l9tyf",
     "pc1phkaywtdwfj64rckp6dsxc49m8ghdh30duk86ae",
     "pc1phc7a09pwaensf940jhl873lvuqeyj3256dl7g9",


### PR DESCRIPTION
## Description

Remove `pc1pfdtn220dvh0wf38q4j2nqjq264t0d7e8ep9ukx` from the banned list.

### Justification

We have recently faced several attacks on the Pactus blockchain that interrupted block creation. 
None of the attacks could damage users' assets, but they potentially hurt other validators in two ways:

1. By sending Zero Bond transactions (Issue #1223), the attacker(s) prevent other validators from receiving block rewards accordingly.
2. By sending spamming transactions (Issue #1232), it interrupts block creation and, in some cases, reduces the availability score of some validators.

After the investigation, we found these accounts as sources of attacks:
- pc1zusayxszmntpjf359fm4tpvj9kj2g8uqjt83d5v
- pc1z6d9kvyqld7ah0ql8c5duvrjz7ery74k07yysvw
- pc1zm4d6lu8j83qp6skd9g0566ewa8t2qvjwk65949

A total of 26,301 transactions were sent by these accounts. From one of the above accounts, we could identify the withdrawal transactions, and by following the withdrawal validators, we could identify the `pc1zl95zy3wny0mufdepx8xk6ravduw0ceurudtqqq` address as the reward address belonging to the attacker(s). All validators who send rewards to this address get banned.

The address `pc1pfdtn220dvh0wf38q4j2nqjq264t0d7e8ep9ukx` was mistakenly included in this list. Since it blocked 268629 that was proposed by this validator, there was a transaction to the above account, but it was not the reward transaction. So, we removed it from the banned list. We have double-checked all the addresses to prevent similar mistakes.