### PR TITLE
fix(consensus): handle query for decided proposal

### DIFF
--- a/consensus/cp.go
+++ b/consensus/cp.go
@@ -17,9 +17,9 @@ func (*changeProposer) onSetProposal(_ *proposal.Proposal) {
 }
 
 func (cp *changeProposer) onTimeout(t *ticker) {
-	if t.Target == tickerTargetQueryVotes {
-		cp.queryVotes()
-		cp.scheduleTimeout(t.Duration*2, cp.height, cp.round, tickerTargetQueryVotes)
+	if t.Target == tickerTargetQueryVote {
+		cp.queryVote()
+		cp.scheduleTimeout(t.Duration*2, cp.height, cp.round, tickerTargetQueryVote)
 	}
 }
 
@@ -327,6 +327,12 @@ func (cp *changeProposer) cpDecide(round int16, cpValue vote.CPValue) {
 	} else if cpValue == vote.CPValueNo {
 		cp.round = round
 		cp.cpDecided = 0
+
+		roundProposal := cp.log.RoundProposal(cp.round)
+		if roundProposal == nil {
+			cp.queryProposal()
+		}
+
 		cp.enterNewState(cp.prepareState)
 	}
 }

--- a/consensus/cp_prevote.go
+++ b/consensus/cp_prevote.go
@@ -29,7 +29,7 @@ func (s *cpPreVoteState) decide() {
 			just := &vote.JustInitYes{}
 			s.signAddCPPreVote(hash.UndefHash, s.cpRound, 1, just)
 		}
