### PR TITLE
fix(grpc): return error on invalid arguments for VerifyMessage

### DIFF
--- a/www/grpc/utils.go
+++ b/www/grpc/utils.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pactus-project/pactus/crypto/bls"
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type utilServer struct {
@@ -37,16 +39,12 @@ func (*utilServer) VerifyMessage(_ context.Context,
 ) (*pactus.VerifyMessageResponse, error) {
 	sig, err := bls.SignatureFromString(req.Signature)
 	if err != nil {
-		return &pactus.VerifyMessageResponse{
-			IsValid: false,
-		}, err
+		return nil, status.Error(codes.InvalidArgument, "signature is invalid")
 	}
 
 	pub, err := bls.PublicKeyFromString(req.PublicKey)
 	if err != nil {
-		return &pactus.VerifyMessageResponse{
-			IsValid: false,
-		}, err
+		return nil, status.Error(codes.InvalidArgument, "public key is invalid")
 	}
 
 	if err := pub.Verify([]byte(req.Message), sig); err == nil {

--- a/www/grpc/utils.go
+++ b/www/grpc/utils.go
@@ -24,7 +24,7 @@ func (*utilServer) SignMessageWithPrivateKey(_ context.Context,
 ) (*pactus.SignMessageWithPrivateKeyResponse, error) {
 	prvKey, err := bls.PrivateKeyFromString(req.PrivateKey)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, "invalid private key")
 	}
 
 	sig := prvKey.Sign([]byte(req.Message)).String()

--- a/www/grpc/utils.go
+++ b/www/grpc/utils.go
@@ -49,13 +49,13 @@ func (*utilServer) VerifyMessage(_ context.Context,
 		}, err
 	}
 
-	if err := pub.Verify([]byte(req.Message), sig); err != nil {
+	if err := pub.Verify([]byte(req.Message), sig); err == nil {
 		return &pactus.VerifyMessageResponse{
-			IsValid: false,
-		}, err
+			IsValid: true,
+		}, nil
 	}
 
 	return &pactus.VerifyMessageResponse{
-		IsValid: true,
+		IsValid: false,
 	}, nil
 }

--- a/www/grpc/utils_test.go
+++ b/www/grpc/utils_test.go
@@ -55,7 +55,7 @@ func TestVerifyMessage(t *testing.T) {
 	sigStr := "923d67a8624cbb7972b29328e15ec76cc846076ccf00a9e94d991c677846f334ae4ba4551396fbcd6d1cab7593baf3b7"
 	invalidSigStr := "113d67a8624cbb7972b29328e15ec76cc846076ccf00a9e94d991c677846f334ae4ba4551396fbcd6d1cab7593baf3c9"
 
-	t.Run("", func(t *testing.T) {
+	t.Run("valid message", func(t *testing.T) {
 		res, err := client.VerifyMessage(context.Background(),
 			&pactus.VerifyMessageRequest{
 				Message:   msg,
@@ -66,15 +66,16 @@ func TestVerifyMessage(t *testing.T) {
 		assert.True(t, res.IsValid)
 	})
 
-	t.Run("", func(t *testing.T) {
-		_, err := client.VerifyMessage(context.Background(),
+	t.Run("invalid message", func(t *testing.T) {
+		res, err := client.VerifyMessage(context.Background(),
 			&pactus.VerifyMessageRequest{
 				Message:   msg,
 				Signature: invalidSigStr,
 				PublicKey: pubStr,
 			})
 
-		assert.NotNil(t, err)
+		assert.Nil(t, err)
+		assert.False(t, res.IsValid)
 	})
 
 	assert.Nil(t, conn.Close(), "Error closing connection")


### PR DESCRIPTION
## Description

This PR enhances error handling by returning `InvalidArgument` error when the Public Key or Signature is invalid. 
This improvement allows users to distinguish between an invalid argument and a signature that does not match the signed message.