### PR TITLE
fix(consensus): only proposer responds to the query proposal

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -333,6 +333,13 @@ func (cs *consensus) proposer(round int16) *validator.Validator {
 	return cs.bcState.Proposer(round)
 }
 
+func (cs *consensus) IsProposer() bool {
+	cs.lk.RLock()
+	defer cs.lk.RUnlock()
+
+	return cs.isProposer()
+}
+
 func (cs *consensus) isProposer() bool {
 	return cs.proposer(cs.round).Address() == cs.valKey.Address()
 }

--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -15,6 +15,7 @@ type Reader interface {
 	HasVote(h hash.Hash) bool
 	HeightRound() (uint32, int16)
 	IsActive() bool
+	IsProposer() bool
 }
 
 type Consensus interface {

--- a/consensus/manager.go
+++ b/consensus/manager.go
@@ -81,11 +81,16 @@ func (mgr *manager) PickRandomVote(round int16) *vote.Vote {
 	return cons.PickRandomVote(round)
 }
 
-// Proposal returns the proposal for a specific round from a random consensus instance.
+// Proposal returns the proposal for a specific round if one of the consensus instances is the proposer.
+// Otherwise, it returns nil.
 func (mgr *manager) Proposal() *proposal.Proposal {
-	cons := mgr.getBestInstance()
+	for _, cons := range mgr.instances {
+		if cons.IsProposer() {
+			return cons.Proposal()
+		}
+	}
 
-	return cons.Proposal()
+	return nil
 }
 
 // HeightRound retrieves the current height and round from a random consensus instance.

--- a/consensus/mock.go
+++ b/consensus/mock.go
@@ -21,6 +21,7 @@ type MockConsensus struct {
 	Votes       []*vote.Vote
 	CurProposal *proposal.Proposal
 	Active      bool
+	Proposer    bool
 	Height      uint32
 	Round       int16
 }
@@ -130,6 +131,13 @@ func (m *MockConsensus) IsActive() bool {
 	defer m.lk.Unlock()
 
 	return m.Active
+}
+
+func (m *MockConsensus) IsProposer() bool {
+	m.lk.Lock()
+	defer m.lk.Unlock()
+
+	return m.Proposer
 }
 
 func (m *MockConsensus) SetActive(active bool) {

--- a/sync/handler_proposal_test.go
+++ b/sync/handler_proposal_test.go
@@ -16,7 +16,8 @@ func TestParsingProposalMessages(t *testing.T) {
 		msg := message.NewProposalMessage(prop)
 		pid := td.RandPeerID()
 
+		td.consMocks[0].Proposer = true
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
-		assert.NotNil(t, td.consMgr.Proposal())
+		assert.Equal(t, prop, td.consMgr.Proposal())
 	})
 }

--- a/sync/handler_query_proposal_test.go
+++ b/sync/handler_query_proposal_test.go
@@ -14,6 +14,7 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 	prop, _ := td.GenerateTestProposal(consensusHeight, 0)
 	pid := td.RandPeerID()
 	td.consMgr.SetProposal(prop)
+	td.consMocks[0].Proposer = true
 
 	t.Run("not the same height", func(t *testing.T) {
 		msg := message.NewQueryProposalMessage(consensusHeight+1, td.RandValAddress())


### PR DESCRIPTION
## Description

The proposer responds to the query-proposal message. This helps to reduce the number of consensus messages.