### PR TITLE
test(network): add path to peerstore in Network tests

### DIFF
--- a/network/network_test.go
+++ b/network/network_test.go
@@ -50,6 +50,7 @@ func testConfig() *Config {
 		ForcePrivateNetwork:  true,
 		NetworkName:          "test",
 		DefaultPort:          12345,
+		PeerStorePath:        util.TempFilePath(),
 	}
 }
 


### PR DESCRIPTION
## Description

This PR adds temporary path to `peerstore` inside tests.