### PR TITLE
feat(sync): ban online peers with duplicated validators

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -531,7 +531,7 @@ func (cs *consensus) HandleQueryVote(height uint32, round int16) *vote.Vote {
 		return nil
 	}
 
-	return votes[util.RandInt32(int32(len(votes)))]
+	return util.RandomElement(votes)
 }
 
 func (cs *consensus) startChangingProposer() {

--- a/util/slice.go
+++ b/util/slice.go
@@ -251,3 +251,8 @@ func Shuffle[T any](slice []T) {
 		slice[i], slice[j] = slice[j], slice[i]
 	})
 }
+
+// RandomElement returns a random element from a slice
+func RandomElement[T any](slice []T) T {
+	return slice[RandInt32(int32(len(slice)))]
+}

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -362,3 +362,10 @@ func TestShuffle(t *testing.T) {
 	assert.NotEqual(t, originalInts, ints, "ints slice was not shuffled")
 	assert.ElementsMatch(t, originalInts, ints, "ints slice does not contain the same elements")
 }
+
+func TestRandomElement(t *testing.T) {
+	slice := []int{1, 2, 3, 4, 5}
+
+	randItem := RandomElement(slice)
+	assert.Contains(t, slice, randItem)
+}


### PR DESCRIPTION
## Description

This PR checks if connected peers have duplicated validators and bans them.