### PR TITLE
chore: bumping version to 1.1.7

### DIFF
--- a/docs/patching.md
+++ b/docs/patching.md
@@ -46,9 +46,9 @@ create environment variables for the release version, which will be used in subs
 Keep your terminal open for further steps.
 
 ```bash
-PRV_VER="1.1.5"
-CUR_VER="1.1.6"
-NEXT_VER="1.1.7"
+PRV_VER="1.1.6"
+CUR_VER="1.1.7"
+NEXT_VER="1.1.8"
 TAG_NAME="v${CUR_VER}"
 TAG_MSG="Version ${CUR_VER}"
 BASE_BRANCH="1.1.x"

--- a/version/version.go
+++ b/version/version.go
@@ -15,8 +15,8 @@ import (
 var NodeVersion = Version{
 	Major: 1,
 	Minor: 1,
-	Patch: 6,
-	Meta:  "",
+	Patch: 7,
+	Meta:  "beta",
 }
 
 // These struct follow the semantic versioning 2.0.0 spec (http://semver.org/)


### PR DESCRIPTION
Bumping version to 1.1.7