### PR TITLE
fix(store): pruning height returns zero when store is not in prune mode

### DIFF
--- a/store/mock.go
+++ b/store/mock.go
@@ -299,5 +299,5 @@ func (*MockStore) IsPruned() bool {
 }
 
 func (*MockStore) PruningHeight() uint32 {
-	return 1
+	return 0
 }

--- a/store/store.go
+++ b/store/store.go
@@ -432,6 +432,7 @@ func (s *store) PruningHeight() uint32 {
 
 	// TODO: it can be optimized (and safer?) by keeping the last block height in memory.
 	cert := s.lastCertificate()
+
 	return cert.Height() - s.config.RetentionBlocks()
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -357,7 +357,7 @@ func TestCancelPrune(t *testing.T) {
 	td := setup(t, conf)
 
 	hits := uint32(0)
-	cb := func(pruned bool, pruningHeight uint32) bool {
+	cb := func(_ bool, _ uint32) bool {
 		hits++
 
 		return true // Cancel pruning

--- a/www/grpc/blockchain.go
+++ b/www/grpc/blockchain.go
@@ -33,11 +33,6 @@ func (s *blockchainServer) GetBlockchainInfo(_ context.Context,
 		cv = append(cv, s.validatorToProto(v))
 	}
 
-	pruningHeight := uint32(0)
-	if s.state.IsPruned() {
-		pruningHeight = s.state.PruningHeight()
-	}
-
 	return &pactus.GetBlockchainInfoResponse{
 		LastBlockHeight:     s.state.LastBlockHeight(),
 		LastBlockHash:       s.state.LastBlockHash().String(),
@@ -46,7 +41,7 @@ func (s *blockchainServer) GetBlockchainInfo(_ context.Context,
 		TotalPower:          s.state.TotalPower(),
 		CommitteePower:      s.state.CommitteePower(),
 		IsPruned:            s.state.IsPruned(),
-		PruningHeight:       pruningHeight,
+		PruningHeight:       s.state.PruningHeight(),
 		LastBlockTime:       s.state.LastBlockTime().Unix(),
 		CommitteeValidators: cv,
 	}, nil

--- a/www/grpc/blockchain_test.go
+++ b/www/grpc/blockchain_test.go
@@ -161,6 +161,8 @@ func TestGetBlockchainInfo(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, td.mockState.TestStore.LastHeight, res.LastBlockHeight)
 		assert.NotEmpty(t, res.LastBlockHash)
+		assert.Zero(t, res.PruningHeight)
+		assert.False(t, res.IsPruned)
 	})
 
 	assert.Nil(t, conn.Close(), "Error closing connection")


### PR DESCRIPTION
## Description

Updated the `PruningHeight` function to correctly return zero if the store is not in prune mode. 