-		s.scheduleTimeout(s.config.QueryVoteTimeout, s.height, s.round, tickerTargetQueryVotes)
+		s.scheduleTimeout(s.config.QueryVoteTimeout, s.height, s.round, tickerTargetQueryVote)
 	} else {
 		cpMainVotes := s.log.CPMainVoteVoteSet(s.round)
 		switch {

--- a/consensus/interface.go
+++ b/consensus/interface.go
@@ -10,7 +10,8 @@ import (
 type Reader interface {
 	ConsensusKey() *bls.PublicKey
 	AllVotes() []*vote.Vote
-	PickRandomVote(round int16) *vote.Vote
+	HandleQueryVote(height uint32, round int16) *vote.Vote
+	HandleQueryProposal(height uint32, round int16) *proposal.Proposal
 	Proposal() *proposal.Proposal
 	HasVote(h hash.Hash) bool
 	HeightRound() (uint32, int16)
@@ -29,11 +30,11 @@ type Consensus interface {
 
 type ManagerReader interface {
 	Instances() []Reader
-	PickRandomVote(round int16) *vote.Vote
+	HandleQueryVote(height uint32, round int16) *vote.Vote
+	HandleQueryProposal(height uint32, round int16) *proposal.Proposal
 	Proposal() *proposal.Proposal
 	HeightRound() (uint32, int16)
 	HasActiveInstance() bool
-	HasProposer() bool
 }
 
 type Manager interface {

--- a/consensus/manager.go
+++ b/consensus/manager.go
@@ -74,18 +74,25 @@ func (mgr *manager) Instances() []Reader {
 	return readers
 }
 
-// PickRandomVote returns a random vote from a random consensus instance.
-func (mgr *manager) PickRandomVote(round int16) *vote.Vote {
-	cons := mgr.getBestInstance()
-
-	return cons.PickRandomVote(round)
-}
-
-// Proposal returns the proposal for a specific round from a random consensus instance.
+// Proposal returns the current proposal for the active round from a random consensus instance.
 func (mgr *manager) Proposal() *proposal.Proposal {
 	cons := mgr.getBestInstance()
 
 	return cons.Proposal()
+}
+
+// HandleQueryProposal returns the proposal for a specific round from a random consensus instance.
+func (mgr *manager) HandleQueryProposal(height uint32, round int16) *proposal.Proposal {
+	cons := mgr.getBestInstance()
+
+	return cons.HandleQueryProposal(height, round)
+}
+
+// HandleQueryVote returns a random vote from a random consensus instance.
+func (mgr *manager) HandleQueryVote(height uint32, round int16) *vote.Vote {
+	cons := mgr.getBestInstance()
+
+	return cons.HandleQueryVote(height, round)
 }
 
 // HeightRound retrieves the current height and round from a random consensus instance.
@@ -99,18 +106,6 @@ func (mgr *manager) HeightRound() (uint32, int16) {
 func (mgr *manager) HasActiveInstance() bool {
 	for _, cons := range mgr.instances {
 		if cons.IsActive() {
-			return true
-		}
-	}
-
-	return false
-}
-
-// HasProposer checks if any of the consensus instances is the proposer
-// for the current round.
-func (mgr *manager) HasProposer() bool {
-	for _, cons := range mgr.instances {
-		if cons.IsProposer() {
 			return true
 		}
 	}

--- a/consensus/mock.go
+++ b/consensus/mock.go
@@ -86,6 +86,10 @@ func (m *MockConsensus) Proposal() *proposal.Proposal {
 	return m.CurProposal
 }
 
+func (m *MockConsensus) HandleQueryProposal(_ uint32, _ int16) *proposal.Proposal {
+	return m.CurProposal
+}
+
 func (m *MockConsensus) HeightRound() (uint32, int16) {
 	return m.Height, m.Round
 }
@@ -94,7 +98,7 @@ func (*MockConsensus) String() string {
 	return ""
 }
 
-func (m *MockConsensus) PickRandomVote(_ int16) *vote.Vote {
+func (m *MockConsensus) HandleQueryVote(_ uint32, _ int16) *vote.Vote {
 	if len(m.Votes) == 0 {
 		return nil
 	}

--- a/consensus/precommit.go
+++ b/consensus/precommit.go
@@ -24,13 +24,7 @@ func (s *precommitState) decide() {
 	if precommitQH != nil {
 		s.logger.Debug("pre-commit has quorum", "hash", precommitQH)
 
-		roundProposal := s.log.RoundProposal(s.round)
-		if roundProposal == nil {
-			// There is a consensus about a proposal that we don't have yet.
-			// Ask peers for this proposal.
-			s.logger.Info("query for a decided proposal", "hash", precommitQH)
-			s.queryProposal()
-		} else if s.hasVoted {
+		if s.hasVoted {
 			// To ensure we have voted and won't be absent from the certificate
 			s.enterNewState(s.commitState)
 		}

--- a/consensus/prepare.go
+++ b/consensus/prepare.go
@@ -66,7 +66,7 @@ func (s *prepareState) onTimeout(t *ticker) {
 			s.queryProposal()
 		}
 		if s.isProposer() {
-			s.queryVotes()
+			s.queryVote()
 		}
 	} else if t.Target == tickerTargetChangeProposer {
 		s.startChangingProposer()

--- a/consensus/prepare_test.go
+++ b/consensus/prepare_test.go
@@ -31,7 +31,7 @@ func TestQueryProposal(t *testing.T) {
 	td.shouldNotPublish(t, td.consP, message.TypeQueryVote)
 }
 
-func TestQueryVotes(t *testing.T) {
+func TestQueryVote(t *testing.T) {
 	td := setup(t)
 
 	td.commitBlockForAllStates(t)

--- a/consensus/ticker.go
+++ b/consensus/ticker.go
@@ -11,7 +11,7 @@ const (
 	tickerTargetNewHeight      = tickerTarget(1)
 	tickerTargetChangeProposer = tickerTarget(2)
 	tickerTargetQueryProposal  = tickerTarget(3)
-	tickerTargetQueryVotes     = tickerTarget(4)
+	tickerTargetQueryVote      = tickerTarget(4)
 )
 
 func (rs tickerTarget) String() string {
@@ -22,7 +22,7 @@ func (rs tickerTarget) String() string {
 		return "change-proposer"
 	case tickerTargetQueryProposal:
 		return "query-proposal"
-	case tickerTargetQueryVotes:
+	case tickerTargetQueryVote:
 		return "query-votes"
 	default:
 		return "Unknown"

--- a/sync/bundle/message/message.go
+++ b/sync/bundle/message/message.go
@@ -107,7 +107,7 @@ func MakeMessage(t Type) Message {
 		return &ProposalMessage{}
 
 	case TypeQueryVote:
-		return &QueryVotesMessage{}
+		return &QueryVoteMessage{}
 
 	case TypeVote:
 		return &VoteMessage{}

--- a/sync/bundle/message/query_votes.go
+++ b/sync/bundle/message/query_votes.go
@@ -8,21 +8,21 @@ import (
 	"github.com/pactus-project/pactus/util/errors"
 )
 
-type QueryVotesMessage struct {
+type QueryVoteMessage struct {
 	Height  uint32         `cbor:"1,keyasint"`
 	Round   int16          `cbor:"2,keyasint"`
 	Querier crypto.Address `cbor:"3,keyasint"`
 }
 
-func NewQueryVotesMessage(height uint32, round int16, querier crypto.Address) *QueryVotesMessage {
-	return &QueryVotesMessage{
+func NewQueryVoteMessage(height uint32, round int16, querier crypto.Address) *QueryVoteMessage {
+	return &QueryVoteMessage{
 		Height:  height,
 		Round:   round,
 		Querier: querier,
 	}
 }
 
-func (m *QueryVotesMessage) BasicCheck() error {
+func (m *QueryVoteMessage) BasicCheck() error {
 	if m.Round < 0 {
 		return errors.Error(errors.ErrInvalidRound)
 	}
@@ -30,18 +30,18 @@ func (m *QueryVotesMessage) BasicCheck() error {
 	return nil
 }
 
-func (*QueryVotesMessage) Type() Type {
+func (*QueryVoteMessage) Type() Type {
 	return TypeQueryVote
 }
 
-func (*QueryVotesMessage) TopicID() network.TopicID {
+func (*QueryVoteMessage) TopicID() network.TopicID {
 	return network.TopicIDConsensus
 }
 
-func (*QueryVotesMessage) ShouldBroadcast() bool {
+func (*QueryVoteMessage) ShouldBroadcast() bool {
 	return true
 }
 
-func (m *QueryVotesMessage) String() string {
+func (m *QueryVoteMessage) String() string {
 	return fmt.Sprintf("{%d/%d %s}", m.Height, m.Round, m.Querier.ShortString())
 }

--- a/sync/bundle/message/query_votes_test.go
+++ b/sync/bundle/message/query_votes_test.go
@@ -9,21 +9,21 @@ import (
 )
 
 func TestQueryVotesType(t *testing.T) {
-	m := &QueryVotesMessage{}
+	m := &QueryVoteMessage{}
 	assert.Equal(t, TypeQueryVote, m.Type())
 }
 
-func TestQueryVotesMessage(t *testing.T) {
+func TestQueryVoteMessage(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	t.Run("Invalid round", func(t *testing.T) {
-		m := NewQueryVotesMessage(0, -1, ts.RandValAddress())
+		m := NewQueryVoteMessage(0, -1, ts.RandValAddress())
 
 		assert.Equal(t, errors.ErrInvalidRound, errors.Code(m.BasicCheck()))
 	})
 
 	t.Run("OK", func(t *testing.T) {
-		m := NewQueryVotesMessage(100, 0, ts.RandValAddress())
+		m := NewQueryVoteMessage(100, 0, ts.RandValAddress())
 
 		assert.NoError(t, m.BasicCheck())
 		assert.Contains(t, m.String(), "100")

--- a/sync/firewall/firewall_test.go
+++ b/sync/firewall/firewall_test.go
@@ -74,7 +74,7 @@ func setup(t *testing.T, conf *Config) *testData {
 }
 
 func (td *testData) testGossipBundle() []byte {
-	bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
+	bdl := bundle.NewBundle(message.NewQueryVoteMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkMainnet)
 	d, _ := bdl.Encode()
 
@@ -326,7 +326,7 @@ func TestBannedAddress(t *testing.T) {
 func TestNetworkFlagsMainnet(t *testing.T) {
 	td := setup(t, nil)
 
-	bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
+	bdl := bundle.NewBundle(message.NewQueryVoteMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkMainnet)
 	assert.NoError(t, td.firewall.checkBundle(bdl))
 
@@ -341,7 +341,7 @@ func TestNetworkFlagsTestnet(t *testing.T) {
 	td := setup(t, nil)
 	td.state.TestGenesis = genesis.TestnetGenesis()
 
-	bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
+	bdl := bundle.NewBundle(message.NewQueryVoteMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	assert.NoError(t, td.firewall.checkBundle(bdl))
 
@@ -356,7 +356,7 @@ func TestNetworkFlagsLocalnet(t *testing.T) {
 	td := setup(t, nil)
 	td.state.TestParams.BlockVersion = 0x3f // changing genesis hash
 
-	bdl := bundle.NewBundle(message.NewQueryVotesMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
+	bdl := bundle.NewBundle(message.NewQueryVoteMessage(td.RandHeight(), td.RandRound(), td.RandValAddress()))
 	bdl.Flags = util.SetFlag(bdl.Flags, bundle.BundleFlagNetworkTestnet)
 	assert.Error(t, td.firewall.checkBundle(bdl))
 

--- a/sync/handler_proposal_test.go
+++ b/sync/handler_proposal_test.go
@@ -17,6 +17,6 @@ func TestParsingProposalMessages(t *testing.T) {
 		pid := td.RandPeerID()
 
 		td.receivingNewMessage(td.sync, msg, pid)
-		assert.NotNil(t, td.consMgr.Proposal())
+		assert.Equal(t, prop, td.consMgr.Proposal())
 	})
 }

--- a/sync/handler_query_proposal.go
+++ b/sync/handler_query_proposal.go
@@ -20,27 +20,7 @@ func (handler *queryProposalHandler) ParseMessage(m message.Message, _ peer.ID) 
 	msg := m.(*message.QueryProposalMessage)
 	handler.logger.Trace("parsing QueryProposal message", "msg", msg)
 
-	if !handler.consMgr.HasActiveInstance() {
-		handler.logger.Debug("ignoring QueryProposal, not active", "msg", msg)
-
-		return
-	}
-
-	if !handler.consMgr.HasProposer() {
-		handler.logger.Debug("ignoring QueryProposal, not proposer", "msg", msg)
-
-		return
-	}
-
-	height, round := handler.consMgr.HeightRound()
-	if msg.Height != height || msg.Round != round {
-		handler.logger.Debug("ignoring QueryProposal, not same height/round", "msg", msg,
-			"height", height, "round", round)
-
-		return
-	}
-
-	prop := handler.consMgr.Proposal()
+	prop := handler.consMgr.HandleQueryProposal(msg.Height, msg.Round)
 	if prop != nil {
 		response := message.NewProposalMessage(prop)
 		handler.broadcast(response)

--- a/sync/handler_query_proposal_test.go
+++ b/sync/handler_query_proposal_test.go
@@ -11,56 +11,24 @@ func TestParsingQueryProposalMessages(t *testing.T) {
 	td := setup(t, nil)
 
 	consHeight, consRound := td.consMgr.HeightRound()
-	prop, _ := td.GenerateTestProposal(consHeight, 0)
-	pid := td.RandPeerID()
-	td.consMgr.SetProposal(prop)
 
-	t.Run("doesn't have active validator", func(t *testing.T) {
+	t.Run("doesn't have the proposal", func(t *testing.T) {
+		pid := td.RandPeerID()
 		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
-		td.receivingNewMessage(td.sync, msg, pid)
-
-		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
-	})
-
-	td.consMocks[0].Active = true
-
-	t.Run("not the proposer", func(t *testing.T) {
-		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
-		td.receivingNewMessage(td.sync, msg, pid)
-
-		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
-	})
-
-	td.consMocks[0].Proposer = true
-
-	t.Run("not the same height", func(t *testing.T) {
-		msg := message.NewQueryProposalMessage(consHeight+1, consRound, td.RandValAddress())
-		td.receivingNewMessage(td.sync, msg, pid)
-
-		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
-	})
-
-	t.Run("not the same round", func(t *testing.T) {
-		msg := message.NewQueryProposalMessage(consHeight, consRound+1, td.RandValAddress())
 		td.receivingNewMessage(td.sync, msg, pid)
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
 	})
 
 	t.Run("should respond to the query proposal message", func(t *testing.T) {
+		prop, _ := td.GenerateTestProposal(consHeight, 0)
+		pid := td.RandPeerID()
+		td.consMgr.SetProposal(prop)
 		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
 		td.receivingNewMessage(td.sync, msg, pid)
 
 		bdl := td.shouldPublishMessageWithThisType(t, message.TypeProposal)
 		assert.Equal(t, prop.Hash(), bdl.Message.(*message.ProposalMessage).Proposal.Hash())
-	})
-
-	t.Run("doesn't have the proposal", func(t *testing.T) {
-		td.consMocks[0].CurProposal = nil
-		msg := message.NewQueryProposalMessage(consHeight, consRound, td.RandValAddress())
-		td.receivingNewMessage(td.sync, msg, pid)
-
-		td.shouldNotPublishMessageWithThisType(t, message.TypeProposal)
 	})
 }
 

--- a/sync/handler_query_votes.go
+++ b/sync/handler_query_votes.go
@@ -6,42 +6,28 @@ import (
 	"github.com/pactus-project/pactus/sync/peerset/peer"
 )
 
-type queryVotesHandler struct {
+type queryVoteHandler struct {
 	*synchronizer
 }
 
-func newQueryVotesHandler(sync *synchronizer) messageHandler {
-	return &queryVotesHandler{
+func newQueryVoteHandler(sync *synchronizer) messageHandler {
+	return &queryVoteHandler{
 		sync,
 	}
 }
 
-func (handler *queryVotesHandler) ParseMessage(m message.Message, _ peer.ID) {
-	msg := m.(*message.QueryVotesMessage)
-	handler.logger.Trace("parsing QueryVotes message", "msg", msg)
+func (handler *queryVoteHandler) ParseMessage(m message.Message, _ peer.ID) {
+	msg := m.(*message.QueryVoteMessage)
+	handler.logger.Trace("parsing QueryVote message", "msg", msg)
 
-	if !handler.consMgr.HasActiveInstance() {
-		handler.logger.Debug("ignoring QueryVotes, not active", "msg", msg)
-
-		return
-	}
-
-	height, _ := handler.consMgr.HeightRound()
-	if msg.Height != height {
-		handler.logger.Debug("ignoring QueryVotes, not same height", "msg", msg,
-			"height", height)
-
-		return
-	}
-
-	v := handler.consMgr.PickRandomVote(msg.Round)
+	v := handler.consMgr.HandleQueryVote(msg.Height, msg.Round)
 	if v != nil {
 		response := message.NewVoteMessage(v)
 		handler.broadcast(response)
 	}
 }
 
-func (*queryVotesHandler) PrepareBundle(m message.Message) *bundle.Bundle {
+func (*queryVoteHandler) PrepareBundle(m message.Message) *bundle.Bundle {
 	bdl := bundle.NewBundle(m)
 
 	return bdl

--- a/sync/handler_query_votes_test.go
+++ b/sync/handler_query_votes_test.go
@@ -7,44 +7,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParsingQueryVotesMessages(t *testing.T) {
+func TestParsingQueryVoteMessages(t *testing.T) {
 	td := setup(t, nil)
 
-	consensusHeight, _ := td.consMgr.HeightRound()
-	v1, _ := td.GenerateTestPrecommitVote(consensusHeight, 0)
-	td.consMgr.AddVote(v1)
-	pid := td.RandPeerID()
-
-	t.Run("doesn't have active validator", func(t *testing.T) {
-		msg := message.NewQueryVotesMessage(consensusHeight, 1, td.RandValAddress())
+	consHeight, consRound := td.consMgr.HeightRound()
+	t.Run("doesn't have any votes", func(t *testing.T) {
+		pid := td.RandPeerID()
+		msg := message.NewQueryVoteMessage(consHeight, consRound, td.RandValAddress())
 		td.receivingNewMessage(td.sync, msg, pid)
 
 		td.shouldNotPublishMessageWithThisType(t, message.TypeVote)
 	})
 
-	td.consMocks[0].Active = true
-
 	t.Run("should respond to the query votes message", func(t *testing.T) {
-		msg := message.NewQueryVotesMessage(consensusHeight, 1, td.RandValAddress())
+		v1, _ := td.GenerateTestPrecommitVote(consHeight, consRound)
+		td.consMgr.AddVote(v1)
+		pid := td.RandPeerID()
+		msg := message.NewQueryVoteMessage(consHeight, consRound, td.RandValAddress())
 		td.receivingNewMessage(td.sync, msg, pid)
 
 		bdl := td.shouldPublishMessageWithThisType(t, message.TypeVote)
 		assert.Equal(t, v1.Hash(), bdl.Message.(*message.VoteMessage).Vote.Hash())
 	})
-
-	t.Run("doesn't have any votes", func(t *testing.T) {
-		msg := message.NewQueryVotesMessage(consensusHeight+1, 1, td.RandValAddress())
-		td.receivingNewMessage(td.sync, msg, pid)
-
-		td.shouldNotPublishMessageWithThisType(t, message.TypeVote)
-	})
 }
 
-func TestBroadcastingQueryVotesMessages(t *testing.T) {
+func TestBroadcastingQueryVoteMessages(t *testing.T) {
 	td := setup(t, nil)
 
 	consensusHeight := td.state.LastBlockHeight() + 1
-	msg := message.NewQueryVotesMessage(consensusHeight, 1, td.RandValAddress())
+	msg := message.NewQueryVoteMessage(consensusHeight, 1, td.RandValAddress())
 	td.sync.broadcast(msg)
 
 	td.shouldPublishMessageWithThisType(t, message.TypeQueryVote)

--- a/sync/handler_vote_test.go
+++ b/sync/handler_vote_test.go
@@ -16,6 +16,6 @@ func TestParsingVoteMessages(t *testing.T) {
 		pid := td.RandPeerID()
 
 		td.receivingNewMessage(td.sync, msg, pid)
-		assert.Equal(t, v.Hash(), td.consMgr.PickRandomVote(0).Hash())
+		assert.Contains(t, td.consMocks[0].AllVotes(), v)
 	})
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -96,7 +96,7 @@ func NewSynchronizer(
 	handlers[message.TypeTransaction] = newTransactionsHandler(sync)
 	handlers[message.TypeQueryProposal] = newQueryProposalHandler(sync)
 	handlers[message.TypeProposal] = newProposalHandler(sync)
-	handlers[message.TypeQueryVote] = newQueryVotesHandler(sync)
+	handlers[message.TypeQueryVote] = newQueryVoteHandler(sync)
 	handlers[message.TypeVote] = newVoteHandler(sync)
 	handlers[message.TypeBlockAnnounce] = newBlockAnnounceHandler(sync)
 	handlers[message.TypeBlocksRequest] = newBlocksRequestHandler(sync)


### PR DESCRIPTION
## Description

When the validators decide not to change the proposer and the proposal gets locked, the `QueryProposal` message can be responded to by all validators. 
This ensures that if the proposer fails, the proposal can still be broadcasted by other validators.
