### PR TITLE
chore(genesis): set deprecated fee values to 0 for localnet

### DIFF
--- a/genesis/testnet.json
+++ b/genesis/testnet.json
@@ -9,9 +9,9 @@
         "bond_interval": 360,
         "unbond_interval": 181440,
         "sortition_interval": 17,
-        "fee_fraction": 0.0001,
-        "minimum_fee": 1000,
-        "maximum_fee": 1000000,
+        "fee_fraction": 0.0,
+        "minimum_fee": 0,
+        "maximum_fee": 0,
         "minimum_stake": 1000000000,
         "maximum_stake": 1000000000000
     },


### PR DESCRIPTION
## Description

## Related issue

- Fixes #1341 