### PR TITLE
feat(wallet): query incremental timeout

### DIFF
--- a/www/grpc/wallet.go
+++ b/www/grpc/wallet.go
@@ -120,7 +120,7 @@ func (s *walletServer) UnloadWallet(_ context.Context,
 func (s *walletServer) GetTotalBalance(_ context.Context,
 	req *pactus.GetTotalBalanceRequest,
 ) (*pactus.GetTotalBalanceResponse, error) {
-	balance, err := s.walletManager.TotalBalance(req.WalletName) //nolint
+	balance, err := s.walletManager.TotalBalance(req.WalletName)
 	if err != nil {
 		return nil, err
 	}

--- a/www/grpc/wallet.go
+++ b/www/grpc/wallet.go
@@ -120,7 +120,7 @@ func (s *walletServer) UnloadWallet(_ context.Context,
 func (s *walletServer) GetTotalBalance(_ context.Context,
 	req *pactus.GetTotalBalanceRequest,
 ) (*pactus.GetTotalBalanceResponse, error) {
-	balance, err := s.walletManager.TotalBalance(req.WalletName)
+	balance, err := s.walletManager.TotalBalance(req.WalletName) //nolint
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This PR creates a time-out for querying data from gRPC on the wallet. we set a timeout for 5 seconds where the default is 30 seconds. we can make sure a slow RPC won't slow down the proccess.