### PR TITLE
fix(network): set infinite limit for resource manager 

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -115,9 +115,8 @@ func newNetwork(conf *Config, log *logger.SubLogger, opts []lp2p.Option) (*netwo
 		opts = append(opts, lp2p.DisableMetrics())
 	}
 
-	limit := BuildConcreteLimitConfig(conf.MaxConns)
 	resMgr, err := lp2prcmgr.NewResourceManager(
-		lp2prcmgr.NewFixedLimiter(limit),
+		lp2prcmgr.NewFixedLimiter(lp2prcmgr.InfiniteLimits),
 		rcMgrOpt...,
 	)
 	if err != nil {
@@ -129,8 +128,8 @@ func newNetwork(conf *Config, log *logger.SubLogger, opts []lp2p.Option) (*netwo
 	// in contrast, the Resource Manager represents a hard limit where connections will fail to
 	// be created in the first place once we’ve reached our limits.
 	//
-	lowWM := conf.MaxConns                    // Low  Watermark, ex: 64 (if max_conn = 64)
-	highWM := conf.MaxConns + conf.MinConns() // High Watermark, ex: 78 (if max_conn = 64)
+	lowWM := conf.MaxConns                        // Low  Watermark, ex: 64 (if max_conn = 64)
+	highWM := conf.MaxConns + (conf.MaxConns / 4) // High Watermark, ex: 80 (if max_conn = 64)
 	connMgr, err := lp2pconnmgr.NewConnManager(
 		lowWM, highWM,
 		lp2pconnmgr.WithGracePeriod(time.Minute),

--- a/network/network.go
+++ b/network/network.go
@@ -124,11 +124,12 @@ func newNetwork(conf *Config, log *logger.SubLogger, opts []lp2p.Option) (*netwo
 		return nil, LibP2PError{Err: err}
 	}
 
-	// https://github.com/libp2p/go-libp2p/issues/2616
-	// The connection manager doesn't reject any connections.
-	// It just triggers a pruning run once the high watermark is reached (or surpassed).
+	// https://docs.libp2p.io/concepts/security/dos-mitigation/#limit-the-number-of-connections-your-application-needs
+	// The ConnManager is in charge of pruning connections to stay below the defined high watermark,
+	// in contrast, the Resource Manager represents a hard limit where connections will fail to
+	// be created in the first place once we’ve reached our limits.
 	//
-	lowWM := conf.MinConns()                  // Low  Watermark, ex: 14 (if max_conn = 64)
+	lowWM := conf.MaxConns                    // Low  Watermark, ex: 64 (if max_conn = 64)
 	highWM := conf.MaxConns + conf.MinConns() // High Watermark, ex: 78 (if max_conn = 64)
 	connMgr, err := lp2pconnmgr.NewConnManager(
 		lowWM, highWM,

--- a/network/utils.go
+++ b/network/utils.go
@@ -143,7 +143,7 @@ func BuildConcreteLimitConfig(maxConns int) lp2prcmgr.ConcreteLimitConfig {
 
 		limit.ConnsInbound = maxConnVal
 		limit.ConnsOutbound = maxConnVal
-		limit.Conns = maxConnVal
+		limit.Conns = maxConnVal * 2
 		limit.StreamsInbound = maxConnVal * 16
 		limit.StreamsOutbound = maxConnVal * 16
 		limit.Streams = maxConnVal * 16

--- a/network/utils.go
+++ b/network/utils.go
@@ -11,7 +11,6 @@ import (
 	lp2phost "github.com/libp2p/go-libp2p/core/host"
 	lp2pnetwork "github.com/libp2p/go-libp2p/core/network"
 	lp2ppeer "github.com/libp2p/go-libp2p/core/peer"
-	lp2prcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	lp2pswarm "github.com/libp2p/go-libp2p/p2p/net/swarm"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/pactus-project/pactus/crypto/hash"
@@ -133,32 +132,6 @@ func SubnetsToFilters(subnets []*net.IPNet, action multiaddr.Action) *multiaddr.
 	}
 
 	return filters
-}
-
-func BuildConcreteLimitConfig(maxConns int) lp2prcmgr.ConcreteLimitConfig {
-	changes := lp2prcmgr.PartialLimitConfig{}
-
-	updateResourceLimits := func(limit *lp2prcmgr.ResourceLimits, maxConns int, coefficient float32) {
-		maxConnVal := lp2prcmgr.LimitVal(int(float32(maxConns) * coefficient))
-
-		limit.ConnsInbound = maxConnVal
-		limit.ConnsOutbound = maxConnVal
-		limit.Conns = maxConnVal * 2
-		limit.StreamsInbound = maxConnVal * 16
-		limit.StreamsOutbound = maxConnVal * 16
-		limit.Streams = maxConnVal * 16
-	}
-
-	updateResourceLimits(&changes.System, maxConns, 1)
-	updateResourceLimits(&changes.ServiceDefault, maxConns, 1)
-	updateResourceLimits(&changes.ProtocolDefault, maxConns, 1)
-	updateResourceLimits(&changes.ProtocolPeerDefault, maxConns, 1)
-	updateResourceLimits(&changes.Transient, maxConns, 0.5)
-
-	defaultLimitConfig := lp2prcmgr.DefaultLimits.AutoScale()
-	changedLimitConfig := changes.Build(defaultLimitConfig)
-
-	return changedLimitConfig
 }
 
 func MessageIDFunc(m *lp2pspb.Message) string {

--- a/www/grpc/network.go
+++ b/www/grpc/network.go
@@ -54,6 +54,9 @@ func (s *networkServer) GetNetworkInfo(_ context.Context,
 	peerInfos := make([]*pactus.PeerInfo, 0, ps.Len())
 
 	ps.IteratePeers(func(peer *peerset.Peer) bool {
+		if !peer.IsConnected() {
+			return false
+		}
 		p := new(pactus.PeerInfo)
 		peerInfos = append(peerInfos, p)
 

--- a/www/grpc/network.go
+++ b/www/grpc/network.go
@@ -54,9 +54,6 @@ func (s *networkServer) GetNetworkInfo(_ context.Context,
 	peerInfos := make([]*pactus.PeerInfo, 0, ps.Len())
 
 	ps.IteratePeers(func(peer *peerset.Peer) bool {
-		if !peer.IsConnected() {
-			return false
-		}
 		p := new(pactus.PeerInfo)
 		peerInfos = append(peerInfos, p)
 


### PR DESCRIPTION
## Description

This PR fixes a mistake on resource manager limit. The high watermark limit should be a bit less than the rcmgr connections limit.
Otherwise "High Watermark" trimming never happens because it's higher than the rcmgr limit. 

Read more here:
https://github.com/libp2p/go-libp2p/issues/2628#issuecomment-1809829270