### PR TITLE
feat(wallet): add timeout client connection

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -388,7 +388,8 @@ func StartNode(workingDir string, passwordFetcher func(*wallet.Wallet) (string, 
 	}
 
 	defaultWalletPath := PactusDefaultWalletPath(workingDir)
-	walletInstance, err := wallet.Open(defaultWalletPath, true)
+	walletInstance, err := wallet.Open(defaultWalletPath, true,
+		wallet.WithCustomServers([]string{conf.GRPC.Listen}))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -170,8 +170,6 @@ func run(n *node.Node, wlt *wallet.Wallet, app *gtk.Application) {
 	grpcAddr := n.GRPC().Address()
 	cmd.PrintInfoMsgf("connect wallet to grpc server: %s\n", grpcAddr)
 
-	wlt.SetServerAddr(grpcAddr)
-
 	nodeModel := newNodeModel(n)
 	walletModel := newWalletModel(wlt, n)
 

--- a/cmd/wallet/main.go
+++ b/cmd/wallet/main.go
@@ -9,10 +9,10 @@ import (
 )
 
 var (
-	pathOpt       *string
-	offlineOpt    *bool
-	serverAddrOpt *string
-	timeoutOpt    *int
+	pathOpt        *string
+	offlineOpt     *bool
+	serverAddrsOpt *[]string
+	timeoutOpt     *int
 )
 
 func addPasswordOption(c *cobra.Command) *string {
@@ -21,16 +21,20 @@ func addPasswordOption(c *cobra.Command) *string {
 }
 
 func openWallet() (*wallet.Wallet, error) {
-	wlt, err := wallet.Open(*pathOpt, *offlineOpt)
+	opts := make([]wallet.Option, 0)
+
+	if *serverAddrsOpt != nil {
+		opts = append(opts, wallet.WithCustomServers(*serverAddrsOpt))
+	}
+
+	if *timeoutOpt > 0 {
+		opts = append(opts, wallet.WithTimeout(time.Duration(*timeoutOpt)*time.Second))
+	}
+
+	wlt, err := wallet.Open(*pathOpt, *offlineOpt, opts...)
 	if err != nil {
 		return nil, err
 	}
-
-	if *serverAddrOpt != "" {
-		wlt.SetServerAddr(*serverAddrOpt)
-	}
-
-	wlt.SetClientTimeout(time.Duration(*timeoutOpt) * time.Second)
 
 	return wlt, err
 }
@@ -48,12 +52,9 @@ func main() {
 	pathOpt = rootCmd.PersistentFlags().String("path",
 		cmd.PactusDefaultWalletPath(cmd.PactusDefaultHomeDir()), "the path to the wallet file")
 	offlineOpt = rootCmd.PersistentFlags().Bool("offline", false, "offline mode")
-	serverAddrOpt = rootCmd.PersistentFlags().String("server", "", "server gRPC address")
+	serverAddrsOpt = rootCmd.PersistentFlags().StringSlice("servers", []string{}, "servers gRPC address")
 	timeoutOpt = rootCmd.PersistentFlags().Int("timeout", 1,
-		"specifies the timeout duration for the client connection in seconds. "+
-			"this timeout determines how long the client will attempt to establish a connection with the server "+
-			"before failing with an error. Adjust this value based on network conditions and server response times "+
-			"to ensure a balance between responsiveness and reliability.")
+		"specifies the timeout duration for the client connection in seconds")
 
 	buildCreateCmd(rootCmd)
 	buildRecoverCmd(rootCmd)

--- a/cmd/wallet/main.go
+++ b/cmd/wallet/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/pactus-project/pactus/cmd"
 	"github.com/pactus-project/pactus/wallet"
 	"github.com/spf13/cobra"
@@ -10,6 +12,7 @@ var (
 	pathOpt       *string
 	offlineOpt    *bool
 	serverAddrOpt *string
+	timeoutOpt    *int
 )
 
 func addPasswordOption(c *cobra.Command) *string {
@@ -26,6 +29,8 @@ func openWallet() (*wallet.Wallet, error) {
 	if *serverAddrOpt != "" {
 		wlt.SetServerAddr(*serverAddrOpt)
 	}
+
+	wlt.SetClientTimeout(time.Duration(*timeoutOpt) * time.Second)
 
 	return wlt, err
 }
@@ -44,6 +49,11 @@ func main() {
 		cmd.PactusDefaultWalletPath(cmd.PactusDefaultHomeDir()), "the path to the wallet file")
 	offlineOpt = rootCmd.PersistentFlags().Bool("offline", false, "offline mode")
 	serverAddrOpt = rootCmd.PersistentFlags().String("server", "", "server gRPC address")
+	timeoutOpt = rootCmd.PersistentFlags().Int("timeout", 1,
+		"specifies the timeout duration for the client connection in seconds. "+
+			"this timeout determines how long the client will attempt to establish a connection with the server "+
+			"before failing with an error. Adjust this value based on network conditions and server response times "+
+			"to ensure a balance between responsiveness and reliability.")
 
 	buildCreateCmd(rootCmd)
 	buildRecoverCmd(rootCmd)

--- a/wallet/client.go
+++ b/wallet/client.go
@@ -58,7 +58,7 @@ func (c *grpcClient) connect() error {
 		opts := make([]grpc.DialOption, 0)
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-		if len(c.servers) > 0 {
+		if len(c.servers) > 1 {
 			opts = append(opts, grpc.WithContextDialer(func(_ context.Context, s string) (net.Conn, error) {
 				return net.DialTimeout("tcp", s, c.timeout)
 			}))

--- a/wallet/client.go
+++ b/wallet/client.go
@@ -67,9 +67,7 @@ func (c *grpcClient) connect() error {
 		_, err = blockchainClient.GetBlockchainInfo(c.ctx,
 			&pactus.GetBlockchainInfoRequest{})
 		if err != nil {
-			if err := conn.Close(); err != nil {
-				return err
-			}
+			_ = conn.Close()
 
 			continue
 		}

--- a/wallet/client.go
+++ b/wallet/client.go
@@ -66,7 +66,7 @@ func (c *grpcClient) connect() error {
 
 		conn, err := grpc.NewClient(server, opts...)
 		if err != nil {
-			return err
+			continue
 		}
 
 		blockchainClient := pactus.NewBlockchainClient(conn)

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -84,11 +84,10 @@ func (wm *Manager) LoadWallet(walletName, serverAddr string) error {
 	}
 
 	walletPath := util.MakeAbs(filepath.Join(wm.walletDirectory, walletName))
-	wlt, err := Open(walletPath, true)
+	wlt, err := Open(walletPath, true, WithCustomServers([]string{serverAddr}))
 	if err != nil {
 		return err
 	}
-	wlt.SetServerAddr(serverAddr)
 
 	wm.wallets[walletName] = wlt
 

--- a/wallet/options.go
+++ b/wallet/options.go
@@ -1,0 +1,27 @@
+package wallet
+
+import "time"
+
+type walletOpt struct {
+	timeout time.Duration
+	servers []string
+}
+
+type Option func(*walletOpt)
+
+var defaultWalletOpt = &walletOpt{
+	timeout: 1 * time.Second,
+	servers: make([]string, 0),
+}
+
+func WithTimeout(timeout time.Duration) Option {
+	return func(opt *walletOpt) {
+		opt.timeout = timeout
+	}
+}
+
+func WithCustomServers(servers []string) Option {
+	return func(opt *walletOpt) {
+		opt.servers = servers
+	}
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -47,7 +47,7 @@ func CheckMnemonic(mnemonic string) error {
 // A wallet can be opened in offline or online modes.
 // Offline wallet doesn’t have any connection to any node.
 // Online wallet has a connection to one of the pre-defined servers.
-func Open(walletPath string, offline bool) (*Wallet, error) {
+func Open(walletPath string, offline bool, options ...Option) (*Wallet, error) {
 	data, err := util.ReadFile(walletPath)
 	if err != nil {
 		return nil, err
@@ -59,12 +59,24 @@ func Open(walletPath string, offline bool) (*Wallet, error) {
 		return nil, err
 	}
 
-	return newWallet(walletPath, store, offline)
+	opts := defaultWalletOpt
+
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	return newWallet(walletPath, store, offline, opts)
 }
 
 // Create creates a wallet from mnemonic (seed phrase) and save it at the
 // given path.
-func Create(walletPath, mnemonic, password string, chain genesis.ChainType) (*Wallet, error) {
+func Create(walletPath, mnemonic, password string, chain genesis.ChainType, options ...Option) (*Wallet, error) {
+	opts := defaultWalletOpt
+
+	for _, opt := range options {
+		opt(opts)
+	}
+
 	walletPath = util.MakeAbs(walletPath)
 	if util.PathExists(walletPath) {
 		return nil, ExitsError{
@@ -89,7 +101,7 @@ func Create(walletPath, mnemonic, password string, chain genesis.ChainType) (*Wa
 		Network:   chain,
 		Vault:     nil,
 	}
-	wallet, err := newWallet(walletPath, store, true)
+	wallet, err := newWallet(walletPath, store, true, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +118,7 @@ func Create(walletPath, mnemonic, password string, chain genesis.ChainType) (*Wa
 	return wallet, nil
 }
 
-func newWallet(walletPath string, store *store, offline bool) (*Wallet, error) {
+func newWallet(walletPath string, store *store, offline bool, option *walletOpt) (*Wallet, error) {
 	if !store.Network.IsMainnet() {
 		crypto.AddressHRP = "tpc"
 		crypto.PublicKeyHRP = "tpublic"
@@ -115,7 +127,7 @@ func newWallet(walletPath string, store *store, offline bool) (*Wallet, error) {
 		crypto.XPrivateKeyHRP = "txsecret"
 	}
 
-	client := newGrpcClient()
+	client := newGrpcClient(option.timeout, option.servers)
 
 	w := &Wallet{
 		store:      store,
@@ -146,18 +158,13 @@ func newWallet(walletPath string, store *store, offline bool) (*Wallet, error) {
 		}
 
 		util.Shuffle(netServers)
-		w.grpcClient.SetServerAddrs(netServers)
+
+		if client.servers == nil {
+			client.servers = netServers
+		}
 	}
 
 	return w, nil
-}
-
-func (w *Wallet) SetServerAddr(addr string) {
-	w.grpcClient.SetServerAddrs([]string{addr})
-}
-
-func (w *Wallet) SetClientTimeout(timeout time.Duration) {
-	w.grpcClient.SetTimeoutConnection(timeout)
 }
 
 func (w *Wallet) Name() string {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -156,6 +156,10 @@ func (w *Wallet) SetServerAddr(addr string) {
 	w.grpcClient.SetServerAddrs([]string{addr})
 }
 
+func (w *Wallet) SetClientTimeout(timeout time.Duration) {
+	w.grpcClient.SetTimeoutConnection(timeout)
+}
+
 func (w *Wallet) Name() string {
 	return path.Base(w.path)
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -34,11 +34,6 @@ func setup(t *testing.T) *testData {
 	password := ""
 	walletPath := util.TempFilePath()
 	mnemonic, _ := wallet.GenerateMnemonic(128)
-	wlt, err := wallet.Create(walletPath, mnemonic, password, genesis.Mainnet)
-	assert.NoError(t, err)
-	assert.False(t, wlt.IsEncrypted())
-	assert.Equal(t, wlt.Path(), walletPath)
-	assert.Equal(t, wlt.Name(), path.Base(walletPath))
 
 	grpcConf := &grpc.Config{
 		Enable: true,
@@ -57,7 +52,12 @@ func setup(t *testing.T) *testData {
 
 	assert.NoError(t, gRPCServer.StartServer())
 
-	wlt.SetServerAddr(gRPCServer.Address())
+	wlt, err := wallet.Create(walletPath, mnemonic, password, genesis.Mainnet,
+		wallet.WithCustomServers([]string{gRPCServer.Address()}))
+	assert.NoError(t, err)
+	assert.False(t, wlt.IsEncrypted())
+	assert.Equal(t, wlt.Path(), walletPath)
+	assert.Equal(t, wlt.Name(), path.Base(walletPath))
 
 	return &testData{
 		TestSuite: ts,


### PR DESCRIPTION
## Description

This PR introduces a client timeout for connections when dialing to the server. The primary goal is to prevent delays during query retrieval by setting a maximum duration for establishing a connection. This ensures that if a server is unresponsive or slow, the client will not hang indefinitely, thereby improving the overall responsiveness and reliability of the application.