### PR TITLE
feat(firewall): check valid gossip and stream messages

### DIFF
--- a/network/gossip.go
+++ b/network/gossip.go
@@ -253,7 +253,7 @@ func (g *gossipService) onReceiveMessage(m *lp2pps.Message) {
 		return
 	}
 
-	g.logger.Debug("receiving new gossip message", "source", m.GetFrom())
+	g.logger.Debug("receiving new gossip message", "from", m.ReceivedFrom)
 	event := &GossipMessage{
 		From: m.ReceivedFrom,
 		Data: m.Data,

--- a/network/gossip.go
+++ b/network/gossip.go
@@ -75,6 +75,9 @@ func (g *gossipService) Broadcast(msg []byte, topicID TopicID) error {
 	g.logger.Debug("publishing new message", "topic", topicID)
 
 	switch topicID {
+	case TopicIDUnspecified:
+		return InvalidTopicError{TopicID: topicID}
+
 	case TopicIDBlock:
 		if g.topicBlock == nil {
 			return NotSubscribedError{TopicID: topicID}
@@ -114,6 +117,9 @@ func (g *gossipService) publish(msg []byte, topic *lp2pps.Topic) error {
 // JoinTopic joins to the topic with the given name and subscribes to receive topic messages.
 func (g *gossipService) JoinTopic(topicID TopicID, sp ShouldPropagate) error {
 	switch topicID {
+	case TopicIDUnspecified:
+		return InvalidTopicError{TopicID: topicID}
+
 	case TopicIDBlock:
 		if g.topicBlock != nil {
 			g.logger.Warn("already subscribed to block topic")

--- a/network/gossip_test.go
+++ b/network/gossip_test.go
@@ -3,7 +3,7 @@ package network
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJoinConsensusTopic(t *testing.T) {
@@ -11,12 +11,26 @@ func TestJoinConsensusTopic(t *testing.T) {
 
 	msg := []byte("test-consensus-topic")
 
-	require.ErrorIs(t, net.gossip.Broadcast(msg, TopicIDConsensus),
+	assert.ErrorIs(t, net.gossip.Broadcast(msg, TopicIDConsensus),
 		NotSubscribedError{
 			TopicID: TopicIDConsensus,
 		})
-	require.NoError(t, net.JoinTopic(TopicIDConsensus, alwaysPropagate))
-	require.NoError(t, net.gossip.Broadcast(msg, TopicIDConsensus))
+	assert.NoError(t, net.JoinTopic(TopicIDConsensus, alwaysPropagate))
+	assert.NoError(t, net.gossip.Broadcast(msg, TopicIDConsensus))
+}
+
+func TestJoinInvalidTopic(t *testing.T) {
+	net := makeTestNetwork(t, testConfig(), nil)
+
+	assert.ErrorIs(t, net.JoinTopic(TopicIDUnspecified, alwaysPropagate),
+		InvalidTopicError{
+			TopicID: TopicIDUnspecified,
+		})
+
+	assert.ErrorIs(t, net.JoinTopic(TopicID(-1), alwaysPropagate),
+		InvalidTopicError{
+			TopicID: TopicID(-1),
+		})
 }
 
 func TestInvalidTopic(t *testing.T) {
@@ -24,7 +38,12 @@ func TestInvalidTopic(t *testing.T) {
 
 	msg := []byte("test-invalid-topic")
 
-	require.ErrorIs(t, net.gossip.Broadcast(msg, -1),
+	assert.ErrorIs(t, net.gossip.Broadcast(msg, TopicIDUnspecified),
+		InvalidTopicError{
+			TopicID: TopicIDUnspecified,
+		})
+
+	assert.ErrorIs(t, net.gossip.Broadcast(msg, -1),
 		InvalidTopicError{
 			TopicID: TopicID(-1),
 		})

--- a/network/interface.go
+++ b/network/interface.go
@@ -9,6 +9,7 @@ import (
 type TopicID int
 
 const (
+	TopicIDUnspecified TopicID = 0
 	TopicIDBlock       TopicID = 1
 	TopicIDTransaction TopicID = 2
 	TopicIDConsensus   TopicID = 3
@@ -16,6 +17,9 @@ const (
 
 func (t TopicID) String() string {
 	switch t {
+	case TopicIDUnspecified:
+		return "unspecified"
+
 	case TopicIDBlock:
 		return "block"
 

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -57,7 +57,7 @@ func testConfig() *Config {
 func shouldReceiveEvent(t *testing.T, net *network, eventType EventType) Event {
 	t.Helper()
 
-	timeout := time.NewTimer(8 * time.Second)
+	timeout := time.NewTimer(10 * time.Second)
 
 	for {
 		select {

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -232,6 +232,41 @@ func TestNetwork(t *testing.T) {
 			assert.NotContains(t, protos, lp2pproto.ProtoIDv2Stop)
 			assert.Contains(t, protos, lp2pproto.ProtoIDv2Hop)
 		}, time.Second, 100*time.Millisecond)
+
+		require.EventuallyWithT(t, func(_ *assert.CollectT) {
+			protos := networkX.Protocols()
+			assert.NotContains(t, protos, lp2pproto.ProtoIDv2Stop)
+			assert.NotContains(t, protos, lp2pproto.ProtoIDv2Hop)
+		}, time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("Reachability", func(t *testing.T) {
+		fmt.Printf("Running %s\n", t.Name())
+
+		require.EventuallyWithT(t, func(_ *assert.CollectT) {
+			reachability := networkB.ReachabilityStatus()
+			assert.Equal(t, "Public", reachability)
+		}, time.Second, 100*time.Millisecond)
+
+		require.EventuallyWithT(t, func(_ *assert.CollectT) {
+			reachability := networkM.ReachabilityStatus()
+			assert.Equal(t, "Private", reachability)
+		}, time.Second, 100*time.Millisecond)
+
+		require.EventuallyWithT(t, func(_ *assert.CollectT) {
+			reachability := networkN.ReachabilityStatus()
+			assert.Equal(t, "Private", reachability)
+		}, time.Second, 100*time.Millisecond)
+
+		require.EventuallyWithT(t, func(_ *assert.CollectT) {
+			reachability := networkP.ReachabilityStatus()
+			assert.Equal(t, "Public", reachability)
+		}, time.Second, 100*time.Millisecond)
+
+		require.EventuallyWithT(t, func(_ *assert.CollectT) {
+			reachability := networkP.ReachabilityStatus()
+			assert.Equal(t, "Public", reachability)
+		}, time.Second, 100*time.Millisecond)
 	})
 
 	t.Run("all nodes have at least one connection to the bootstrap node B", func(t *testing.T) {
@@ -355,7 +390,7 @@ func TestNetwork(t *testing.T) {
 	// TODO: How to test this?
 	// t.Run("nodes M and N (private, connected via relay) can communicate using the relay node R", func(t *testing.T) {
 	// 	msgM := ts.RandBytes(64)
-	// 	require.NoError(t, networkM.SendTo(msgM, networkN.SelfID()))
+	// 	networkM.SendTo(msgM, networkN.SelfID())
 	// 	eM := shouldReceiveEvent(t, networkN, EventTypeStream).(*StreamMessage)
 	// 	assert.Equal(t, readData(t, eM.Reader, len(msgM)), msgM)
 	// })

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -167,7 +167,7 @@ func TestNetwork(t *testing.T) {
 	confM.EnableRelay = true
 	confM.BootstrapAddrStrings = bootstrapAddresses
 	confM.ListenAddrStrings = []string{
-		"/ip4/127.0.0.1/tcp/9987",
+		"/ip4/127.0.0.1/tcp/0",
 	}
 	fmt.Println("Starting Private node M")
 	networkM := makeTestNetwork(t, confM, []lp2p.Option{
@@ -179,7 +179,7 @@ func TestNetwork(t *testing.T) {
 	confN.EnableRelay = true
 	confN.BootstrapAddrStrings = bootstrapAddresses
 	confN.ListenAddrStrings = []string{
-		"/ip4/127.0.0.1/tcp/5678",
+		"/ip4/127.0.0.1/tcp/0",
 	}
 	fmt.Println("Starting Private node N")
 	networkN := makeTestNetwork(t, confN, []lp2p.Option{

--- a/state/mock.go
+++ b/state/mock.go
@@ -42,7 +42,7 @@ type MockState struct {
 
 func MockingState(ts *testsuite.TestSuite) *MockState {
 	cmt, valKeys := ts.GenerateTestCommittee(21)
-	genDoc := genesis.TestnetGenesis()
+	genDoc := genesis.MainnetGenesis()
 
 	return &MockState{
 		ts:            ts,

--- a/sync/bundle/message/block_announce.go
+++ b/sync/bundle/message/block_announce.go
@@ -3,6 +3,7 @@ package message
 import (
 	"fmt"
 
+	"github.com/pactus-project/pactus/network"
 	"github.com/pactus-project/pactus/types/block"
 	"github.com/pactus-project/pactus/types/certificate"
 )
@@ -33,6 +34,14 @@ func (m *BlockAnnounceMessage) Height() uint32 {
 
 func (*BlockAnnounceMessage) Type() Type {
 	return TypeBlockAnnounce
+}
+
+func (*BlockAnnounceMessage) TopicID() network.TopicID {
+	return network.TopicIDBlock
+}
+
+func (*BlockAnnounceMessage) ShouldBroadcast() bool {
+	return true
 }
 
 func (m *BlockAnnounceMessage) String() string {

--- a/sync/bundle/message/blocks_request.go
+++ b/sync/bundle/message/blocks_request.go
@@ -3,6 +3,7 @@ package message
 import (
 	"fmt"
 
+	"github.com/pactus-project/pactus/network"
 	"github.com/pactus-project/pactus/util/errors"
 )
 
@@ -37,6 +38,14 @@ func (m *BlocksRequestMessage) BasicCheck() error {
 
 func (*BlocksRequestMessage) Type() Type {
 	return TypeBlocksRequest
+}
+
+func (*BlocksRequestMessage) TopicID() network.TopicID {
+	return network.TopicIDUnspecified
+}
+
+func (*BlocksRequestMessage) ShouldBroadcast() bool {
+	return false
 }
 
 func (m *BlocksRequestMessage) String() string {

--- a/sync/bundle/message/blocks_response.go
+++ b/sync/bundle/message/blocks_response.go
@@ -3,6 +3,7 @@ package message
 import (
 	"fmt"
 
+	"github.com/pactus-project/pactus/network"
 	"github.com/pactus-project/pactus/types/certificate"
 )
 
@@ -40,6 +41,14 @@ func (m *BlocksResponseMessage) BasicCheck() error {
 
 func (*BlocksResponseMessage) Type() Type {
 	return TypeBlocksResponse
+}
+
+func (*BlocksResponseMessage) TopicID() network.TopicID {
+	return network.TopicIDUnspecified
+}
+
+func (*BlocksResponseMessage) ShouldBroadcast() bool {
+	return false
 }
 
 func (m *BlocksResponseMessage) Count() uint32 {

--- a/sync/bundle/message/hello.go
+++ b/sync/bundle/message/hello.go
@@ -7,6 +7,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pactus-project/pactus/crypto/bls"
 	"github.com/pactus-project/pactus/crypto/hash"
+	"github.com/pactus-project/pactus/network"
 	"github.com/pactus-project/pactus/sync/peerset/peer/service"
 	"github.com/pactus-project/pactus/util/errors"
 	"github.com/pactus-project/pactus/version"
@@ -62,6 +63,14 @@ func (m *HelloMessage) SignBytes() []byte {
 
 func (*HelloMessage) Type() Type {
 	return TypeHello
+}
+
+func (*HelloMessage) TopicID() network.TopicID {
+	return network.TopicIDUnspecified
+}
+
+func (*HelloMessage) ShouldBroadcast() bool {
+	return false
 }
 
 func (m *HelloMessage) String() string {

--- a/sync/bundle/message/hello_ack.go
+++ b/sync/bundle/message/hello_ack.go
@@ -2,6 +2,8 @@ package message
 
 import (
 	"fmt"
+
+	"github.com/pactus-project/pactus/network"
 )
 
 type HelloAckMessage struct {
@@ -24,6 +26,14 @@ func (*HelloAckMessage) BasicCheck() error {
 
 func (*HelloAckMessage) Type() Type {
 	return TypeHelloAck
+}
+
+func (*HelloAckMessage) TopicID() network.TopicID {
+	return network.TopicIDUnspecified
+}
+
+func (*HelloAckMessage) ShouldBroadcast() bool {
+	return false
 }
 
 func (m *HelloAckMessage) String() string {

--- a/sync/bundle/message/message.go
+++ b/sync/bundle/message/message.go
@@ -52,36 +52,6 @@ const (
 	TypeBlocksResponse = Type(10)
 )
 
-func (t Type) TopicID() network.TopicID {
-	switch t {
-	case TypeBlockAnnounce:
-
-		return network.TopicIDBlock
-
-	case TypeTransaction:
-
-		return network.TopicIDTransaction
-
-	case TypeQueryProposal,
-		TypeProposal,
-		TypeQueryVote,
-		TypeVote:
-
-		return network.TopicIDConsensus
-
-	case TypeHello,
-		TypeHelloAck,
-		TypeBlocksRequest,
-		TypeBlocksResponse:
-
-		return -1 // topic id for direct message
-
-	default:
-
-		return -2 // topic id for unknown message
-	}
-}
-
 func (t Type) String() string {
 	switch t {
 	case TypeHello:
@@ -91,7 +61,7 @@ func (t Type) String() string {
 		return "hello-ack"
 
 	case TypeTransaction:
-		return "txs"
+		return "transaction"
 
 	case TypeQueryProposal:
 		return "query-proposal"
@@ -100,7 +70,7 @@ func (t Type) String() string {
 		return "proposal"
 
 	case TypeQueryVote:
-		return "query-votes"
+		return "query-vote"
 
 	case TypeVote:
 		return "vote"
@@ -109,10 +79,10 @@ func (t Type) String() string {
 		return "block-announce"
 
 	case TypeBlocksRequest:
-		return "blocks-req"
+		return "blocks-request"
 
 	case TypeBlocksResponse:
-		return "blocks-res"
+		return "blocks-response"
 
 	default:
 		return fmt.Sprintf("%d", t)
@@ -159,5 +129,7 @@ func MakeMessage(t Type) Message {
 type Message interface {
 	BasicCheck() error
 	Type() Type
+	TopicID() network.TopicID
+	ShouldBroadcast() bool
 	String() string
 }

--- a/sync/bundle/message/message_test.go
+++ b/sync/bundle/message/message_test.go
@@ -1,0 +1,35 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/pactus-project/pactus/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessage(t *testing.T) {
+	testCases := []struct {
+		msgType         Type
+		typeName        string
+		topicID         network.TopicID
+		shouldBroadcast bool
+	}{
+		{TypeHello, "hello", network.TopicIDUnspecified, false},
+		{TypeHelloAck, "hello-ack", network.TopicIDUnspecified, false},
+		{TypeTransaction, "transaction", network.TopicIDTransaction, true},
+		{TypeQueryProposal, "query-proposal", network.TopicIDConsensus, true},
+		{TypeProposal, "proposal", network.TopicIDConsensus, true},
+		{TypeQueryVote, "query-vote", network.TopicIDConsensus, true},
+		{TypeVote, "vote", network.TopicIDConsensus, true},
+		{TypeBlockAnnounce, "block-announce", network.TopicIDBlock, true},
+		{TypeBlocksRequest, "blocks-request", network.TopicIDUnspecified, false},
+		{TypeBlocksResponse, "blocks-response", network.TopicIDUnspecified, false},
+	}
+
+	for _, tc := range testCases {
+		msg := MakeMessage(tc.msgType)
+		assert.Equal(t, tc.typeName, msg.Type().String())
+		assert.Equal(t, tc.topicID, msg.TopicID())
+		assert.Equal(t, tc.shouldBroadcast, msg.ShouldBroadcast())
+	}
+}

--- a/sync/bundle/message/proposal.go
+++ b/sync/bundle/message/proposal.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"github.com/pactus-project/pactus/network"
 	"github.com/pactus-project/pactus/types/proposal"
 )
 
@@ -22,6 +23,14 @@ func (*ProposalMessage) BasicCheck() error {
 
 func (*ProposalMessage) Type() Type {
 	return TypeProposal
+}
+
+func (*ProposalMessage) TopicID() network.TopicID {
+	return network.TopicIDConsensus
+}
+
+func (*ProposalMessage) ShouldBroadcast() bool {
+	return true
 }
 
 func (m *ProposalMessage) String() string {

--- a/sync/bundle/message/query_proposal.go
+++ b/sync/bundle/message/query_proposal.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pactus-project/pactus/crypto"
+	"github.com/pactus-project/pactus/network"
 	"github.com/pactus-project/pactus/util/errors"
 )
 
@@ -31,6 +32,14 @@ func (m *QueryProposalMessage) BasicCheck() error {
 
 func (*QueryProposalMessage) Type() Type {
 	return TypeQueryProposal
+}
+
+func (*QueryProposalMessage) TopicID() network.TopicID {
+	return network.TopicIDConsensus
+}
+
+func (*QueryProposalMessage) ShouldBroadcast() bool {
+	return true
 }
 
 func (m *QueryProposalMessage) String() string {

--- a/sync/bundle/message/query_votes.go
+++ b/sync/bundle/message/query_votes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pactus-project/pactus/crypto"
+	"github.com/pactus-project/pactus/network"
 	"github.com/pactus-project/pactus/util/errors"
 )
 
@@ -31,6 +32,14 @@ func (m *QueryVotesMessage) BasicCheck() error {
 
 func (*QueryVotesMessage) Type() Type {
 	return TypeQueryVote
+}
+
+func (*QueryVotesMessage) TopicID() network.TopicID {
+	return network.TopicIDConsensus
+}
+
+func (*QueryVotesMessage) ShouldBroadcast() bool {
+	return true
 }
 
 func (m *QueryVotesMessage) String() string {

--- a/sync/bundle/message/transactions.go
+++ b/sync/bundle/message/transactions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pactus-project/pactus/network"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/util/errors"
 )
@@ -33,6 +34,14 @@ func (m *TransactionsMessage) BasicCheck() error {
 
 func (*TransactionsMessage) Type() Type {
 	return TypeTransaction
+}
+
+func (*TransactionsMessage) TopicID() network.TopicID {
+	return network.TopicIDTransaction
+}
+
+func (*TransactionsMessage) ShouldBroadcast() bool {
+	return true
 }
 
 func (m *TransactionsMessage) String() string {

--- a/sync/bundle/message/vote.go
+++ b/sync/bundle/message/vote.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"github.com/pactus-project/pactus/network"
 	"github.com/pactus-project/pactus/types/vote"
 )
 
@@ -20,6 +21,14 @@ func (m *VoteMessage) BasicCheck() error {
 
 func (*VoteMessage) Type() Type {
 	return TypeVote
+}
+
+func (*VoteMessage) TopicID() network.TopicID {
+	return network.TopicIDConsensus
+}
+
+func (*VoteMessage) ShouldBroadcast() bool {
+	return true
 }
 
 func (m *VoteMessage) String() string {

--- a/sync/firewall/errors.go
+++ b/sync/firewall/errors.go
@@ -1,0 +1,24 @@
+package firewall
+
+import (
+	"errors"
+	"fmt"
+
+	lp2pcore "github.com/libp2p/go-libp2p/core"
+)
+
+// PeerBannedError is returned when a message received from a banned peer-id or banned address.
+type PeerBannedError struct {
+	PeerID  lp2pcore.PeerID
+	Address string
+}
+
+func (e PeerBannedError) Error() string {
+	return fmt.Sprintf("peer is banned, peer-id: %s, remote-address: %s", e.PeerID, e.Address)
+}
+
+// ErrGossipMessage is returned when a stream message sends as gossip message.
+var ErrGossipMessage = errors.New("receive stream message as gossip message")
+
+// ErrStreamMessage is returned when a gossip message sends as stream message.
+var ErrStreamMessage = errors.New("receive gossip message as stream message")

--- a/sync/handler.go
+++ b/sync/handler.go
@@ -7,6 +7,6 @@ import (
 )
 
 type messageHandler interface {
-	ParseMessage(message.Message, peer.ID) error
+	ParseMessage(message.Message, peer.ID)
 	PrepareBundle(message.Message) *bundle.Bundle
 }

--- a/sync/handler_block_announce_test.go
+++ b/sync/handler_block_announce_test.go
@@ -23,7 +23,10 @@ func TestParsingBlockAnnounceMessages(t *testing.T) {
 	t.Run("Receiving new block announce message, without committing previous block", func(t *testing.T) {
 		td.receivingNewMessage(td.sync, msg2, pid)
 
-		assert.Equal(t, td.sync.state.LastBlockHeight(), lastHeight)
+		stateHeight := td.sync.state.LastBlockHeight()
+		consHeight, _ := td.consMgr.HeightRound()
+		assert.Equal(t, lastHeight, stateHeight)
+		assert.Equal(t, lastHeight+1, consHeight)
 	})
 
 	t.Run("Receiving missed block, should commit both blocks", func(t *testing.T) {

--- a/sync/handler_block_announce_test.go
+++ b/sync/handler_block_announce_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/pactus-project/pactus/sync/bundle/message"
-	"github.com/pactus-project/pactus/types/certificate"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,29 +21,16 @@ func TestParsingBlockAnnounceMessages(t *testing.T) {
 	msg2 := message.NewBlockAnnounceMessage(blk2, cert2)
 
 	t.Run("Receiving new block announce message, without committing previous block", func(t *testing.T) {
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg2, pid))
+		td.receivingNewMessage(td.sync, msg2, pid)
 
 		assert.Equal(t, td.sync.state.LastBlockHeight(), lastHeight)
 	})
 
 	t.Run("Receiving missed block, should commit both blocks", func(t *testing.T) {
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg1, pid))
+		td.receivingNewMessage(td.sync, msg1, pid)
 
 		assert.Equal(t, td.sync.state.LastBlockHeight(), lastHeight+2)
 	})
-}
-
-func TestInvalidBlockAnnounce(t *testing.T) {
-	td := setup(t, nil)
-
-	pid := td.RandPeerID()
-	height := td.state.LastBlockHeight() + 1
-	blk, _ := td.GenerateTestBlock(height)
-	invCert := certificate.NewBlockCertificate(height, 0)
-	msg := message.NewBlockAnnounceMessage(blk, invCert)
-
-	err := td.receivingNewMessage(td.sync, msg, pid)
-	assert.Error(t, err)
 }
 
 func TestBroadcastingBlockAnnounceMessages(t *testing.T) {
@@ -56,4 +42,22 @@ func TestBroadcastingBlockAnnounceMessages(t *testing.T) {
 
 	msg1 := td.shouldPublishMessageWithThisType(t, message.TypeBlockAnnounce)
 	assert.Equal(t, msg1.Message.(*message.BlockAnnounceMessage).Certificate.Height(), msg.Certificate.Height())
+}
+
+func TestCacheAnnouncedBlock(t *testing.T) {
+	td := setup(t, nil)
+
+	height := td.RandHeight()
+	blk1, cert1 := td.GenerateTestBlock(height)
+	blk2, cert2 := td.GenerateTestBlock(height)
+	msg1 := message.NewBlockAnnounceMessage(blk1, cert1)
+	msg2 := message.NewBlockAnnounceMessage(blk2, cert2)
+
+	td.receivingNewMessage(td.sync, msg1, td.RandPeerID())
+	td.receivingNewMessage(td.sync, msg2, td.RandPeerID())
+
+	cachedBlock := td.sync.cache.GetBlock(height)
+	cachedCert := td.sync.cache.GetCertificate(height)
+	assert.Equal(t, cachedBlock, blk1)
+	assert.Equal(t, cachedCert, cert1)
 }

--- a/sync/handler_blocks_request.go
+++ b/sync/handler_blocks_request.go
@@ -19,7 +19,7 @@ func newBlocksRequestHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID) error {
+func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID) {
 	msg := m.(*message.BlocksRequestMessage)
 	handler.logger.Trace("parsing BlocksRequest message", "msg", msg)
 
@@ -30,7 +30,7 @@ func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID
 
 		handler.respond(response, pid)
 
-		return nil
+		return
 	}
 
 	if !status.IsKnown() {
@@ -39,7 +39,7 @@ func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID
 
 		handler.respond(response, pid)
 
-		return nil
+		return
 	}
 
 	ourHeight := handler.state.LastBlockHeight()
@@ -50,7 +50,7 @@ func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID
 
 			handler.respond(response, pid)
 
-			return nil
+			return
 		}
 	}
 
@@ -60,7 +60,7 @@ func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID
 
 		handler.respond(response, pid)
 
-		return nil
+		return
 	}
 
 	if msg.Count > handler.config.LatestBlockInterval {
@@ -69,7 +69,7 @@ func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID
 
 		handler.respond(response, pid)
 
-		return nil
+		return
 	}
 
 	// Help this peer to sync up
@@ -100,15 +100,13 @@ func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID
 
 		handler.respond(response, pid)
 
-		return nil
+		return
 	}
 
 	response := message.NewBlocksResponseMessage(message.ResponseCodeNoMoreBlocks,
 		message.ResponseCodeNoMoreBlocks.String(), msg.SessionID, 0, nil, nil)
 
 	handler.respond(response, pid)
-
-	return nil
 }
 
 func (*blocksRequestHandler) PrepareBundle(m message.Message) *bundle.Bundle {

--- a/sync/handler_blocks_request_test.go
+++ b/sync/handler_blocks_request_test.go
@@ -24,7 +24,7 @@ func TestBlocksRequestMessages(t *testing.T) {
 		t.Run("Reject request from unknown peers", func(t *testing.T) {
 			pid := td.RandPeerID()
 			msg := message.NewBlocksRequestMessage(sid, curHeight-1, 1)
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeBlocksResponse)
 			res := bdl.Message.(*message.BlocksResponseMessage)
@@ -37,7 +37,7 @@ func TestBlocksRequestMessages(t *testing.T) {
 		t.Run("Reject request from peers without handshaking", func(t *testing.T) {
 			pid := td.addPeer(t, status.StatusConnected, service.New(service.None))
 			msg := message.NewBlocksRequestMessage(sid, curHeight-1, 1)
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeBlocksResponse)
 			res := bdl.Message.(*message.BlocksResponseMessage)
@@ -49,7 +49,7 @@ func TestBlocksRequestMessages(t *testing.T) {
 
 		t.Run("Peer requested blocks that we don't have", func(t *testing.T) {
 			msg := message.NewBlocksRequestMessage(sid, curHeight+1, 1)
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeBlocksResponse)
 			res := bdl.Message.(*message.BlocksResponseMessage)
@@ -59,7 +59,7 @@ func TestBlocksRequestMessages(t *testing.T) {
 
 		t.Run("Reject requests not within `LatestBlockInterval`", func(t *testing.T) {
 			msg := message.NewBlocksRequestMessage(sid, curHeight-config.LatestBlockInterval-1, 1)
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeBlocksResponse)
 			res := bdl.Message.(*message.BlocksResponseMessage)
@@ -69,7 +69,7 @@ func TestBlocksRequestMessages(t *testing.T) {
 
 		t.Run("Request blocks more than `LatestBlockInterval`", func(t *testing.T) {
 			msg := message.NewBlocksRequestMessage(sid, 10, config.LatestBlockInterval+1)
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeBlocksResponse)
 			res := bdl.Message.(*message.BlocksResponseMessage)
@@ -80,7 +80,7 @@ func TestBlocksRequestMessages(t *testing.T) {
 		t.Run("Accept request within `LatestBlockInterval`", func(t *testing.T) {
 			t.Run("Peer needs more block", func(t *testing.T) {
 				msg := message.NewBlocksRequestMessage(sid, curHeight-config.BlockPerMessage, config.BlockPerMessage)
-				assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+				td.receivingNewMessage(td.sync, msg, pid)
 
 				bdl1 := td.shouldPublishMessageWithThisType(t, message.TypeBlocksResponse)
 				res1 := bdl1.Message.(*message.BlocksResponseMessage)
@@ -99,7 +99,7 @@ func TestBlocksRequestMessages(t *testing.T) {
 
 			t.Run("Peer synced", func(t *testing.T) {
 				msg := message.NewBlocksRequestMessage(sid, curHeight-config.BlockPerMessage+1, config.BlockPerMessage)
-				assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+				td.receivingNewMessage(td.sync, msg, pid)
 
 				bdl1 := td.shouldPublishMessageWithThisType(t, message.TypeBlocksResponse)
 				res1 := bdl1.Message.(*message.BlocksResponseMessage)
@@ -124,7 +124,7 @@ func TestBlocksRequestMessages(t *testing.T) {
 
 		t.Run("Requesting one block", func(t *testing.T) {
 			msg := message.NewBlocksRequestMessage(sid, 1, 2)
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 
 			msg1 := td.shouldPublishMessageWithThisType(t, message.TypeBlocksResponse)
 			assert.Equal(t, msg1.Message.(*message.BlocksResponseMessage).ResponseCode, message.ResponseCodeMoreBlocks)

--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -226,7 +226,7 @@ func makeAliceAndBobNetworks(t *testing.T) *networkAliceBob {
 	require.Eventually(t, func() bool {
 		return syncAlice.PeerSet().Len() == 1 &&
 			syncBob.PeerSet().Len() == 1
-	}, time.Second, 100*time.Millisecond)
+	}, 2*time.Second, 100*time.Millisecond)
 
 	require.Equal(t, status.StatusKnown, syncAlice.PeerSet().GetPeerStatus(syncBob.SelfID()))
 	require.Equal(t, status.StatusKnown, syncBob.PeerSet().GetPeerStatus(syncAlice.SelfID()))

--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -72,9 +72,8 @@ func TestStrippedPublicKey(t *testing.T) {
 	lastHeight := td.state.LastBlockHeight()
 
 	// Add a new block and keep the signer key
-	indexedPub, indexedPrv := td.RandBLSKeyPair()
-	trx0 := tx.NewTransferTx(lastHeight, indexedPub.AccountAddress(), td.RandAccAddress(), 1, 1, "")
-	td.HelperSignTransaction(indexedPrv, trx0)
+	_, indexedPrv := td.RandBLSKeyPair()
+	trx0 := td.GenerateTestTransferTx(testsuite.TransactionWithSigner(indexedPrv))
 	trxs0 := []*tx.Tx{trx0}
 	blk0, cert0 := td.GenerateTestBlock(lastHeight+1, testsuite.BlockWithTransactions(trxs0))
 	err := td.state.CommitBlock(blk0, cert0)
@@ -82,15 +81,13 @@ func TestStrippedPublicKey(t *testing.T) {
 	lastHeight++
 	// -----
 
-	rndPub, rndPrv := td.RandBLSKeyPair()
-	trx1 := tx.NewTransferTx(lastHeight, rndPub.AccountAddress(), td.RandAccAddress(), 1, 1, "")
-	td.HelperSignTransaction(rndPrv, trx1)
+	_, rndPrv := td.RandBLSKeyPair()
+	trx1 := td.GenerateTestTransferTx(testsuite.TransactionWithSigner(rndPrv))
 	trx1.StripPublicKey()
 	trxs1 := []*tx.Tx{trx1}
 	blk1, _ := td.GenerateTestBlock(lastHeight+1, testsuite.BlockWithTransactions(trxs1))
 
-	trx2 := tx.NewTransferTx(lastHeight, indexedPub.AccountAddress(), td.RandAccAddress(), 1, 1, "")
-	td.HelperSignTransaction(indexedPrv, trx2)
+	trx2 := td.GenerateTestTransferTx(testsuite.TransactionWithSigner(indexedPrv))
 	trx2.StripPublicKey()
 	trxs2 := []*tx.Tx{trx2}
 	blk2, _ := td.GenerateTestBlock(lastHeight+1, testsuite.BlockWithTransactions(trxs2))

--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -168,8 +168,8 @@ func makeAliceAndBobNetworks(t *testing.T) *networkAliceBob {
 	valKeyBob := []*bls.ValidatorKey{ts.RandValKey()}
 	stateAlice := state.MockingState(ts)
 	stateBob := state.MockingState(ts)
-	consMgrAlice, _ := consensus.MockingManager(ts, valKeyAlice)
-	consMgrBob, _ := consensus.MockingManager(ts, valKeyBob)
+	consMgrAlice, _ := consensus.MockingManager(ts, stateAlice, valKeyAlice)
+	consMgrBob, _ := consensus.MockingManager(ts, stateBob, valKeyBob)
 	internalMessageCh := make(chan message.Message, 1000)
 	networkAlice := network.MockingNetwork(ts, ts.RandPeerID())
 	networkBob := network.MockingNetwork(ts, ts.RandPeerID())

--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -98,7 +98,6 @@ func (handler *helloHandler) acknowledge(msg *message.HelloAckMessage, to peer.I
 
 		handler.sendTo(msg, to)
 		handler.peerSet.UpdateStatus(to, status.StatusBanned)
-		handler.network.CloseConnection(to)
 	} else {
 		handler.logger.Info("acknowledging hello message", "msg", msg,
 			"to", to)

--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -23,7 +23,7 @@ func newHelloHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error {
+func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) {
 	msg := m.(*message.HelloMessage)
 	handler.logger.Trace("parsing Hello message", "msg", msg)
 
@@ -45,7 +45,7 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error 
 
 		handler.acknowledge(response, pid)
 
-		return nil
+		return
 	}
 
 	if msg.GenesisHash != handler.state.Genesis().Hash() {
@@ -55,7 +55,7 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error 
 
 		handler.acknowledge(response, pid)
 
-		return nil
+		return
 	}
 
 	if math.Abs(time.Since(msg.MyTime()).Seconds()) > 10 {
@@ -64,7 +64,7 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error 
 
 		handler.acknowledge(response, pid)
 
-		return nil
+		return
 	}
 
 	agent, _ := version.ParseAgent(msg.Agent)
@@ -74,7 +74,7 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error 
 
 		handler.acknowledge(response, pid)
 
-		return nil
+		return
 	}
 
 	handler.peerSet.UpdateHeight(pid, msg.Height, msg.BlockHash)
@@ -82,8 +82,6 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) error 
 
 	response := message.NewHelloAckMessage(message.ResponseCodeOK, "Ok", handler.state.LastBlockHeight())
 	handler.acknowledge(response, pid)
-
-	return nil
 }
 
 func (*helloHandler) PrepareBundle(m message.Message) *bundle.Bundle {

--- a/sync/handler_hello_ack.go
+++ b/sync/handler_hello_ack.go
@@ -18,7 +18,7 @@ func newHelloAckHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *helloAckHandler) ParseMessage(m message.Message, pid peer.ID) error {
+func (handler *helloAckHandler) ParseMessage(m message.Message, pid peer.ID) {
 	msg := m.(*message.HelloAckMessage)
 	handler.logger.Trace("parsing HelloAck message", "msg", msg)
 
@@ -28,7 +28,7 @@ func (handler *helloAckHandler) ParseMessage(m message.Message, pid peer.ID) err
 
 		handler.network.CloseConnection(pid)
 
-		return nil
+		return
 	}
 
 	handler.peerSet.UpdateStatus(pid, status.StatusKnown)
@@ -37,8 +37,6 @@ func (handler *helloAckHandler) ParseMessage(m message.Message, pid peer.ID) err
 	if msg.Height > handler.state.LastBlockHeight() {
 		handler.updateBlockchain()
 	}
-
-	return nil
 }
 
 func (*helloAckHandler) PrepareBundle(m message.Message) *bundle.Bundle {

--- a/sync/handler_hello_ack_test.go
+++ b/sync/handler_hello_ack_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pactus-project/pactus/sync/bundle/message"
 	"github.com/pactus-project/pactus/sync/peerset/peer/status"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestParsingHelloAckMessages(t *testing.T) {
@@ -16,7 +15,8 @@ func TestParsingHelloAckMessages(t *testing.T) {
 			pid := td.RandPeerID()
 			msg := message.NewHelloAckMessage(message.ResponseCodeRejected, "rejected", td.RandHeight())
 
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
+			td.checkPeerStatus(t, pid, status.StatusUnknown)
 		})
 
 	t.Run("Receiving HelloAck message: OK hello",
@@ -24,7 +24,7 @@ func TestParsingHelloAckMessages(t *testing.T) {
 			pid := td.RandPeerID()
 			msg := message.NewHelloAckMessage(message.ResponseCodeOK, "ok", td.RandHeight())
 
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 			td.checkPeerStatus(t, pid, status.StatusKnown)
 		})
 }

--- a/sync/handler_hello_test.go
+++ b/sync/handler_hello_test.go
@@ -28,7 +28,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
 			from := td.RandPeerID()
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, from))
+			td.receivingNewMessage(td.sync, msg, from)
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeHelloAck)
 			assert.Equal(t, bdl.Message.(*message.HelloAckMessage).ResponseCode, message.ResponseCodeRejected)
 		})
@@ -42,7 +42,7 @@ func TestParsingHelloMessages(t *testing.T) {
 				td.state.LastBlockHash(), invGenHash)
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 			td.checkPeerStatus(t, pid, status.StatusBanned)
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeHelloAck)
 			assert.Equal(t, bdl.Message.(*message.HelloAckMessage).ResponseCode, message.ResponseCodeRejected)
@@ -58,7 +58,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
 			msg.MyTimeUnixMilli = msg.MyTime().Add(-10 * time.Second).UnixMilli()
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 			td.checkPeerStatus(t, pid, status.StatusBanned)
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeHelloAck)
 			assert.Equal(t, bdl.Message.(*message.HelloAckMessage).ResponseCode, message.ResponseCodeRejected)
@@ -74,7 +74,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
 			msg.MyTimeUnixMilli = msg.MyTime().Add(20 * time.Second).UnixMilli()
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 			td.checkPeerStatus(t, pid, status.StatusBanned)
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeHelloAck)
 			assert.Equal(t, bdl.Message.(*message.HelloAckMessage).ResponseCode, message.ResponseCodeRejected)
@@ -96,7 +96,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			msg.Agent = nodeAgent.String()
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 			td.checkPeerStatus(t, pid, status.StatusBanned)
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeHelloAck)
 			assert.Equal(t, bdl.Message.(*message.HelloAckMessage).ResponseCode, message.ResponseCodeRejected)
@@ -112,7 +112,7 @@ func TestParsingHelloMessages(t *testing.T) {
 			msg.Agent = "invalid-agent"
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 			td.checkPeerStatus(t, pid, status.StatusBanned)
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeHelloAck)
 			assert.Equal(t, bdl.Message.(*message.HelloAckMessage).ResponseCode, message.ResponseCodeRejected)
@@ -127,7 +127,7 @@ func TestParsingHelloMessages(t *testing.T) {
 				td.state.LastBlockHash(), td.state.Genesis().Hash())
 			msg.Sign([]*bls.ValidatorKey{valKey})
 
-			assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+			td.receivingNewMessage(td.sync, msg, pid)
 
 			bdl := td.shouldPublishMessageWithThisType(t, message.TypeHelloAck)
 			assert.Equal(t, bdl.Message.(*message.HelloAckMessage).ResponseCode, message.ResponseCodeOK)

--- a/sync/handler_proposal.go
+++ b/sync/handler_proposal.go
@@ -16,13 +16,11 @@ func newProposalHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *proposalHandler) ParseMessage(m message.Message, _ peer.ID) error {
+func (handler *proposalHandler) ParseMessage(m message.Message, _ peer.ID) {
 	msg := m.(*message.ProposalMessage)
 	handler.logger.Trace("parsing Proposal message", "msg", msg)
 
 	handler.consMgr.SetProposal(msg.Proposal)
-
-	return nil
 }
 
 func (*proposalHandler) PrepareBundle(m message.Message) *bundle.Bundle {

--- a/sync/handler_proposal_test.go
+++ b/sync/handler_proposal_test.go
@@ -16,7 +16,7 @@ func TestParsingProposalMessages(t *testing.T) {
 		msg := message.NewProposalMessage(prop)
 		pid := td.RandPeerID()
 
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 		assert.NotNil(t, td.consMgr.Proposal())
 	})
 }

--- a/sync/handler_query_proposal.go
+++ b/sync/handler_query_proposal.go
@@ -16,20 +16,20 @@ func newQueryProposalHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *queryProposalHandler) ParseMessage(m message.Message, _ peer.ID) error {
+func (handler *queryProposalHandler) ParseMessage(m message.Message, _ peer.ID) {
 	msg := m.(*message.QueryProposalMessage)
 	handler.logger.Trace("parsing QueryProposal message", "msg", msg)
 
 	if !handler.consMgr.HasActiveInstance() {
 		handler.logger.Debug("ignoring QueryProposal, not active", "msg", msg)
 
-		return nil
+		return
 	}
 
 	if !handler.consMgr.HasProposer() {
 		handler.logger.Debug("ignoring QueryProposal, not proposer", "msg", msg)
 
-		return nil
+		return
 	}
 
 	height, round := handler.consMgr.HeightRound()
@@ -37,7 +37,7 @@ func (handler *queryProposalHandler) ParseMessage(m message.Message, _ peer.ID) 
 		handler.logger.Debug("ignoring QueryProposal, not same height/round", "msg", msg,
 			"height", height, "round", round)
 
-		return nil
+		return
 	}
 
 	prop := handler.consMgr.Proposal()
@@ -45,8 +45,6 @@ func (handler *queryProposalHandler) ParseMessage(m message.Message, _ peer.ID) 
 		response := message.NewProposalMessage(prop)
 		handler.broadcast(response)
 	}
-
-	return nil
 }
 
 func (*queryProposalHandler) PrepareBundle(m message.Message) *bundle.Bundle {

--- a/sync/handler_query_proposal_test.go
+++ b/sync/handler_query_proposal_test.go
@@ -17,7 +17,7 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 
 	t.Run("doesn't have active validator", func(t *testing.T) {
 		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
 	})
@@ -26,7 +26,7 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 
 	t.Run("not the proposer", func(t *testing.T) {
 		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
 	})
@@ -35,21 +35,21 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 
 	t.Run("not the same height", func(t *testing.T) {
 		msg := message.NewQueryProposalMessage(consHeight+1, consRound, td.RandValAddress())
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
 	})
 
 	t.Run("not the same round", func(t *testing.T) {
 		msg := message.NewQueryProposalMessage(consHeight, consRound+1, td.RandValAddress())
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
 	})
 
 	t.Run("should respond to the query proposal message", func(t *testing.T) {
 		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		bdl := td.shouldPublishMessageWithThisType(t, message.TypeProposal)
 		assert.Equal(t, bdl.Message.(*message.ProposalMessage).Proposal.Hash(), prop.Hash())
@@ -58,7 +58,7 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 	t.Run("doesn't have the proposal", func(t *testing.T) {
 		td.consMocks[0].CurProposal = nil
 		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
 	})

--- a/sync/handler_query_votes.go
+++ b/sync/handler_query_votes.go
@@ -16,14 +16,14 @@ func newQueryVotesHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *queryVotesHandler) ParseMessage(m message.Message, _ peer.ID) error {
+func (handler *queryVotesHandler) ParseMessage(m message.Message, _ peer.ID) {
 	msg := m.(*message.QueryVotesMessage)
 	handler.logger.Trace("parsing QueryVotes message", "msg", msg)
 
 	if !handler.consMgr.HasActiveInstance() {
 		handler.logger.Debug("ignoring QueryVotes, not active", "msg", msg)
 
-		return nil
+		return
 	}
 
 	height, _ := handler.consMgr.HeightRound()
@@ -31,7 +31,7 @@ func (handler *queryVotesHandler) ParseMessage(m message.Message, _ peer.ID) err
 		handler.logger.Debug("ignoring QueryVotes, not same height", "msg", msg,
 			"height", height)
 
-		return nil
+		return
 	}
 
 	v := handler.consMgr.PickRandomVote(msg.Round)
@@ -39,8 +39,6 @@ func (handler *queryVotesHandler) ParseMessage(m message.Message, _ peer.ID) err
 		response := message.NewVoteMessage(v)
 		handler.broadcast(response)
 	}
-
-	return nil
 }
 
 func (*queryVotesHandler) PrepareBundle(m message.Message) *bundle.Bundle {

--- a/sync/handler_query_votes_test.go
+++ b/sync/handler_query_votes_test.go
@@ -17,7 +17,7 @@ func TestParsingQueryVotesMessages(t *testing.T) {
 
 	t.Run("doesn't have active validator", func(t *testing.T) {
 		msg := message.NewQueryVotesMessage(consensusHeight, 1, td.RandValAddress())
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeVote)
 	})
@@ -26,7 +26,7 @@ func TestParsingQueryVotesMessages(t *testing.T) {
 
 	t.Run("should respond to the query votes message", func(t *testing.T) {
 		msg := message.NewQueryVotesMessage(consensusHeight, 1, td.RandValAddress())
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		bdl := td.shouldPublishMessageWithThisType(t, message.TypeVote)
 		assert.Equal(t, bdl.Message.(*message.VoteMessage).Vote.Hash(), v1.Hash())
@@ -34,7 +34,7 @@ func TestParsingQueryVotesMessages(t *testing.T) {
 
 	t.Run("doesn't have any votes", func(t *testing.T) {
 		msg := message.NewQueryVotesMessage(consensusHeight+1, 1, td.RandValAddress())
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeVote)
 	})

--- a/sync/handler_transactions.go
+++ b/sync/handler_transactions.go
@@ -16,7 +16,7 @@ func newTransactionsHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *transactionsHandler) ParseMessage(m message.Message, _ peer.ID) error {
+func (handler *transactionsHandler) ParseMessage(m message.Message, _ peer.ID) {
 	msg := m.(*message.TransactionsMessage)
 	handler.logger.Trace("parsing Transactions message", "msg", msg)
 
@@ -25,8 +25,6 @@ func (handler *transactionsHandler) ParseMessage(m message.Message, _ peer.ID) e
 			handler.logger.Debug("cannot append transaction", "tx", trx, "error", err)
 		}
 	}
-
-	return nil
 }
 
 func (*transactionsHandler) PrepareBundle(m message.Message) *bundle.Bundle {

--- a/sync/handler_transactions_test.go
+++ b/sync/handler_transactions_test.go
@@ -16,8 +16,18 @@ func TestParsingTransactionsMessages(t *testing.T) {
 		msg := message.NewTransactionsMessage([]*tx.Tx{trx1})
 		pid := td.RandPeerID()
 
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 
 		assert.NotNil(t, td.sync.state.PendingTx(trx1.ID()))
 	})
+}
+
+func TestBroadcastingTransactionVotesMessages(t *testing.T) {
+	td := setup(t, nil)
+
+	trx1 := td.GenerateTestBondTx()
+	msg := message.NewTransactionsMessage([]*tx.Tx{trx1})
+	td.sync.broadcast(msg)
+
+	td.shouldPublishMessageWithThisType(t, message.TypeTransaction)
 }

--- a/sync/handler_vote.go
+++ b/sync/handler_vote.go
@@ -16,13 +16,11 @@ func newVoteHandler(sync *synchronizer) messageHandler {
 	}
 }
 
-func (handler *voteHandler) ParseMessage(m message.Message, _ peer.ID) error {
+func (handler *voteHandler) ParseMessage(m message.Message, _ peer.ID) {
 	msg := m.(*message.VoteMessage)
 	handler.logger.Trace("parsing Vote message", "msg", msg)
 
 	handler.consMgr.AddVote(msg.Vote)
-
-	return nil
 }
 
 func (*voteHandler) PrepareBundle(m message.Message) *bundle.Bundle {

--- a/sync/handler_vote_test.go
+++ b/sync/handler_vote_test.go
@@ -15,7 +15,7 @@ func TestParsingVoteMessages(t *testing.T) {
 		msg := message.NewVoteMessage(v)
 		pid := td.RandPeerID()
 
-		assert.NoError(t, td.receivingNewMessage(td.sync, msg, pid))
+		td.receivingNewMessage(td.sync, msg, pid)
 		assert.Equal(t, td.consMgr.PickRandomVote(0).Hash(), v.Hash())
 	})
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -64,7 +64,7 @@ func setup(t *testing.T, config *Config) *testData {
 	valKeys := []*bls.ValidatorKey{ts.RandValKey(), ts.RandValKey()}
 	mockState := state.MockingState(ts)
 
-	consMgr, consMocks := consensus.MockingManager(ts, []*bls.ValidatorKey{valKeys[0], valKeys[1]})
+	consMgr, consMocks := consensus.MockingManager(ts, mockState, []*bls.ValidatorKey{valKeys[0], valKeys[1]})
 	consMgr.MoveToNewHeight()
 
 	broadcastCh := make(chan message.Message, 1000)

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -19,8 +19,8 @@ func lastHeight() uint32 {
 }
 
 func waitForNewBlocks(num uint32) {
-	height := lastHeight() + num
 	for i := uint32(0); i < num; i++ {
+		height := lastHeight()
 		if lastHeight() > height {
 			break
 		}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -72,10 +72,9 @@ func TestMain(m *testing.M) {
 
 		tConfigs[i].TxPool.MinFeePAC = 0.000001
 		tConfigs[i].Store.Path = util.TempDirPath()
-		tConfigs[i].Store.RetentionDays = 10
-		tConfigs[i].Consensus.ChangeProposerTimeout = 4 * time.Second
-		tConfigs[i].Consensus.ChangeProposerDelta = 4 * time.Second
-		tConfigs[i].Consensus.QueryVoteTimeout = 4 * time.Second
+		tConfigs[i].Consensus.ChangeProposerTimeout = 2 * time.Second
+		tConfigs[i].Consensus.ChangeProposerDelta = 2 * time.Second
+		tConfigs[i].Consensus.QueryVoteTimeout = 2 * time.Second
 		tConfigs[i].Logger.Levels["default"] = "info"
 		tConfigs[i].Logger.Levels["_state"] = "info"
 		tConfigs[i].Logger.Levels["_sync"] = "info"

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -60,14 +60,12 @@ func setup(t *testing.T, conf *Config) *testData {
 
 	const bufSize = 1024 * 1024
 
-	mockConsMgr, consMocks := consensus.MockingManager(ts, []*bls.ValidatorKey{
-		ts.RandValKey(), ts.RandValKey(),
-	})
-
 	listener := bufconn.Listen(bufSize)
+	valKeys := []*bls.ValidatorKey{ts.RandValKey(), ts.RandValKey()}
 	mockState := state.MockingState(ts)
 	mockNet := network.MockingNetwork(ts, ts.RandPeerID())
 	mockSync := sync.MockingSync(ts)
+	mockConsMgr, consMocks := consensus.MockingManager(ts, mockState, valKeys)
 
 	mockState.CommitTestBlocks(10)
 

--- a/www/http/http_test.go
+++ b/www/http/http_test.go
@@ -43,12 +43,11 @@ func setup(t *testing.T) *testData {
 	//
 	http.DefaultServeMux = new(http.ServeMux)
 
+	valKeys := []*bls.ValidatorKey{ts.RandValKey(), ts.RandValKey()}
 	mockState := state.MockingState(ts)
 	mockSync := sync.MockingSync(ts)
 	mockNet := network.MockingNetwork(ts, ts.RandPeerID())
-	mockConsMgr, _ := consensus.MockingManager(ts, []*bls.ValidatorKey{
-		ts.RandValKey(), ts.RandValKey(),
-	})
+	mockConsMgr, _ := consensus.MockingManager(ts, mockState, valKeys)
 
 	mockConsMgr.MoveToNewHeight()
 


### PR DESCRIPTION
## Description

This PR implements a TODO to check if gossip messages are not sent directly and if stream messages are not broadcasted. If so, the message will be dropped and the peer will be banned.