### PR TITLE
chore(state): revet maximum transaction in block to 1000

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -35,7 +35,7 @@ import (
 	"github.com/pactus-project/pactus/www/nanomsg/event"
 )
 
-var maxTransactionsPerBlock = 100
+var maxTransactionsPerBlock = 1000
 
 type state struct {
 	lk sync.RWMutex


### PR DESCRIPTION
## Description

This PR sets the maximum number of transactions in a block to 1000.
