### PR TITLE
fix(pactus-shell): pactus shell support basic auth

### DIFF
--- a/cmd/shell/main.go
+++ b/cmd/shell/main.go
@@ -1,16 +1,15 @@
 package main
 
 import (
-	"context"
-
+	"encoding/base64"
+	"fmt"
 	"github.com/NathanBaulch/protoc-gen-cobra/client"
 	"github.com/NathanBaulch/protoc-gen-cobra/naming"
 	"github.com/pactus-project/pactus/cmd"
-	"github.com/pactus-project/pactus/www/grpc/basicauth"
 	pb "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
@@ -19,23 +18,20 @@ const (
 )
 
 func main() {
+	var (
+		username string
+		password string
+	)
+
 	rootCmd := &cobra.Command{
 		Use:   "shell",
 		Short: "Pactus Shell",
 		Long:  `pactus-shell is a command line tool for interacting with the Pactus blockchain using gRPC`,
 	}
 
-	auth := &basicauth.BasicAuth{}
-
 	client.RegisterFlagBinder(func(fs *pflag.FlagSet, namer naming.Namer) {
-		fs.StringVar(&auth.Username, namer("auth-username"), "", "username for gRPC basic authentication")
-		fs.StringVar(&auth.Password, namer("auth-password"), "", "password for gRPC basic authentication")
-	})
-
-	client.RegisterPreDialer(func(_ context.Context, opts *[]grpc.DialOption) error {
-		*opts = append(*opts, grpc.WithPerRPCCredentials(auth))
-
-		return nil
+		fs.StringVar(&username, namer("auth-username"), "", "username for gRPC basic authentication")
+		fs.StringVar(&password, namer("auth-password"), "", "password for gRPC basic authentication")
 	})
 
 	changeDefaultParameters := func(c *cobra.Command) *cobra.Command {
@@ -46,6 +42,16 @@ func main() {
 		c.PersistentFlags().Lookup("response-format").DefValue = defaultResponseFormat
 
 		return c
+	}
+
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if username != "" && password != "" {
+			auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+			md := metadata.Pairs("authorization", "Basic "+auth)
+			ctx := metadata.NewOutgoingContext(cmd.Context(), md)
+			cmd.SetContext(ctx)
+		}
+		return nil
 	}
 
 	rootCmd.AddCommand(changeDefaultParameters(pb.BlockchainClientCommand()))

--- a/cmd/shell/main.go
+++ b/cmd/shell/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+
 	"github.com/NathanBaulch/protoc-gen-cobra/client"
 	"github.com/NathanBaulch/protoc-gen-cobra/naming"
 	"github.com/pactus-project/pactus/cmd"
@@ -44,13 +45,14 @@ func main() {
 		return c
 	}
 
-	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		if username != "" && password != "" {
 			auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 			md := metadata.Pairs("authorization", "Basic "+auth)
 			ctx := metadata.NewOutgoingContext(cmd.Context(), md)
 			cmd.SetContext(ctx)
 		}
+
 		return nil
 	}
 


### PR DESCRIPTION
## Description

Before pactus shell don't pass authentication basic auth for gRPC, currently supported and pass switchs:

- `--auth-username`
- `--auth-password`

## Related issue(s)

- Fixes #1376