### PR TITLE
fix(consensus): move to new round on decided vote

### DIFF
--- a/consensus/config.go
+++ b/consensus/config.go
@@ -12,7 +12,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		ChangeProposerTimeout:    8 * time.Second,
 		ChangeProposerDelta:      4 * time.Second,
-		MinimumAvailabilityScore: 0.9,
+		MinimumAvailabilityScore: 0.6666666,
 	}
 }
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -314,6 +314,24 @@ func (cs *consensus) AddVote(v *vote.Vote) {
 
 			return
 		}
+
+		// TODO: merge me with strongTermination
+		if v.Type() == vote.VoteTypeCPDecided {
+			if v.Round() > cs.round {
+				if v.CPValue() == vote.CPValueOne {
+					cs.round = cs.round + 1
+					cs.cpDecided = 1
+					cs.enterNewState(cs.proposeState)
+				} else if v.CPValue() == vote.CPValueZero {
+					roundProposal := cs.log.RoundProposal(cs.round)
+					if roundProposal == nil {
+						cs.queryProposal()
+					}
+					cs.cpDecided = 0
+					cs.enterNewState(cs.prepareState)
+				}
+			}
+		}
 	}
 
 	added, err := cs.log.AddVote(v)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -318,8 +318,9 @@ func (cs *consensus) AddVote(v *vote.Vote) {
 		// TODO: merge me with strongTermination
 		if v.Type() == vote.VoteTypeCPDecided {
 			if v.Round() > cs.round {
+				cs.logger.Info("move to new round on decided vote", "vote", v)
 				if v.CPValue() == vote.CPValueOne {
-					cs.round = cs.round + 1
+					cs.round = v.Round() + 1
 					cs.cpDecided = 1
 					cs.enterNewState(cs.proposeState)
 				} else if v.CPValue() == vote.CPValueZero {
@@ -327,6 +328,7 @@ func (cs *consensus) AddVote(v *vote.Vote) {
 					if roundProposal == nil {
 						cs.queryProposal()
 					}
+					cs.round = v.Round()
 					cs.cpDecided = 0
 					cs.enterNewState(cs.prepareState)
 				}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -315,25 +315,7 @@ func (cs *consensus) AddVote(v *vote.Vote) {
 			return
 		}
 
-		// TODO: merge me with strongTermination
-		if v.Type() == vote.VoteTypeCPDecided {
-			if v.Round() > cs.round {
-				cs.logger.Info("move to new round on decided vote", "vote", v)
-				if v.CPValue() == vote.CPValueOne {
-					cs.round = v.Round() + 1
-					cs.cpDecided = 1
-					cs.enterNewState(cs.proposeState)
-				} else if v.CPValue() == vote.CPValueZero {
-					roundProposal := cs.log.RoundProposal(cs.round)
-					if roundProposal == nil {
-						cs.queryProposal()
-					}
-					cs.round = v.Round()
-					cs.cpDecided = 0
-					cs.enterNewState(cs.prepareState)
-				}
-			}
-		}
+		cs.strongTerminationOnDecidedVote(v)
 	}
 
 	added, err := cs.log.AddVote(v)


### PR DESCRIPTION
## Description

This PR applies the following patches to the consensus:

1. Once a validator sees a proper and justified "Decided" vote, it moves the consensus to the vote's round, even if it is a prior round.
2. Considering 1/3 of faulty nodes in a faulty network, the minimum availability score is set to 0.666.