### PR TITLE
fix(network): set latest support version to 1.1.6

### DIFF
--- a/sync/config.go
+++ b/sync/config.go
@@ -33,7 +33,7 @@ func DefaultConfig() *Config {
 		LatestSupportingVer: version.Version{
 			Major: 1,
 			Minor: 1,
-			Patch: 0,
+			Patch: 6,
 		},
 	}
 }


### PR DESCRIPTION
# Description

This PR updates the latest supported version to 1.1.6. As a result, connections with nodes running lower versions will be rejected.