### PR TITLE
fix: change CalculateFee to be backward compatible

### DIFF
--- a/execution/errors.go
+++ b/execution/errors.go
@@ -73,12 +73,3 @@ type SignerBannedError struct {
 func (e SignerBannedError) Error() string {
 	return fmt.Sprintf("the signer is banned: %s", e.addr.String())
 }
-
-// TODO: remove me later.
-type SpamTxError struct {
-	addr crypto.Address
-}
-
-func (s SpamTxError) Error() string {
-	return fmt.Sprintf("the spam tx is rejected: %s", s.addr.String())
-}

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -44,15 +44,6 @@ func (exe *Execution) Execute(trx *tx.Tx, sb sandbox.Sandbox) error {
 		}
 	}
 
-	// TODO: remove me later.
-	if trx.Payload().Type() == payload.TypeTransfer {
-		if trx.Payload().Receiver() != nil && trx.Payload().Signer() == *trx.Payload().Receiver() {
-			return SpamTxError{
-				addr: trx.Payload().Signer(),
-			}
-		}
-	}
-
 	if exists := sb.AnyRecentTransaction(trx.ID()); exists {
 		return TransactionCommittedError{
 			ID: trx.ID(),

--- a/state/state.go
+++ b/state/state.go
@@ -773,7 +773,29 @@ func (st *state) publishEvents(height uint32, blk *block.Block) {
 }
 
 func (st *state) CalculateFee(amt amount.Amount, payloadType payload.Type) amount.Amount {
-	return st.txPool.EstimatedFee(amt, payloadType)
+	switch payloadType {
+	case payload.TypeUnbond,
+		payload.TypeSortition:
+
+		return 0
+
+	case payload.TypeTransfer,
+		payload.TypeBond,
+		payload.TypeWithdraw:
+		fee := amt.MulF64(st.params.FeeFractionDeprecated)
+		fee = util.Max(fee, st.params.MinimumFeeDeprecated)
+		fee = util.Min(fee, st.params.MaximumFeeDeprecated)
+
+		return fee
+
+	default:
+		return 0
+	}
+
+	// TODO:
+	// The above code should be replaced by the below code once the majority of the nodes are upgraded.
+	// This helps to smoothly migrate the nodes.
+	// return st.txPool.EstimatedFee(amt, payloadType)
 }
 
 func (st *state) PublicKey(addr crypto.Address) (crypto.PublicKey, error) {

--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -19,18 +19,22 @@ func newPool(maxSize int, minFee amount.Amount) pool {
 }
 
 func (p *pool) calculateDynamicFee() amount.Amount {
-	totalSize := p.list.Capacity()
-	currentSize := p.list.Size()
-	usageRatio := float64(currentSize) / float64(totalSize)
+	capacity := p.list.Capacity()
+	size := p.list.Size()
+	usageRatio := float64(size) / float64(capacity)
 
 	switch {
 	case usageRatio > 0.90:
-		return p.minFee * 10000
+		return p.minFee * 1000000
 	case usageRatio > 0.80:
-		return p.minFee * 1000
+		return p.minFee * 100000
 	case usageRatio > 0.70:
-		return p.minFee * 100
+		return p.minFee * 10000
+	case usageRatio > 0.60:
+		return p.minFee * 1000
 	case usageRatio > 0.50:
+		return p.minFee * 100
+	case usageRatio > 0.40:
 		return p.minFee * 10
 	default:
 		return p.minFee

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -83,7 +83,7 @@ func (td *testData) shouldPublishTransaction(t *testing.T, id tx.ID) {
 func TestCalculateDynamicFee(t *testing.T) {
 	minFee := amount.Amount(1000)
 	config := Config{
-		MaxSize:   10,
+		MaxSize:   16,
 		MinFeePAC: minFee.ToPAC(),
 	}
 	td := setup(t, &config)
@@ -99,21 +99,29 @@ func TestCalculateDynamicFee(t *testing.T) {
 	// Make sure the pool is empty
 	assert.Equal(t, td.pool.Size(), 0)
 
-	trx1 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee, "ok")
-	trx2 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee, "ok")
-	trx3 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee, "ok")
-	trx4 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee, "ok")
-	trx5 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee*10, "ok")
-	trx6 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee*1000, "ok")
-	trx7 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee*10000, "ok")
+	trx01 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee, "ok")
+	trx02 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee, "ok")
+	trx03 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee, "ok")
+	trx04 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee, "ok")
+	trx05 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee*100, "ok")
+	trx06 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee*100, "ok")
+	trx07 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee*1000, "ok")
+	trx08 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee*10000, "ok")
+	trx09 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee*100000, "ok")
+	trx10 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee*1000000, "ok")
+	trx11 := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), td.RandAmount(), minFee, "ok")
 
-	assert.NoError(t, td.pool.AppendTx(trx1))
-	assert.NoError(t, td.pool.AppendTx(trx2))
-	assert.NoError(t, td.pool.AppendTx(trx3))
-	assert.NoError(t, td.pool.AppendTx(trx4))
-	assert.NoError(t, td.pool.AppendTx(trx5))
-	assert.NoError(t, td.pool.AppendTx(trx6))
-	assert.NoError(t, td.pool.AppendTx(trx7))
+	assert.NoError(t, td.pool.AppendTx(trx01))
+	assert.NoError(t, td.pool.AppendTx(trx02))
+	assert.NoError(t, td.pool.AppendTx(trx03))
+	assert.NoError(t, td.pool.AppendTx(trx04))
+	assert.NoError(t, td.pool.AppendTx(trx05))
+	assert.NoError(t, td.pool.AppendTx(trx06))
+	assert.NoError(t, td.pool.AppendTx(trx07))
+	assert.NoError(t, td.pool.AppendTx(trx08))
+	assert.NoError(t, td.pool.AppendTx(trx09))
+	assert.NoError(t, td.pool.AppendTx(trx10))
+	assert.Error(t, td.pool.AppendTx(trx11))
 }
 
 func TestAppendAndRemove(t *testing.T) {
@@ -160,7 +168,7 @@ func TestFullPool(t *testing.T) {
 
 	for i := 0; i < len(trxs); i++ {
 		trx := tx.NewTransferTx(randHeight+1, senderAddr,
-			td.RandAccAddress(), 1e9, 100_000_000, "ok")
+			td.RandAccAddress(), 1e9, 1000_000_000, "ok")
 
 		assert.NoError(t, td.pool.AppendTx(trx))
 		trxs[i] = trx


### PR DESCRIPTION
## Description

This PR  changes `CalculateFee` to be backward compatible with the previous versions.