### PR TITLE
test: add more logs for network-test

### DIFF
--- a/network/gossip.go
+++ b/network/gossip.go
@@ -72,7 +72,7 @@ func newGossipService(ctx context.Context, host lp2phost.Host, eventCh chan Even
 
 // Broadcast broadcasts a message with the specified topic ID to the network.
 func (g *gossipService) Broadcast(msg []byte, topicID TopicID) error {
-	g.logger.Trace("publishing new message", "topic", topicID)
+	g.logger.Debug("publishing new message", "topic", topicID)
 
 	switch topicID {
 	case TopicIDBlock:

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -210,7 +210,7 @@ func TestNetwork(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	t.Run("Supported Protocols", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		require.EventuallyWithT(t, func(_ *assert.CollectT) {
 			protos := networkM.Protocols()
@@ -232,7 +232,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("all nodes have at least one connection to the bootstrap node B", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.GreaterOrEqual(c, networkP.NumConnectedPeers(), 1) // Connected to B, M, N, X
@@ -256,7 +256,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("Gossip: all nodes receive gossip messages", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		msg := ts.RandBytes(64)
 
@@ -274,7 +274,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("only nodes subscribed to the consensus topic receive consensus gossip messages", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		msg := ts.RandBytes(64)
 
@@ -291,7 +291,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("node P (public) is directly accessible by nodes M and N (private behind NAT)", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		require.NoError(t, networkM.host.Connect(networkM.ctx, *publicAddrInfo))
 
@@ -303,7 +303,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("node P (public) is directly accessible by node X (private behind NAT, without relay)", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		require.NoError(t, networkX.host.Connect(networkX.ctx, *publicAddrInfo))
 
@@ -315,7 +315,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("node P (public) is directly accessible by node B (bootstrap)", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		msgB := ts.RandBytes(64)
 
@@ -326,7 +326,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("Ignore broadcasting identical messages", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		msg := ts.RandBytes(64)
 
@@ -343,7 +343,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("node X (private, not connected via relay) is not accessible by node M", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		msgM := ts.RandBytes(64)
 		require.Error(t, networkM.SendTo(msgM, networkX.SelfID()))
@@ -358,7 +358,7 @@ func TestNetwork(t *testing.T) {
 	// })
 
 	t.Run("closing connection", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		msgB := ts.RandBytes(64)
 
@@ -370,7 +370,7 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("Reachability Status", func(t *testing.T) {
-		fmt.Println(t.Name())
+		t.Log(t.Name())
 
 		assert.Equal(t, networkP.ReachabilityStatus(), "Public")
 		assert.Equal(t, networkB.ReachabilityStatus(), "Public")

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -210,6 +210,8 @@ func TestNetwork(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	t.Run("Supported Protocols", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		require.EventuallyWithT(t, func(_ *assert.CollectT) {
 			protos := networkM.Protocols()
 			assert.Contains(t, protos, lp2pproto.ProtoIDv2Stop)
@@ -230,6 +232,8 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("all nodes have at least one connection to the bootstrap node B", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.GreaterOrEqual(c, networkP.NumConnectedPeers(), 1) // Connected to B, M, N, X
 		}, 5*time.Second, 100*time.Millisecond)
@@ -252,6 +256,8 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("Gossip: all nodes receive gossip messages", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		msg := ts.RandBytes(64)
 
 		require.NoError(t, networkP.Broadcast(msg, TopicIDBlock))
@@ -268,6 +274,8 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("only nodes subscribed to the consensus topic receive consensus gossip messages", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		msg := ts.RandBytes(64)
 
 		require.NoError(t, networkP.Broadcast(msg, TopicIDConsensus))
@@ -283,6 +291,8 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("node P (public) is directly accessible by nodes M and N (private behind NAT)", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		require.NoError(t, networkM.host.Connect(networkM.ctx, *publicAddrInfo))
 
 		msgM := ts.RandBytes(64)
@@ -293,6 +303,8 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("node P (public) is directly accessible by node X (private behind NAT, without relay)", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		require.NoError(t, networkX.host.Connect(networkX.ctx, *publicAddrInfo))
 
 		msgX := ts.RandBytes(64)
@@ -303,6 +315,8 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("node P (public) is directly accessible by node B (bootstrap)", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		msgB := ts.RandBytes(64)
 
 		require.NoError(t, networkB.SendTo(msgB, networkP.SelfID()))
@@ -312,6 +326,8 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("Ignore broadcasting identical messages", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		msg := ts.RandBytes(64)
 
 		require.NoError(t, networkM.Broadcast(msg, TopicIDBlock))
@@ -327,6 +343,8 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("node X (private, not connected via relay) is not accessible by node M", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		msgM := ts.RandBytes(64)
 		require.Error(t, networkM.SendTo(msgM, networkX.SelfID()))
 	})
@@ -340,6 +358,8 @@ func TestNetwork(t *testing.T) {
 	// })
 
 	t.Run("closing connection", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		msgB := ts.RandBytes(64)
 
 		networkP.Stop()
@@ -350,6 +370,8 @@ func TestNetwork(t *testing.T) {
 	})
 
 	t.Run("Reachability Status", func(t *testing.T) {
+		fmt.Println(t.Name())
+
 		assert.Equal(t, networkP.ReachabilityStatus(), "Public")
 		assert.Equal(t, networkB.ReachabilityStatus(), "Public")
 		assert.Equal(t, networkM.ReachabilityStatus(), "Private")


### PR DESCRIPTION
## Description

This PR adds more logs for the NetworkTest to trace the test failure.