### PR TITLE
fix(state): improve node startup by optimizing availability score calculation

### DIFF
--- a/consensus/propose.go
+++ b/consensus/propose.go
@@ -29,7 +29,7 @@ func (s *proposeState) decide() {
 	// TODO: write test for me
 	score := s.bcState.AvailabilityScore(proposer.Number())
 
-	// Based on PIP-19, if the Availability Score is less than 0.9,
+	// Based on PIP-19, if the Availability Score is less than the Minimum threshold,
 	// we initiate the Change-Proposer phase.
 	if score < s.config.MinimumAvailabilityScore {
 		s.logger.Info("availability score of proposer is low",

--- a/fastconsensus/propose.go
+++ b/fastconsensus/propose.go
@@ -29,7 +29,7 @@ func (s *proposeState) decide() {
 	// TODO: write test for me
 	score := s.bcState.AvailabilityScore(proposer.Number())
 
-	// Based on PIP-19, if the Availability Score is less than 0.9,
+	// Based on PIP-19, if the Availability Score is less than the Minimum threshold,
 	// we initiate the Change-Proposer phase.
 	if score < s.config.MinimumAvailabilityScore {
 		s.logger.Info("availability score of proposer is low",

--- a/state/state.go
+++ b/state/state.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 	"time"
@@ -110,11 +111,15 @@ func LoadOrNewState(
 		if err != nil {
 			return nil, err
 		}
-		blk, err := cb.ToBlock()
+		// This code decodes the block certificate from the block data
+		// without decoding the header and transactions.
+		r := bytes.NewReader(cb.Data[138:]) // Block header is 138 bytes
+		cert := new(certificate.BlockCertificate)
+		err = cert.Decode(r)
 		if err != nil {
 			return nil, err
 		}
-		scoreMgr.SetCertificate(blk.PrevCertificate())
+		scoreMgr.SetCertificate(cert)
 	}
 	st.scoreMgr = scoreMgr
 


### PR DESCRIPTION
## Description

Instead of decoding the full block, use the block header to obtain the prev certificate.

## Related issue(s)

- Fixes #1337