### PR TITLE
fix(cmd): prevent sudden crash on download error

### DIFF
--- a/cmd/daemon/import.go
+++ b/cmd/daemon/import.go
@@ -81,11 +81,8 @@ func buildImportCmd(parentCmd *cobra.Command) {
 
 		cmd.PrintLine()
 
-		importer.Download(
-			c.Context(),
-			&selected,
-			downloadProgressBar,
-		)
+		err = importer.Download(c.Context(), &selected, downloadProgressBar)
+		cmd.FatalErrorCheck(err)
 
 		cmd.PrintLine()
 		cmd.PrintLine()

--- a/cmd/gtk/startup_assistant.go
+++ b/cmd/gtk/startup_assistant.go
@@ -258,12 +258,8 @@ func startupAssistant(workingDir string, chainType genesis.ChainType) bool {
 									go func() {
 										log.Printf("start downloading...\n")
 
-										importer.Download(
-											ctx,
-											&md[snapshotIndex],
-											func(fileName string, totalSize, downloaded int64,
-												percentage float64,
-											) {
+										err := importer.Download(ctx, &md[snapshotIndex],
+											func(fileName string, totalSize, downloaded int64, percentage float64) {
 												percent := int(percentage)
 												glib.IdleAdd(func() {
 													dlMessage := fmt.Sprintf("🌐 Downloading %s | %d%% (%s / %s)",
@@ -278,6 +274,8 @@ func startupAssistant(workingDir string, chainType genesis.ChainType) bool {
 										)
 
 										glib.IdleAdd(func() {
+											fatalErrorCheck(err)
+
 											log.Printf("extracting data...\n")
 											ssPBLabel.SetText("   " + "📂 Extracting downloaded files...")
 											err := importer.ExtractAndStoreFiles()

--- a/cmd/importer.go
+++ b/cmd/importer.go
@@ -156,8 +156,8 @@ func (i *Importer) Download(ctx context.Context, metadata *Metadata,
 			stateFunc(fileName, state.TotalSize, state.Downloaded, state.Percent)
 			if state.Completed {
 				log.Println("download completed")
-
 				done <- nil
+
 				return
 			}
 		}

--- a/util/io.go
+++ b/util/io.go
@@ -90,8 +90,7 @@ func IsDirEmpty(name string) bool {
 	return errors.Is(err, io.EOF)
 }
 
-// IsDirNotExistsOrEmpty returns true if a directory does not exist or is empty.
-// It checks if the path exists and, if so, whether the directory is empty.
+// IsDirNotExistsOrEmpty checks if the path exists and, if so, whether the directory is empty.
 func IsDirNotExistsOrEmpty(name string) bool {
 	if !PathExists(name) {
 		return true
@@ -203,9 +202,16 @@ func NewFixedReader(max int, buf []byte) *FixedReader {
 
 // MoveDirectory moves a directory from srcDir to dstDir, including all its contents.
 // If dstDir already exists and is not empty, it returns an error.
+// If the parent directory of dstDir does not exist, it will be created.
 func MoveDirectory(srcDir, dstDir string) error {
-	if !IsDirNotExistsOrEmpty(dstDir) {
+	if PathExists(dstDir) {
 		return fmt.Errorf("destination directory %s already exists", dstDir)
+	}
+
+	// Get the parent directory of the destination directory
+	parentDir := filepath.Dir(dstDir)
+	if err := os.MkdirAll(parentDir, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create parent directories for %s: %w", dstDir, err)
 	}
 
 	if err := os.Rename(srcDir, dstDir); err != nil {

--- a/util/io.go
+++ b/util/io.go
@@ -210,7 +210,7 @@ func MoveDirectory(srcDir, dstDir string) error {
 
 	// Get the parent directory of the destination directory
 	parentDir := filepath.Dir(dstDir)
-	if err := os.MkdirAll(parentDir, os.ModePerm); err != nil {
+	if err := Mkdir(parentDir); err != nil {
 		return fmt.Errorf("failed to create parent directories for %s: %w", dstDir, err)
 	}
 


### PR DESCRIPTION
## Description

This PR prevents a sudden panic if downloading data encounters an error. 
It also creates the parent directory to prevent an error when moving data.