### PR TITLE
fix(consensus): add round to query proposal message

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -609,6 +609,9 @@ func TestPickRandomVote(t *testing.T) {
 
 	rndVote1 := td.consP.PickRandomVote(1)
 	assert.Equal(t, rndVote1.Type(), vote.VoteTypePrepare)
+
+	rndVote2 := td.consP.PickRandomVote(2)
+	assert.Nil(t, rndVote2)
 }
 
 func TestSetProposalFromPreviousRound(t *testing.T) {

--- a/sync/bundle/message/query_proposal.go
+++ b/sync/bundle/message/query_proposal.go
@@ -4,21 +4,28 @@ import (
 	"fmt"
 
 	"github.com/pactus-project/pactus/crypto"
+	"github.com/pactus-project/pactus/util/errors"
 )
 
 type QueryProposalMessage struct {
 	Height  uint32         `cbor:"1,keyasint"`
+	Round   int16          `cbor:"3,keyasint"`
 	Querier crypto.Address `cbor:"2,keyasint"`
 }
 
-func NewQueryProposalMessage(height uint32, querier crypto.Address) *QueryProposalMessage {
+func NewQueryProposalMessage(height uint32, round int16, querier crypto.Address) *QueryProposalMessage {
 	return &QueryProposalMessage{
 		Height:  height,
+		Round:   round,
 		Querier: querier,
 	}
 }
 
 func (m *QueryProposalMessage) BasicCheck() error {
+	if m.Round < 0 {
+		return errors.Error(errors.ErrInvalidRound)
+	}
+
 	return nil
 }
 

--- a/sync/bundle/message/query_proposal_test.go
+++ b/sync/bundle/message/query_proposal_test.go
@@ -23,7 +23,7 @@ func TestQueryProposalMessage(t *testing.T) {
 	})
 
 	t.Run("OK", func(t *testing.T) {
-		m := NewQueryVotesMessage(100, 0, ts.RandValAddress())
+		m := NewQueryProposalMessage(100, 0, ts.RandValAddress())
 
 		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), "100")

--- a/sync/bundle/message/query_proposal_test.go
+++ b/sync/bundle/message/query_proposal_test.go
@@ -3,6 +3,7 @@ package message
 import (
 	"testing"
 
+	"github.com/pactus-project/pactus/util/errors"
 	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,6 +16,16 @@ func TestQueryProposalType(t *testing.T) {
 func TestQueryProposalMessage(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	m := NewQueryProposalMessage(0, ts.RandValAddress())
-	assert.NoError(t, m.BasicCheck())
+	t.Run("Invalid round", func(t *testing.T) {
+		m := NewQueryProposalMessage(0, -1, ts.RandValAddress())
+
+		assert.Equal(t, errors.Code(m.BasicCheck()), errors.ErrInvalidRound)
+	})
+
+	t.Run("OK", func(t *testing.T) {
+		m := NewQueryVotesMessage(100, 0, ts.RandValAddress())
+
+		assert.NoError(t, m.BasicCheck())
+		assert.Contains(t, m.String(), "100")
+	})
 }

--- a/sync/handler_query_proposal.go
+++ b/sync/handler_query_proposal.go
@@ -39,18 +39,23 @@ func (handler *queryProposalHandler) ParseMessage(m message.Message, _ peer.ID) 
 	}
 
 	if !handler.rateLimit.AllowRequest() {
-		handler.logger.Warn("ignoring QueryProposal, rate limit exceeded", "msg", msg)
+		handler.logger.Debug("ignoring QueryProposal, rate limit exceeded", "msg", msg)
 
 		return nil
 	}
 
-	height, _ := handler.consMgr.HeightRound()
-	if msg.Height == height {
-		prop := handler.consMgr.Proposal()
-		if prop != nil {
-			response := message.NewProposalMessage(prop)
-			handler.broadcast(response)
-		}
+	height, round := handler.consMgr.HeightRound()
+	if msg.Height != height || msg.Round != round {
+		handler.logger.Debug("ignoring QueryProposal, not same height/round", "msg", msg,
+			"height", height, "round", round)
+
+		return nil
+	}
+
+	prop := handler.consMgr.Proposal()
+	if prop != nil {
+		response := message.NewProposalMessage(prop)
+		handler.broadcast(response)
 	}
 
 	return nil

--- a/sync/handler_query_proposal_test.go
+++ b/sync/handler_query_proposal_test.go
@@ -10,13 +10,13 @@ import (
 func TestParsingQueryProposalMessages(t *testing.T) {
 	td := setup(t, nil)
 
-	consensusHeight, _ := td.consMgr.HeightRound()
-	prop, _ := td.GenerateTestProposal(consensusHeight, 0)
+	consHeight, consRound := td.consMgr.HeightRound()
+	prop, _ := td.GenerateTestProposal(consHeight, 0)
 	pid := td.RandPeerID()
 	td.consMgr.SetProposal(prop)
 
 	t.Run("doesn't have active validator", func(t *testing.T) {
-		msg := message.NewQueryProposalMessage(consensusHeight+1, td.RandValAddress())
+		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeVote)
@@ -25,7 +25,7 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 	td.consMocks[0].Active = true
 
 	t.Run("not the proposer", func(t *testing.T) {
-		msg := message.NewQueryProposalMessage(consensusHeight+1, td.RandValAddress())
+		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeVote)
@@ -34,14 +34,21 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 	td.consMocks[0].Proposer = true
 
 	t.Run("not the same height", func(t *testing.T) {
-		msg := message.NewQueryProposalMessage(consensusHeight+1, td.RandValAddress())
+		msg := message.NewQueryProposalMessage(consHeight+1, consRound, td.RandValAddress())
+		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+
+		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
+	})
+
+	t.Run("not the same round", func(t *testing.T) {
+		msg := message.NewQueryProposalMessage(consHeight, consRound+1, td.RandValAddress())
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
 	})
 
 	t.Run("should respond to the query proposal message", func(t *testing.T) {
-		msg := message.NewQueryProposalMessage(consensusHeight, td.RandValAddress())
+		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		bdl := td.shouldPublishMessageWithThisType(t, message.TypeProposal)
@@ -50,7 +57,7 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 
 	t.Run("doesn't have the proposal", func(t *testing.T) {
 		td.consMocks[0].CurProposal = nil
-		msg := message.NewQueryProposalMessage(consensusHeight, td.RandValAddress())
+		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
 		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
@@ -60,8 +67,8 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 func TestBroadcastingQueryProposalMessages(t *testing.T) {
 	td := setup(t, nil)
 
-	consensusHeight := td.state.LastBlockHeight() + 1
-	msg := message.NewQueryProposalMessage(consensusHeight, td.RandValAddress())
+	consHeight, consRound := td.consMgr.HeightRound()
+	msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
 	td.sync.broadcast(msg)
 
 	td.shouldPublishMessageWithThisType(t, message.TypeQueryProposal)

--- a/sync/handler_query_votes.go
+++ b/sync/handler_query_votes.go
@@ -33,18 +33,23 @@ func (handler *queryVotesHandler) ParseMessage(m message.Message, _ peer.ID) err
 	}
 
 	if !handler.rateLimit.AllowRequest() {
-		handler.logger.Warn("ignoring QueryVotes, rate limit exceeded", "msg", msg)
+		handler.logger.Debug("ignoring QueryVotes, rate limit exceeded", "msg", msg)
 
 		return nil
 	}
 
 	height, _ := handler.consMgr.HeightRound()
-	if msg.Height == height {
-		v := handler.consMgr.PickRandomVote(msg.Round)
-		if v != nil {
-			response := message.NewVoteMessage(v)
-			handler.broadcast(response)
-		}
+	if msg.Height != height {
+		handler.logger.Debug("ignoring QueryVotes, not same height", "msg", msg,
+			"height", height)
+
+		return nil
+	}
+
+	v := handler.consMgr.PickRandomVote(msg.Round)
+	if v != nil {
+		response := message.NewVoteMessage(v)
+		handler.broadcast(response)
 	}
 
 	return nil

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -310,7 +310,7 @@ func TestTestNetFlags(t *testing.T) {
 	td := setup(t, nil)
 
 	td.addValidatorToCommittee(t, td.sync.valKeys[0].PublicKey())
-	bdl := td.sync.prepareBundle(message.NewQueryProposalMessage(td.RandHeight(), td.RandValAddress()))
+	bdl := td.sync.prepareBundle(message.NewQueryProposalMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 	require.False(t, util.IsFlagSet(bdl.Flags, bundle.BundleFlagNetworkMainnet), "invalid flag: %v", bdl)
 	require.True(t, util.IsFlagSet(bdl.Flags, bundle.BundleFlagNetworkTestnet), "invalid flag: %v", bdl)
 }
@@ -409,7 +409,7 @@ func TestBroadcastBlockAnnounce(t *testing.T) {
 func TestBundleSequenceNo(t *testing.T) {
 	td := setup(t, nil)
 
-	msg := message.NewQueryProposalMessage(td.RandHeight(), td.RandValAddress())
+	msg := message.NewQueryProposalMessage(td.RandHeight(), td.RandRound(), td.RandValAddress())
 
 	td.sync.broadcast(msg)
 	bdl1 := td.shouldPublishMessageWithThisType(t, message.TypeQueryProposal)


### PR DESCRIPTION
## Description

This PR adds a round to the query proposal message. By doing so, messages with expired rounds will be ignored.