### PR TITLE
fix(util): remove util.Now helper function

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -376,7 +376,7 @@ func (cs *consensus) signAddVote(v *vote.Vote) {
 
 	_, err := cs.log.AddVote(v)
 	if err != nil {
-		cs.logger.Error("error on adding our vote", "error", err, "vote", v)
+		cs.logger.Warn("error on adding our vote", "error", err, "vote", v)
 	}
 	cs.broadcastVote(v)
 }

--- a/consensus/height.go
+++ b/consensus/height.go
@@ -1,9 +1,10 @@
 package consensus
 
 import (
+	"time"
+
 	"github.com/pactus-project/pactus/types/proposal"
 	"github.com/pactus-project/pactus/types/vote"
-	"github.com/pactus-project/pactus/util"
 )
 
 type newHeightState struct {
@@ -25,7 +26,7 @@ func (s *newHeightState) decide() {
 	s.active = s.bcState.IsInCommittee(s.valKey.Address())
 	s.logger.Info("entering new height", "height", s.height, "active", s.active)
 
-	sleep := s.bcState.LastBlockTime().Add(s.bcState.Params().BlockInterval()).Sub(util.Now())
+	sleep := time.Until(s.bcState.LastBlockTime().Add(s.bcState.Params().BlockInterval()))
 	s.scheduleTimeout(sleep, s.height, s.round, tickerTargetNewHeight)
 }
 

--- a/execution/executor/bond_test.go
+++ b/execution/executor/bond_test.go
@@ -81,7 +81,7 @@ func TestExecuteBondTx(t *testing.T) {
 
 	t.Run("Should fail, inside committee", func(t *testing.T) {
 		pub0 := td.sandbox.Committee().Proposer(0).PublicKey()
-		trx := tx.NewBondTx(lockTime, senderAddr, pub0.ValidatorAddress(), nil, amt, fee)
+		trx := tx.NewBondTx(lockTime, senderAddr, pub0.ValidatorAddress(), nil, 1e9, fee)
 
 		td.check(t, trx, true, ErrValidatorInCommittee)
 		td.check(t, trx, false, nil)

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -95,7 +95,7 @@ func TestCheckGenesisAccountAndValidator(t *testing.T) {
 		accs[pub.AccountAddress()] = acc
 		vals = append(vals, val)
 	}
-	gen := genesis.MakeGenesis(util.Now(), accs, vals, param.DefaultParams())
+	gen := genesis.MakeGenesis(time.Now(), accs, vals, param.DefaultParams())
 
 	for addr, acc := range gen.Accounts() {
 		assert.Equal(t, accs[addr], acc)

--- a/node/node.go
+++ b/node/node.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pactus-project/pactus/sync/bundle/message"
 	"github.com/pactus-project/pactus/sync/peerset/peer/service"
 	"github.com/pactus-project/pactus/txpool"
-	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/logger"
 	"github.com/pactus-project/pactus/version"
 	"github.com/pactus-project/pactus/wallet"
@@ -116,7 +115,7 @@ func NewNode(genDoc *genesis.Genesis, conf *config.Config,
 }
 
 func (n *Node) Start() error {
-	now := util.Now()
+	now := time.Now()
 	genTime := n.genesisDoc.GenesisTime()
 	if genTime.After(now) {
 		logger.Info("💤 Genesis time is in the future. Sleeping until then...",
@@ -125,17 +124,17 @@ func (n *Node) Start() error {
 	}
 
 	if err := n.network.Start(); err != nil {
-		return err
+		return errors.Wrap(err, "could not start Network")
 	}
 	// Wait for network to start
 	time.Sleep(1 * time.Second)
 
 	if err := n.sync.Start(); err != nil {
-		return err
+		return errors.Wrap(err, "could not start Sync")
 	}
 
 	if err := n.consMgr.Start(); err != nil {
-		return err
+		return errors.Wrap(err, "could not start Consensus manager")
 	}
 
 	err := n.grpc.StartServer()
@@ -155,7 +154,7 @@ func (n *Node) Start() error {
 
 	err = n.nanomsg.StartServer()
 	if err != nil {
-		return errors.Wrap(err, "could not start nanomsg server")
+		return errors.Wrap(err, "could not start Nanomsg server")
 	}
 
 	return nil

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -33,15 +33,15 @@ func TestRunningNode(t *testing.T) {
 		[]*validator.Validator{val}, param.DefaultParams())
 	conf := config.DefaultConfigMainnet()
 	conf.GRPC.Enable = true
-	conf.GRPC.Listen = "0:0"
+	conf.GRPC.Listen = "0.0.0.0:0"
 	conf.GRPC.Gateway.Enable = true
-	conf.GRPC.Gateway.Listen = "0:0"
+	conf.GRPC.Gateway.Listen = "0.0.0.0:0"
 	conf.HTTP.Enable = true
-	conf.HTTP.Listen = "0:0"
+	conf.HTTP.Listen = "0.0.0.0:0"
 	conf.JSONRPC.Enable = true
-	conf.JSONRPC.Listen = "0:0"
+	conf.JSONRPC.Listen = "0.0.0.0:0"
 	conf.Nanomsg.Enable = true
-	conf.Nanomsg.Listen = "tcp://0:0"
+	conf.Nanomsg.Listen = "tcp://0.0.0.0:0"
 	conf.Store.Path = util.TempDirPath()
 	conf.Network.EnableRelay = false
 	conf.Network.NetworkKey = util.TempFilePath()

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -2,11 +2,11 @@ package state
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/types/block"
 	"github.com/pactus-project/pactus/types/tx"
-	"github.com/pactus-project/pactus/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,7 +71,7 @@ func TestExecuteBlock(t *testing.T) {
 	t.Run("Subsidy tx is invalid", func(t *testing.T) {
 		txs := block.NewTxs()
 		txs.Append(invSubsidyTx)
-		invBlock := block.MakeBlock(1, util.Now(), txs, td.state.lastInfo.BlockHash(),
+		invBlock := block.MakeBlock(1, time.Now(), txs, td.state.lastInfo.BlockHash(),
 			td.state.stateRoot(), td.state.lastInfo.Certificate(),
 			td.state.lastInfo.SortitionSeed(), proposerAddr)
 		sb := td.state.concreteSandbox()
@@ -83,7 +83,7 @@ func TestExecuteBlock(t *testing.T) {
 		txs := block.NewTxs()
 		txs.Append(validSubsidyTx)
 		txs.Append(invTransferTx)
-		invBlock := block.MakeBlock(1, util.Now(), txs, td.state.lastInfo.BlockHash(),
+		invBlock := block.MakeBlock(1, time.Now(), txs, td.state.lastInfo.BlockHash(),
 			td.state.stateRoot(), td.state.lastInfo.Certificate(),
 			td.state.lastInfo.SortitionSeed(), proposerAddr)
 		sb := td.state.concreteSandbox()
@@ -95,7 +95,7 @@ func TestExecuteBlock(t *testing.T) {
 		txs := block.NewTxs()
 		txs.Append(validTx1)
 		txs.Append(validSubsidyTx)
-		invBlock := block.MakeBlock(1, util.Now(), txs, td.state.lastInfo.BlockHash(),
+		invBlock := block.MakeBlock(1, time.Now(), txs, td.state.lastInfo.BlockHash(),
 			td.state.stateRoot(), td.state.lastInfo.Certificate(),
 			td.state.lastInfo.SortitionSeed(), proposerAddr)
 		sb := td.state.concreteSandbox()
@@ -106,7 +106,7 @@ func TestExecuteBlock(t *testing.T) {
 	t.Run("Has no subsidy", func(t *testing.T) {
 		txs := block.NewTxs()
 		txs.Append(validTx1)
-		invBlock := block.MakeBlock(1, util.Now(), txs, td.state.lastInfo.BlockHash(),
+		invBlock := block.MakeBlock(1, time.Now(), txs, td.state.lastInfo.BlockHash(),
 			td.state.stateRoot(), td.state.lastInfo.Certificate(),
 			td.state.lastInfo.SortitionSeed(), proposerAddr)
 		sb := td.state.concreteSandbox()
@@ -118,7 +118,7 @@ func TestExecuteBlock(t *testing.T) {
 		txs := block.NewTxs()
 		txs.Append(validSubsidyTx)
 		txs.Append(validSubsidyTx)
-		invBlock := block.MakeBlock(1, util.Now(), txs, td.state.lastInfo.BlockHash(),
+		invBlock := block.MakeBlock(1, time.Now(), txs, td.state.lastInfo.BlockHash(),
 			td.state.stateRoot(), td.state.lastInfo.Certificate(),
 			td.state.lastInfo.SortitionSeed(), proposerAddr)
 		sb := td.state.concreteSandbox()
@@ -130,7 +130,7 @@ func TestExecuteBlock(t *testing.T) {
 		txs := block.NewTxs()
 		txs.Append(validSubsidyTx)
 		txs.Append(validTx1)
-		invBlock := block.MakeBlock(1, util.Now(), txs, td.state.lastInfo.BlockHash(),
+		invBlock := block.MakeBlock(1, time.Now(), txs, td.state.lastInfo.BlockHash(),
 			td.state.stateRoot(), td.state.lastInfo.Certificate(),
 			td.state.lastInfo.SortitionSeed(), proposerAddr)
 		sb := td.state.concreteSandbox()

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -15,8 +15,7 @@ func TestProposeBlock(t *testing.T) {
 
 	proposer := td.state.Proposer(0)
 	lockTime := td.state.LastBlockHeight()
-	dupSubsidyTx := tx.NewSubsidyTx(lockTime, proposer.Address(),
-		td.state.params.BlockReward, tx.WithMemo("duplicated subsidy transaction"))
+	dupSubsidyTx := tx.NewSubsidyTx(lockTime, proposer.Address(), td.state.params.BlockReward)
 	invTransferTx := td.GenerateTestTransferTx()
 	invBondTx := td.GenerateTestBondTx()
 	invSortitionTx := td.GenerateTestSortitionTx()

--- a/state/lastinfo/last_info_test.go
+++ b/state/lastinfo/last_info_test.go
@@ -2,6 +2,7 @@ package lastinfo
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/bls"
@@ -11,7 +12,6 @@ import (
 	"github.com/pactus-project/pactus/types/certificate"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/validator"
-	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,7 +75,7 @@ func setup(t *testing.T) *testData {
 	lastHeight := ts.RandHeight()
 	prevCert := ts.GenerateTestBlockCertificate(lastHeight - 1)
 	lastSeed := ts.RandSeed()
-	lastBlock := block.MakeBlock(1, util.Now(), block.Txs{trx},
+	lastBlock := block.MakeBlock(1, time.Now(), block.Txs{trx},
 		prevHash,
 		ts.RandHash(),
 		prevCert, lastSeed, val2.Address())

--- a/state/state.go
+++ b/state/state.go
@@ -588,7 +588,7 @@ func (st *state) CommitteePower() int64 {
 func (st *state) proposeNextBlockTime() time.Time {
 	timestamp := st.lastInfo.BlockTime().Add(st.params.BlockInterval())
 
-	now := util.Now()
+	now := time.Now()
 	if now.After(timestamp.Add(10 * time.Second)) {
 		st.logger.Debug("it looks the last block had delay", "delay", now.Sub(timestamp))
 		timestamp = util.RoundNow(st.params.BlockIntervalInSecond)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -125,7 +125,7 @@ func TestMain(m *testing.M) {
 	params.BondInterval = 8
 	params.CommitteeSize = tCommitteeSize
 	params.TransactionToLiveInterval = 8
-	tGenDoc = genesis.MakeGenesis(util.Now(), accs, vals, params)
+	tGenDoc = genesis.MakeGenesis(time.Now(), accs, vals, params)
 
 	for i := 0; i < tTotalNodes; i++ {
 		tNodes[i], _ = node.NewNode(

--- a/util/testsuite/testsuite.go
+++ b/util/testsuite/testsuite.go
@@ -344,7 +344,7 @@ func (ts *TestSuite) NewBlockMaker() *BlockMaker {
 		Version:  1,
 		Txs:      txs,
 		Proposer: ts.RandValAddress(),
-		Time:     util.Now(),
+		Time:     time.Now(),
 		PrevHash: ts.RandHash(),
 		Seed:     ts.RandSeed(),
 		PrevCert: nil,

--- a/util/time.go
+++ b/util/time.go
@@ -4,12 +4,6 @@ import (
 	"time"
 )
 
-// Now returns the rounded current time in UTC.
-// The rounding behavior is rounding down.
-func Now() time.Time {
-	return RoundNow(1)
-}
-
 // RoundNow returns the result of rounding sec to the current time in UTC.
 // The rounding behavior is rounding down.
 func RoundNow(sec int) time.Time {

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNow(t *testing.T) {
+func TestRoundNow(t *testing.T) {
 	c1 := time.Now()
-	c2 := Now()
+	c2 := RoundNow(1)
 	c3 := RoundNow(5)
 
 	assert.NotEqual(t, c1, c2)


### PR DESCRIPTION
## Description

We use `time.Now` instead of `util.Now` in this PR.