### PR TITLE
refactor(types): using options pattern for memo parameter on new tx functions

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -710,8 +710,8 @@ func TestDuplicateProposal(t *testing.T) {
 	h := uint32(4)
 	r := int16(0)
 	p1 := td.makeProposal(t, h, r)
-	trx := tx.NewTransferTx(h, td.consX.rewardAddr,
-		td.RandAccAddress(), 1000, 1000, "proposal changer")
+	trx := tx.NewTransferTx(h, td.consX.rewardAddr, td.RandAccAddress(), 1000,
+		1000, tx.WithMemo("proposal changer"))
 	td.HelperSignTransaction(td.consX.valKey.PrivateKey(), trx)
 
 	assert.NoError(t, td.txPool.AppendTx(trx))
@@ -913,7 +913,7 @@ func TestByzantine(t *testing.T) {
 	// P votes
 	// Byzantine node create the second proposal and send it to the partitioned node P
 	byzTrx := tx.NewTransferTx(h,
-		td.consB.rewardAddr, td.RandAccAddress(), 1000, 1000, "")
+		td.consB.rewardAddr, td.RandAccAddress(), 1000, 1000)
 	td.HelperSignTransaction(td.consB.valKey.PrivateKey(), byzTrx)
 	assert.NoError(t, td.txPool.AppendTx(byzTrx))
 	p2 := td.makeProposal(t, h, r)

--- a/consensus/precommit_test.go
+++ b/consensus/precommit_test.go
@@ -40,7 +40,7 @@ func TestPrecommitDuplicatedProposal(t *testing.T) {
 
 	p1 := td.makeProposal(t, h, r)
 	trx := tx.NewTransferTx(h, td.consX.rewardAddr,
-		td.RandAccAddress(), 1000, 1000, "invalid proposal")
+		td.RandAccAddress(), 1000, 1000, tx.WithMemo("invalid proposal"))
 	td.HelperSignTransaction(td.consX.valKey.PrivateKey(), trx)
 
 	assert.NoError(t, td.txPool.AppendTx(trx))

--- a/execution/execution_test.go
+++ b/execution/execution_test.go
@@ -63,7 +63,7 @@ func TestTransferLockTime(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			trx := tx.NewTransferTx(tc.lockTime, rndAccAddr, ts.RandAccAddress(), 1000, 1000, "")
+			trx := tx.NewTransferTx(tc.lockTime, rndAccAddr, ts.RandAccAddress(), 1000, 1000)
 			ts.HelperSignTransaction(rndPrvKey, trx)
 
 			strictErr := CheckLockTime(trx, sb, true)
@@ -173,7 +173,7 @@ func TestSubsidyLockTime(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			trx := tx.NewSubsidyTx(tc.lockTime, ts.RandAccAddress(), 1000, "subsidy-test")
+			trx := tx.NewSubsidyTx(tc.lockTime, ts.RandAccAddress(), 1000)
 
 			strictErr := CheckLockTime(trx, sb, true)
 			assert.ErrorIs(t, strictErr, tc.strictErr)
@@ -195,25 +195,25 @@ func TestCheckFee(t *testing.T) {
 		{
 			name: "Subsidy transaction with fee",
 			trx: tx.NewTransferTx(ts.RandHeight(), crypto.TreasuryAddress, ts.RandAccAddress(),
-				ts.RandAmount(), 1, ""),
+				ts.RandAmount(), 1),
 			expectedErr: InvalidFeeError{Fee: 1, Expected: 0},
 		},
 		{
 			name: "Subsidy transaction without fee",
 			trx: tx.NewTransferTx(ts.RandHeight(), crypto.TreasuryAddress, ts.RandAccAddress(),
-				ts.RandAmount(), 0, ""),
+				ts.RandAmount(), 0),
 			expectedErr: nil,
 		},
 		{
 			name: "Transfer transaction with fee",
 			trx: tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), ts.RandAccAddress(),
-				ts.RandAmount(), 0, ""),
+				ts.RandAmount(), 0),
 			expectedErr: nil,
 		},
 		{
 			name: "Transfer transaction without fee",
 			trx: tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), ts.RandAccAddress(),
-				ts.RandAmount(), 0, ""),
+				ts.RandAmount(), 0),
 			expectedErr: nil,
 		},
 	}
@@ -236,14 +236,14 @@ func TestExecute(t *testing.T) {
 	t.Run("Invalid transaction, Should return error", func(t *testing.T) {
 		randAddr := ts.RandAccAddress()
 		trx := tx.NewTransferTx(lockTime, randAddr, ts.RandAccAddress(),
-			ts.RandAmount(), ts.RandFee(), "invalid-tx")
+			ts.RandAmount(), ts.RandFee())
 
 		err := Execute(trx, sb)
 		assert.ErrorIs(t, err, executor.AccountNotFoundError{Address: randAddr})
 	})
 
 	t.Run("Ok", func(t *testing.T) {
-		trx := tx.NewSubsidyTx(lockTime, ts.RandAccAddress(), 1000, "valid-tx")
+		trx := tx.NewSubsidyTx(lockTime, ts.RandAccAddress(), 1000)
 		err := Execute(trx, sb)
 		assert.NoError(t, err)
 
@@ -260,8 +260,7 @@ func TestCheck(t *testing.T) {
 
 	t.Run("Invalid lock-time, Should return error", func(t *testing.T) {
 		invalidLocoTme := lockTime + 1
-		trx := tx.NewTransferTx(invalidLocoTme, crypto.TreasuryAddress,
-			ts.RandAccAddress(), ts.RandAmount(), 0, "invalid lock-time")
+		trx := tx.NewTransferTx(invalidLocoTme, crypto.TreasuryAddress, ts.RandAccAddress(), ts.RandAmount(), 0)
 
 		err := CheckAndExecute(trx, sb, true)
 		assert.ErrorIs(t, err, LockTimeInFutureError{LockTime: invalidLocoTme})
@@ -269,8 +268,7 @@ func TestCheck(t *testing.T) {
 
 	t.Run("Invalid fee, Should return error", func(t *testing.T) {
 		invalidFee := amount.Amount(1)
-		trx := tx.NewTransferTx(lockTime, crypto.TreasuryAddress,
-			ts.RandAccAddress(), ts.RandAmount(), invalidFee, "invalid fee")
+		trx := tx.NewTransferTx(lockTime, crypto.TreasuryAddress, ts.RandAccAddress(), ts.RandAmount(), invalidFee)
 
 		err := CheckAndExecute(trx, sb, true)
 		assert.ErrorIs(t, err, InvalidFeeError{Fee: invalidFee, Expected: 0})
@@ -278,8 +276,7 @@ func TestCheck(t *testing.T) {
 
 	t.Run("Invalid transaction, Should return error", func(t *testing.T) {
 		randAddr := ts.RandAccAddress()
-		trx := tx.NewTransferTx(lockTime, randAddr, ts.RandAccAddress(),
-			ts.RandAmount(), ts.RandFee(), "invalid-tx")
+		trx := tx.NewTransferTx(lockTime, randAddr, ts.RandAccAddress(), ts.RandAmount(), ts.RandFee())
 
 		err := CheckAndExecute(trx, sb, true)
 		assert.ErrorIs(t, err, executor.AccountNotFoundError{Address: randAddr})
@@ -295,7 +292,7 @@ func TestCheck(t *testing.T) {
 	})
 
 	t.Run("Ok", func(t *testing.T) {
-		trx := tx.NewSubsidyTx(lockTime, ts.RandAccAddress(), 1000, "valid-tx")
+		trx := tx.NewSubsidyTx(lockTime, ts.RandAccAddress(), 1000)
 		err := CheckAndExecute(trx, sb, true)
 		assert.NoError(t, err)
 
@@ -315,7 +312,7 @@ func TestReplay(t *testing.T) {
 	lockTime := sb.CurrentHeight()
 
 	trx := tx.NewTransferTx(lockTime,
-		rndAccAddr, ts.RandAccAddress(), 10000, 1000, "")
+		rndAccAddr, ts.RandAccAddress(), 10000, 1000)
 	ts.HelperSignTransaction(rndPrvKey, trx)
 
 	err := Execute(trx, sb)

--- a/execution/executor/bond_test.go
+++ b/execution/executor/bond_test.go
@@ -23,16 +23,14 @@ func TestExecuteBondTx(t *testing.T) {
 
 	t.Run("Should fail, unknown address", func(t *testing.T) {
 		randomAddr := td.RandAccAddress()
-		trx := tx.NewBondTx(lockTime, randomAddr,
-			receiverAddr, valPub, amt, fee, "unknown address")
+		trx := tx.NewBondTx(lockTime, randomAddr, receiverAddr, valPub, amt, fee)
 
 		td.check(t, trx, true, AccountNotFoundError{Address: randomAddr})
 		td.check(t, trx, false, AccountNotFoundError{Address: randomAddr})
 	})
 
 	t.Run("Should fail, public key is not set", func(t *testing.T) {
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			receiverAddr, nil, amt, fee, "no public key")
+		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, nil, amt, fee)
 
 		td.check(t, trx, true, ErrPublicKeyNotSet)
 		td.check(t, trx, false, ErrPublicKeyNotSet)
@@ -43,16 +41,14 @@ func TestExecuteBondTx(t *testing.T) {
 		val := td.sandbox.MakeNewValidator(randPub)
 		td.sandbox.UpdateValidator(val)
 
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			randPub.ValidatorAddress(), randPub, amt, fee, "with public key")
+		trx := tx.NewBondTx(lockTime, senderAddr, randPub.ValidatorAddress(), randPub, amt, fee)
 
 		td.check(t, trx, true, ErrPublicKeyAlreadySet)
 		td.check(t, trx, false, ErrPublicKeyAlreadySet)
 	})
 
 	t.Run("Should fail, insufficient balance", func(t *testing.T) {
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			receiverAddr, valPub, senderBalance+1, 0, "insufficient balance")
+		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, valPub, senderBalance+1, 0)
 
 		td.check(t, trx, true, ErrInsufficientFunds)
 		td.check(t, trx, false, ErrInsufficientFunds)
@@ -63,24 +59,21 @@ func TestExecuteBondTx(t *testing.T) {
 		val := td.sandbox.MakeNewValidator(randPub)
 		val.UpdateUnbondingHeight(td.RandHeight())
 		td.sandbox.UpdateValidator(val)
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			randPub.ValidatorAddress(), nil, amt, fee, "unbonded before")
+		trx := tx.NewBondTx(lockTime, senderAddr, randPub.ValidatorAddress(), nil, amt, fee)
 
 		td.check(t, trx, true, ErrValidatorUnbonded)
 		td.check(t, trx, false, ErrValidatorUnbonded)
 	})
 
 	t.Run("Should fail, amount less than MinimumStake", func(t *testing.T) {
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			receiverAddr, valPub, td.sandbox.TestParams.MinimumStake-1, fee, "less than MinimumStake")
+		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, valPub, td.sandbox.TestParams.MinimumStake-1, fee)
 
 		td.check(t, trx, true, SmallStakeError{td.sandbox.TestParams.MinimumStake})
 		td.check(t, trx, false, SmallStakeError{td.sandbox.TestParams.MinimumStake})
 	})
 
 	t.Run("Should fail, validator's stake exceeds the MaximumStake", func(t *testing.T) {
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			receiverAddr, valPub, td.sandbox.TestParams.MaximumStake+1, fee, "more than MaximumStake")
+		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, valPub, td.sandbox.TestParams.MaximumStake+1, fee)
 
 		td.check(t, trx, true, MaximumStakeError{td.sandbox.TestParams.MaximumStake})
 		td.check(t, trx, false, MaximumStakeError{td.sandbox.TestParams.MaximumStake})
@@ -88,8 +81,7 @@ func TestExecuteBondTx(t *testing.T) {
 
 	t.Run("Should fail, inside committee", func(t *testing.T) {
 		pub0 := td.sandbox.Committee().Proposer(0).PublicKey()
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			pub0.ValidatorAddress(), nil, amt, fee, "inside committee")
+		trx := tx.NewBondTx(lockTime, senderAddr, pub0.ValidatorAddress(), nil, amt, fee)
 
 		td.check(t, trx, true, ErrValidatorInCommittee)
 		td.check(t, trx, false, nil)
@@ -100,15 +92,14 @@ func TestExecuteBondTx(t *testing.T) {
 		val := td.sandbox.MakeNewValidator(randPub)
 		td.sandbox.UpdateValidator(val)
 		td.sandbox.JoinedToCommittee(val.Address())
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			randPub.ValidatorAddress(), nil, amt, fee, "inside committee")
+		trx := tx.NewBondTx(lockTime, senderAddr, randPub.ValidatorAddress(), nil, amt, fee)
 
 		td.check(t, trx, true, ErrValidatorInCommittee)
 		td.check(t, trx, false, nil)
 	})
 
 	t.Run("Ok", func(t *testing.T) {
-		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, valPub, amt, fee, "ok")
+		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, valPub, amt, fee)
 
 		td.check(t, trx, true, nil)
 		td.check(t, trx, false, nil)
@@ -135,7 +126,7 @@ func TestPowerDeltaBond(t *testing.T) {
 		td.sandbox.TestParams.MaximumStake)
 	fee := td.RandFee()
 	lockTime := td.sandbox.CurrentHeight()
-	trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, pub, amt, fee, "ok")
+	trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, pub, amt, fee)
 
 	td.execute(t, trx)
 
@@ -158,24 +149,21 @@ func TestSmallBond(t *testing.T) {
 	fee := td.RandFee()
 
 	t.Run("Rejects bond transaction with zero amount", func(t *testing.T) {
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			receiverAddr, nil, 0, fee, "attacking validator")
+		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, nil, 0, fee)
 
 		td.check(t, trx, true, SmallStakeError{td.sandbox.TestParams.MinimumStake})
 		td.check(t, trx, false, SmallStakeError{td.sandbox.TestParams.MinimumStake})
 	})
 
 	t.Run("Rejects bond transaction below full validator stake", func(t *testing.T) {
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			receiverAddr, nil, 1, fee, "attacking validator")
+		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, nil, 1, fee)
 
 		td.check(t, trx, true, SmallStakeError{td.sandbox.TestParams.MinimumStake})
 		td.check(t, trx, false, SmallStakeError{td.sandbox.TestParams.MinimumStake})
 	})
 
 	t.Run("Accepts bond transaction reaching full validator stake", func(t *testing.T) {
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			receiverAddr, nil, 2, fee, "fulfilling validator stake")
+		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, nil, 2, fee)
 
 		td.check(t, trx, true, nil)
 		td.check(t, trx, false, nil)
@@ -183,8 +171,7 @@ func TestSmallBond(t *testing.T) {
 	})
 
 	t.Run("Rejects bond transaction with zero amount on full validator", func(t *testing.T) {
-		trx := tx.NewBondTx(lockTime, senderAddr,
-			receiverAddr, nil, 0, fee, "attacking validator")
+		trx := tx.NewBondTx(lockTime, senderAddr, receiverAddr, nil, 0, fee)
 
 		td.check(t, trx, true, SmallStakeError{td.sandbox.TestParams.MinimumStake})
 		td.check(t, trx, false, SmallStakeError{td.sandbox.TestParams.MinimumStake})

--- a/execution/executor/transfer_test.go
+++ b/execution/executor/transfer_test.go
@@ -20,24 +20,21 @@ func TestExecuteTransferTx(t *testing.T) {
 
 	t.Run("Should fail, unknown address", func(t *testing.T) {
 		randomAddr := td.RandAccAddress()
-		trx := tx.NewTransferTx(lockTime, randomAddr,
-			receiverAddr, amt, fee, "unknown address")
+		trx := tx.NewTransferTx(lockTime, randomAddr, receiverAddr, amt, fee)
 
 		td.check(t, trx, true, AccountNotFoundError{Address: randomAddr})
 		td.check(t, trx, false, AccountNotFoundError{Address: randomAddr})
 	})
 
 	t.Run("Should fail, insufficient balance", func(t *testing.T) {
-		trx := tx.NewTransferTx(lockTime, senderAddr,
-			receiverAddr, senderBalance+1, 0, "insufficient balance")
+		trx := tx.NewTransferTx(lockTime, senderAddr, receiverAddr, senderBalance+1, 0)
 
 		td.check(t, trx, true, ErrInsufficientFunds)
 		td.check(t, trx, false, ErrInsufficientFunds)
 	})
 
 	t.Run("Ok", func(t *testing.T) {
-		trx := tx.NewTransferTx(lockTime, senderAddr,
-			receiverAddr, amt, fee, "ok")
+		trx := tx.NewTransferTx(lockTime, senderAddr, receiverAddr, amt, fee)
 
 		td.check(t, trx, true, nil)
 		td.check(t, trx, false, nil)
@@ -61,7 +58,7 @@ func TestTransferToSelf(t *testing.T) {
 	fee := td.RandFee()
 	lockTime := td.sandbox.CurrentHeight()
 
-	trx := tx.NewTransferTx(lockTime, senderAddr, senderAddr, amt, fee, "ok")
+	trx := tx.NewTransferTx(lockTime, senderAddr, senderAddr, amt, fee)
 	td.check(t, trx, true, nil)
 	td.check(t, trx, false, nil)
 	td.execute(t, trx)

--- a/execution/executor/unbond_test.go
+++ b/execution/executor/unbond_test.go
@@ -27,7 +27,7 @@ func TestExecuteUnbondTx(t *testing.T) {
 
 	t.Run("Should fail, unknown address", func(t *testing.T) {
 		randomAddr := td.RandValAddress()
-		trx := tx.NewUnbondTx(lockTime, randomAddr, "unknown address")
+		trx := tx.NewUnbondTx(lockTime, randomAddr)
 
 		td.check(t, trx, true, ValidatorNotFoundError{Address: randomAddr})
 		td.check(t, trx, false, ValidatorNotFoundError{Address: randomAddr})
@@ -35,7 +35,7 @@ func TestExecuteUnbondTx(t *testing.T) {
 
 	t.Run("Should fail, inside committee", func(t *testing.T) {
 		val0 := td.sandbox.Committee().Proposer(0)
-		trx := tx.NewUnbondTx(lockTime, val0.Address(), "inside committee")
+		trx := tx.NewUnbondTx(lockTime, val0.Address())
 
 		td.check(t, trx, true, ErrValidatorInCommittee)
 		td.check(t, trx, false, nil)
@@ -46,14 +46,14 @@ func TestExecuteUnbondTx(t *testing.T) {
 		randVal := td.sandbox.MakeNewValidator(randPub)
 		td.sandbox.UpdateValidator(randVal)
 		td.sandbox.JoinedToCommittee(randVal.Address())
-		trx := tx.NewUnbondTx(lockTime, randPub.ValidatorAddress(), "joining committee")
+		trx := tx.NewUnbondTx(lockTime, randPub.ValidatorAddress())
 
 		td.check(t, trx, true, ErrValidatorInCommittee)
 		td.check(t, trx, false, nil)
 	})
 
 	t.Run("Ok", func(t *testing.T) {
-		trx := tx.NewUnbondTx(lockTime, valAddr, "Ok")
+		trx := tx.NewUnbondTx(lockTime, valAddr)
 
 		td.check(t, trx, true, nil)
 		td.check(t, trx, false, nil)
@@ -61,7 +61,7 @@ func TestExecuteUnbondTx(t *testing.T) {
 	})
 
 	t.Run("Should fail, Cannot unbond if already unbonded", func(t *testing.T) {
-		trx := tx.NewUnbondTx(lockTime, valAddr, "Ok")
+		trx := tx.NewUnbondTx(lockTime, valAddr)
 
 		td.check(t, trx, true, ErrValidatorUnbonded)
 		td.check(t, trx, false, ErrValidatorUnbonded)
@@ -87,7 +87,7 @@ func TestPowerDeltaUnbond(t *testing.T) {
 	val.AddToStake(amt)
 	td.sandbox.UpdateValidator(val)
 	lockTime := td.sandbox.CurrentHeight()
-	trx := tx.NewUnbondTx(lockTime, valAddr, "Ok")
+	trx := tx.NewUnbondTx(lockTime, valAddr)
 
 	td.execute(t, trx)
 

--- a/execution/executor/withdraw_test.go
+++ b/execution/executor/withdraw_test.go
@@ -32,16 +32,14 @@ func TestExecuteWithdrawTx(t *testing.T) {
 
 	t.Run("Should fail, unknown address", func(t *testing.T) {
 		randomAddr := td.RandValAddress()
-		trx := tx.NewWithdrawTx(lockTime, randomAddr, receiverAddr,
-			amt, fee, "unknown address")
+		trx := tx.NewWithdrawTx(lockTime, randomAddr, receiverAddr, amt, fee)
 
 		td.check(t, trx, true, ValidatorNotFoundError{Address: randomAddr})
 		td.check(t, trx, false, ValidatorNotFoundError{Address: randomAddr})
 	})
 
 	t.Run("Should fail, hasn't unbonded yet", func(t *testing.T) {
-		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr,
-			amt, fee, "need to unbond first")
+		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr, amt, fee)
 
 		td.check(t, trx, true, ErrValidatorBonded)
 		td.check(t, trx, false, ErrValidatorBonded)
@@ -51,16 +49,14 @@ func TestExecuteWithdrawTx(t *testing.T) {
 	td.sandbox.UpdateValidator(val)
 
 	t.Run("Should fail, insufficient balance", func(t *testing.T) {
-		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr,
-			totalStake, 1, "insufficient balance")
+		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr, totalStake, 1)
 
 		td.check(t, trx, true, ErrInsufficientFunds)
 		td.check(t, trx, false, ErrInsufficientFunds)
 	})
 
 	t.Run("Should fail, hasn't passed unbonding period", func(t *testing.T) {
-		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr,
-			amt, fee, "unbonding period")
+		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr, amt, fee)
 
 		td.check(t, trx, true, ErrUnbondingPeriod)
 		td.check(t, trx, false, ErrUnbondingPeriod)
@@ -70,8 +66,7 @@ func TestExecuteWithdrawTx(t *testing.T) {
 	td.sandbox.TestStore.AddTestBlock(curHeight + 1)
 
 	t.Run("Should pass, Everything is Ok!", func(t *testing.T) {
-		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr,
-			amt, fee, "should be able to withdraw the stake")
+		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr, amt, fee)
 
 		td.check(t, trx, true, nil)
 		td.check(t, trx, false, nil)

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -16,18 +16,18 @@ func TestProposeBlock(t *testing.T) {
 	proposer := td.state.Proposer(0)
 	lockTime := td.state.LastBlockHeight()
 	dupSubsidyTx := tx.NewSubsidyTx(lockTime, proposer.Address(),
-		td.state.params.BlockReward, "duplicated subsidy transaction")
+		td.state.params.BlockReward, tx.WithMemo("duplicated subsidy transaction"))
 	invTransferTx := td.GenerateTestTransferTx()
 	invBondTx := td.GenerateTestBondTx()
 	invSortitionTx := td.GenerateTestSortitionTx()
 
 	pub, _ := td.RandBLSKeyPair()
 	validTrx1 := tx.NewTransferTx(lockTime, td.genAccKey.PublicKeyNative().AccountAddress(),
-		td.RandAccAddress(), 1, 1000, "")
+		td.RandAccAddress(), 1, 1000)
 	td.HelperSignTransaction(td.genAccKey, validTrx1)
 
 	validTrx2 := tx.NewBondTx(lockTime, td.genAccKey.PublicKeyNative().AccountAddress(),
-		pub.ValidatorAddress(), pub, 1000000000, 100000, "")
+		pub.ValidatorAddress(), pub, 1000000000, 100000)
 	td.HelperSignTransaction(td.genAccKey, validTrx2)
 
 	assert.NoError(t, td.state.AddPendingTx(invTransferTx))
@@ -60,7 +60,7 @@ func TestExecuteBlock(t *testing.T) {
 	invTransferTx := td.GenerateTestTransferTx()
 
 	validTx1 := tx.NewTransferTx(1, td.genAccKey.PublicKeyNative().AccountAddress(),
-		td.RandAccAddress(), 1, 1000, "")
+		td.RandAccAddress(), 1, 1000)
 	td.HelperSignTransaction(td.genAccKey, validTx1)
 
 	assert.NoError(t, td.state.AddPendingTx(invTransferTx))

--- a/state/state.go
+++ b/state/state.go
@@ -309,7 +309,7 @@ func (st *state) UpdateLastCertificate(v *vote.Vote) error {
 
 func (st *state) createSubsidyTx(rewardAddr crypto.Address, fee amount.Amount) *tx.Tx {
 	lockTime := st.lastInfo.BlockHeight() + 1
-	transaction := tx.NewSubsidyTx(lockTime, rewardAddr, st.params.BlockReward+fee, "")
+	transaction := tx.NewSubsidyTx(lockTime, rewardAddr, st.params.BlockReward+fee)
 
 	return transaction
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -393,7 +393,7 @@ func TestSortition(t *testing.T) {
 	assert.Equal(t, int64(4), td.state.CommitteePower())
 
 	trx := tx.NewBondTx(1, td.genAccKey.PublicKeyNative().AccountAddress(),
-		secValKey.Address(), secValKey.PublicKey(), 1000000000, 100000, "")
+		secValKey.Address(), secValKey.PublicKey(), 1000000000, 100000)
 	td.HelperSignTransaction(td.genAccKey, trx)
 	assert.NoError(t, td.state.AddPendingTx(trx))
 
@@ -526,7 +526,7 @@ func TestLoadState(t *testing.T) {
 	pub, _ := td.RandBLSKeyPair()
 	lockTime := td.state.LastBlockHeight()
 	bondTrx := tx.NewBondTx(lockTime, td.genAccKey.PublicKeyNative().AccountAddress(),
-		pub.ValidatorAddress(), pub, 1000000000, 100000, "")
+		pub.ValidatorAddress(), pub, 1000000000, 100000)
 	td.HelperSignTransaction(td.genAccKey, bondTrx)
 
 	assert.NoError(t, td.state.AddPendingTx(bondTrx))
@@ -591,7 +591,7 @@ func TestCheckMaximumTransactionPerBlock(t *testing.T) {
 	for i := 0; i < maxTransactionsPerBlock+2; i++ {
 		amt := td.RandAmount()
 		fee := td.state.CalculateFee(amt, payload.TypeTransfer)
-		trx := tx.NewTransferTx(lockTime, senderAddr, td.RandAccAddress(), amt, fee, "")
+		trx := tx.NewTransferTx(lockTime, senderAddr, td.RandAccAddress(), amt, fee)
 		err := td.state.AddPendingTx(trx)
 		assert.NoError(t, err)
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -169,9 +169,9 @@ func TestStrippedPublicKey(t *testing.T) {
 	lastHeight := lastCert.Height()
 	randPubKey, _ := td.RandBLSKeyPair()
 
-	trx0 := tx.NewTransferTx(lastHeight, knownPubKey.AccountAddress(), td.RandAccAddress(), 1, 1, "")
-	trx1 := tx.NewTransferTx(lastHeight, randPubKey.AccountAddress(), td.RandAccAddress(), 1, 1, "")
-	trx2 := tx.NewTransferTx(lastHeight, randPubKey.AccountAddress(), td.RandAccAddress(), 1, 1, "")
+	trx0 := tx.NewTransferTx(lastHeight, knownPubKey.AccountAddress(), td.RandAccAddress(), 1, 1)
+	trx1 := tx.NewTransferTx(lastHeight, randPubKey.AccountAddress(), td.RandAccAddress(), 1, 1)
+	trx2 := tx.NewTransferTx(lastHeight, randPubKey.AccountAddress(), td.RandAccAddress(), 1, 1)
 
 	trx0.StripPublicKey()
 	trx1.SetPublicKey(randPubKey)

--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -30,7 +30,7 @@ func broadcastSendTransaction(t *testing.T, sender *bls.ValidatorKey, receiver c
 	t.Helper()
 
 	lockTime := lastHeight() + 1
-	trx := tx.NewTransferTx(lockTime, sender.PublicKey().AccountAddress(), receiver, amt, fee, "")
+	trx := tx.NewTransferTx(lockTime, sender.PublicKey().AccountAddress(), receiver, amt, fee)
 	sig := sender.Sign(trx.SignBytes())
 
 	trx.SetPublicKey(sender.PublicKey())
@@ -47,7 +47,7 @@ func broadcastBondTransaction(t *testing.T, sender *bls.ValidatorKey, pub *bls.P
 	t.Helper()
 
 	lockTime := lastHeight() + 1
-	trx := tx.NewBondTx(lockTime, sender.PublicKey().AccountAddress(), pub.ValidatorAddress(), pub, stake, fee, "")
+	trx := tx.NewBondTx(lockTime, sender.PublicKey().AccountAddress(), pub.ValidatorAddress(), pub, stake, fee)
 	sig := sender.Sign(trx.SignBytes())
 
 	trx.SetPublicKey(sender.PublicKey())

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -83,7 +83,7 @@ func TestAppendAndRemove(t *testing.T) {
 
 	height := td.RandHeight()
 	td.sandbox.TestStore.AddTestBlock(height)
-	testTrx := tx.NewSubsidyTx(height+1, td.RandAccAddress(), 1e9, "subsidy-tx")
+	testTrx := tx.NewSubsidyTx(height+1, td.RandAccAddress(), 1e9)
 
 	assert.NoError(t, td.pool.AppendTx(testTrx))
 	assert.True(t, td.pool.HasTx(testTrx.ID()))
@@ -121,8 +121,7 @@ func TestFullPool(t *testing.T) {
 	assert.Equal(t, 0, td.pool.Size())
 
 	for i := 0; i < len(trxs); i++ {
-		trx := tx.NewTransferTx(randHeight+1, senderAddr,
-			td.RandAccAddress(), 1e9, 1000_000_000, "ok")
+		trx := tx.NewTransferTx(randHeight+1, senderAddr, td.RandAccAddress(), 1e9, 1000_000_000)
 
 		assert.NoError(t, td.pool.AppendTx(trx))
 		trxs[i] = trx
@@ -166,17 +165,14 @@ func TestPrepareBlockTransactions(t *testing.T) {
 	val3.AddToStake(1000e9)
 	td.sandbox.UpdateValidator(val3)
 
-	transferTx := tx.NewTransferTx(randHeight+1, acc1Addr,
-		td.RandAccAddress(), 1e9, 100_000_000, "transfer-tx")
+	transferTx := tx.NewTransferTx(randHeight+1, acc1Addr, td.RandAccAddress(), 1e9, 100_000_000)
 
 	pub, _ := td.RandBLSKeyPair()
-	bondTx := tx.NewBondTx(randHeight+2, acc1Addr,
-		pub.ValidatorAddress(), pub, 1e9, 100_000_000, "bond-tx")
+	bondTx := tx.NewBondTx(randHeight+2, acc1Addr, pub.ValidatorAddress(), pub, 1e9, 100_000_000)
 
-	unbondTx := tx.NewUnbondTx(randHeight+3, val1.Address(), "unbond-tx")
+	unbondTx := tx.NewUnbondTx(randHeight+3, val1.Address())
 
-	withdrawTx := tx.NewWithdrawTx(randHeight+4, val2.Address(),
-		td.RandAccAddress(), 1e9, 100_000_000, "withdraw-tx")
+	withdrawTx := tx.NewWithdrawTx(randHeight+4, val2.Address(), td.RandAccAddress(), 1e9, 100_000_000)
 
 	td.sandbox.TestAcceptSortition = true
 	sortitionTx := tx.NewSortitionTx(randHeight, val3.Address(),
@@ -202,7 +198,7 @@ func TestAppendAndBroadcast(t *testing.T) {
 
 	height := td.RandHeight()
 	td.sandbox.TestStore.AddTestBlock(height)
-	testTrx := tx.NewSubsidyTx(height+1, td.RandAccAddress(), 1e9, "subsidy-tx")
+	testTrx := tx.NewSubsidyTx(height+1, td.RandAccAddress(), 1e9)
 
 	assert.NoError(t, td.pool.AppendTxAndBroadcast(testTrx))
 	td.shouldPublishTransaction(t, testTrx.ID())
@@ -218,9 +214,9 @@ func TestAddSubsidyTransactions(t *testing.T) {
 	td.sandbox.TestStore.AddTestBlock(randHeight)
 	proposer1 := td.RandAccAddress()
 	proposer2 := td.RandAccAddress()
-	trx1 := tx.NewSubsidyTx(randHeight, proposer1, 1e9, "subsidy-tx-1")
-	trx2 := tx.NewSubsidyTx(randHeight+1, proposer1, 1e9, "subsidy-tx-1")
-	trx3 := tx.NewSubsidyTx(randHeight+1, proposer2, 1e9, "subsidy-tx-2")
+	trx1 := tx.NewSubsidyTx(randHeight, proposer1, 1e9, tx.WithMemo("subsidy-tx-1"))
+	trx2 := tx.NewSubsidyTx(randHeight+1, proposer1, 1e9, tx.WithMemo("subsidy-tx-1"))
+	trx3 := tx.NewSubsidyTx(randHeight+1, proposer2, 1e9, tx.WithMemo("subsidy-tx-2"))
 
 	err := td.pool.AppendTx(trx1)
 	assert.ErrorIs(t, err, AppendError{

--- a/types/tx/factory.go
+++ b/types/tx/factory.go
@@ -9,7 +9,7 @@ import (
 )
 
 func NewSubsidyTx(lockTime uint32,
-	receiver crypto.Address, amt amount.Amount, memo string,
+	receiver crypto.Address, amt amount.Amount, opts ...TxOption,
 ) *Tx {
 	return NewTransferTx(
 		lockTime,
@@ -17,12 +17,12 @@ func NewSubsidyTx(lockTime uint32,
 		receiver,
 		amt,
 		0,
-		memo)
+		opts...)
 }
 
 func NewTransferTx(lockTime uint32,
 	sender, receiver crypto.Address,
-	amt, fee amount.Amount, memo string,
+	amt, fee amount.Amount, opts ...TxOption,
 ) *Tx {
 	pld := &payload.TransferPayload{
 		From:   sender,
@@ -30,13 +30,13 @@ func NewTransferTx(lockTime uint32,
 		Amount: amt,
 	}
 
-	return newTx(lockTime, pld, fee, memo)
+	return newTx(lockTime, pld, fee, opts...)
 }
 
 func NewBondTx(lockTime uint32,
 	sender, receiver crypto.Address,
 	pubKey *bls.PublicKey,
-	stake, fee amount.Amount, memo string,
+	stake, fee amount.Amount, opts ...TxOption,
 ) *Tx {
 	pld := &payload.BondPayload{
 		From:      sender,
@@ -45,24 +45,24 @@ func NewBondTx(lockTime uint32,
 		Stake:     stake,
 	}
 
-	return newTx(lockTime, pld, fee, memo)
+	return newTx(lockTime, pld, fee, opts...)
 }
 
 func NewUnbondTx(lockTime uint32,
 	val crypto.Address,
-	memo string,
+	opts ...TxOption,
 ) *Tx {
 	pld := &payload.UnbondPayload{
 		Validator: val,
 	}
 
-	return newTx(lockTime, pld, 0, memo)
+	return newTx(lockTime, pld, 0, opts...)
 }
 
 func NewWithdrawTx(lockTime uint32,
 	val, acc crypto.Address,
 	amt, fee amount.Amount,
-	memo string,
+	opts ...TxOption,
 ) *Tx {
 	pld := &payload.WithdrawPayload{
 		From:   val,
@@ -70,7 +70,7 @@ func NewWithdrawTx(lockTime uint32,
 		Amount: amt,
 	}
 
-	return newTx(lockTime, pld, fee, memo)
+	return newTx(lockTime, pld, fee, opts...)
 }
 
 func NewSortitionTx(lockTime uint32,
@@ -82,5 +82,5 @@ func NewSortitionTx(lockTime uint32,
 		Proof:     proof,
 	}
 
-	return newTx(lockTime, pld, 0, "")
+	return newTx(lockTime, pld, 0)
 }

--- a/types/tx/tx.go
+++ b/types/tx/tx.go
@@ -42,21 +42,28 @@ type txData struct {
 	PublicKey crypto.PublicKey
 }
 
-func newTx(lockTime uint32, pld payload.Payload, fee amount.Amount,
-	memo string,
-) *Tx {
-	trx := &Tx{
-		data: txData{
-			Flags:    flagNotSigned,
-			LockTime: lockTime,
-			Version:  versionLatest,
-			Payload:  pld,
-			Fee:      fee,
-			Memo:     memo,
-		},
+type TxOption func(*txData)
+
+func WithMemo(memo string) TxOption {
+	return func(td *txData) {
+		td.Memo = memo
+	}
+}
+
+func newTx(lockTime uint32, pld payload.Payload, fee amount.Amount, opts ...TxOption) *Tx {
+	data := txData{
+		Flags:    flagNotSigned,
+		LockTime: lockTime,
+		Version:  versionLatest,
+		Payload:  pld,
+		Fee:      fee,
 	}
 
-	return trx
+	for _, opt := range opts {
+		opt(&data)
+	}
+
+	return &Tx{data: data}
 }
 
 // FromBytes constructs a new transaction from byte array.

--- a/types/tx/tx_test.go
+++ b/types/tx/tx_test.go
@@ -91,7 +91,7 @@ func TestBasicCheck(t *testing.T) {
 
 	t.Run("LockTime is not defined", func(t *testing.T) {
 		trx := tx.NewTransferTx(0,
-			ts.RandAccAddress(), ts.RandAccAddress(), ts.RandAmount(), ts.RandAmount(), "")
+			ts.RandAccAddress(), ts.RandAccAddress(), ts.RandAmount(), ts.RandAmount())
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -103,7 +103,7 @@ func TestBasicCheck(t *testing.T) {
 		bigMemo := strings.Repeat("a", 65)
 
 		trx := tx.NewTransferTx(ts.RandHeight(),
-			ts.RandAccAddress(), ts.RandAccAddress(), ts.RandAmount(), ts.RandAmount(), bigMemo)
+			ts.RandAccAddress(), ts.RandAccAddress(), ts.RandAmount(), ts.RandAmount(), tx.WithMemo(bigMemo))
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -114,8 +114,7 @@ func TestBasicCheck(t *testing.T) {
 	t.Run("Invalid payload, Should returns error", func(t *testing.T) {
 		invAddr := ts.RandAccAddress()
 		invAddr[0] = 3
-		trx := tx.NewTransferTx(ts.RandHeight(),
-			ts.RandAccAddress(), invAddr, 1e9, ts.RandAmount(), "invalid address")
+		trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), invAddr, 1e9, ts.RandAmount())
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -124,8 +123,7 @@ func TestBasicCheck(t *testing.T) {
 	})
 
 	t.Run("Invalid amount", func(t *testing.T) {
-		trx := tx.NewTransferTx(ts.RandHeight(),
-			ts.RandAccAddress(), ts.RandAccAddress(), -1, 1, "invalid amount")
+		trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), ts.RandAccAddress(), -1, 1)
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -134,8 +132,7 @@ func TestBasicCheck(t *testing.T) {
 	})
 
 	t.Run("Invalid amount", func(t *testing.T) {
-		trx := tx.NewTransferTx(ts.RandHeight(),
-			ts.RandAccAddress(), ts.RandAccAddress(), (42e15)+1, 1, "invalid amount")
+		trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), ts.RandAccAddress(), (42e15)+1, 1)
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -144,8 +141,7 @@ func TestBasicCheck(t *testing.T) {
 	})
 
 	t.Run("Invalid fee", func(t *testing.T) {
-		trx := tx.NewTransferTx(ts.RandHeight(),
-			ts.RandAccAddress(), ts.RandAccAddress(), 1, -1, "invalid fee")
+		trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), ts.RandAccAddress(), 1, -1)
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -154,8 +150,7 @@ func TestBasicCheck(t *testing.T) {
 	})
 
 	t.Run("Invalid fee", func(t *testing.T) {
-		trx := tx.NewTransferTx(ts.RandHeight(),
-			ts.RandAccAddress(), ts.RandAccAddress(), 1, (42e15)+1, "invalid fee")
+		trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), ts.RandAccAddress(), 1, (42e15)+1)
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -165,8 +160,7 @@ func TestBasicCheck(t *testing.T) {
 
 	t.Run("Invalid signer address", func(t *testing.T) {
 		valKey := ts.RandValKey()
-		trx := tx.NewTransferTx(ts.RandHeight(),
-			ts.RandAccAddress(), ts.RandAccAddress(), 1, 1, "invalid valKey")
+		trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), ts.RandAccAddress(), 1, 1)
 		sig := valKey.PrivateKey().Sign(trx.SignBytes())
 		trx.SetSignature(sig)
 		trx.SetPublicKey(valKey.PublicKey())
@@ -226,7 +220,7 @@ func TestSubsidyTx(t *testing.T) {
 	pub, prv := ts.RandBLSKeyPair()
 
 	t.Run("Has signature", func(t *testing.T) {
-		trx := tx.NewSubsidyTx(ts.RandHeight(), pub.AccountAddress(), 2500, "subsidy")
+		trx := tx.NewSubsidyTx(ts.RandHeight(), pub.AccountAddress(), 2500)
 		sig := prv.Sign(trx.SignBytes())
 		trx.SetSignature(sig)
 
@@ -237,7 +231,7 @@ func TestSubsidyTx(t *testing.T) {
 	})
 
 	t.Run("Has public key", func(t *testing.T) {
-		trx := tx.NewSubsidyTx(ts.RandHeight(), pub.AccountAddress(), 2500, "subsidy")
+		trx := tx.NewSubsidyTx(ts.RandHeight(), pub.AccountAddress(), 2500)
 		trx.SetPublicKey(pub)
 
 		err := trx.BasicCheck()
@@ -247,7 +241,7 @@ func TestSubsidyTx(t *testing.T) {
 	})
 
 	t.Run("Strip public key", func(t *testing.T) {
-		trx := tx.NewSubsidyTx(ts.RandHeight(), pub.AccountAddress(), 2500, "subsidy")
+		trx := tx.NewSubsidyTx(ts.RandHeight(), pub.AccountAddress(), 2500)
 		trx.StripPublicKey()
 
 		err := trx.BasicCheck()
@@ -310,8 +304,7 @@ func TestInvalidSignature(t *testing.T) {
 		valKey := ts.RandValKey()
 		trx0 := ts.GenerateTestUnbondTx(testsuite.TransactionWithSigner(valKey.PrivateKey()))
 
-		trx := tx.NewUnbondTx(trx0.LockTime(), valKey.Address(),
-			"invalidate signature")
+		trx := tx.NewUnbondTx(trx0.LockTime(), valKey.Address(), tx.WithMemo("invalidate signature"))
 		trx.SetPublicKey(trx0.PublicKey())
 		trx.SetSignature(trx0.Signature())
 
@@ -399,7 +392,7 @@ func TestFlagNotSigned(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), ts.RandAccAddress(),
-		ts.RandAmount(), ts.RandAmount(), "")
+		ts.RandAmount(), ts.RandAmount())
 	assert.False(t, trx.IsSigned(), "FlagNotSigned should not be set for new transactions")
 
 	trx.SetSignature(ts.RandBLSSignature())

--- a/util/testsuite/testsuite.go
+++ b/util/testsuite/testsuite.go
@@ -529,8 +529,7 @@ func (ts *TestSuite) GenerateTestTransferTx(options ...func(tm *TransactionMaker
 	for _, opt := range options {
 		opt(tm)
 	}
-	trx := tx.NewTransferTx(tm.LockTime, tm.PubKey.AccountAddress(), ts.RandAccAddress(),
-		tm.Amount, tm.Fee, "test send-tx")
+	trx := tx.NewTransferTx(tm.LockTime, tm.PubKey.AccountAddress(), ts.RandAccAddress(), tm.Amount, tm.Fee)
 	ts.HelperSignTransaction(tm.PrvKey, trx)
 
 	return trx
@@ -543,8 +542,7 @@ func (ts *TestSuite) GenerateTestBondTx(options ...func(tm *TransactionMaker)) *
 	for _, opt := range options {
 		opt(tm)
 	}
-	trx := tx.NewBondTx(tm.LockTime, tm.PubKey.AccountAddress(), ts.RandValAddress(),
-		nil, tm.Amount, tm.Fee, "test bond-tx")
+	trx := tx.NewBondTx(tm.LockTime, tm.PubKey.AccountAddress(), ts.RandValAddress(), nil, tm.Amount, tm.Fee)
 	ts.HelperSignTransaction(tm.PrvKey, trx)
 
 	return trx
@@ -571,7 +569,7 @@ func (ts *TestSuite) GenerateTestUnbondTx(options ...func(tm *TransactionMaker))
 	for _, opt := range options {
 		opt(tm)
 	}
-	trx := tx.NewUnbondTx(tm.LockTime, tm.PubKey.ValidatorAddress(), "test unbond-tx")
+	trx := tx.NewUnbondTx(tm.LockTime, tm.PubKey.ValidatorAddress())
 	ts.HelperSignTransaction(tm.PrvKey, trx)
 
 	return trx
@@ -584,8 +582,7 @@ func (ts *TestSuite) GenerateTestWithdrawTx(options ...func(tm *TransactionMaker
 	for _, opt := range options {
 		opt(tm)
 	}
-	trx := tx.NewWithdrawTx(tm.LockTime, tm.PubKey.ValidatorAddress(), ts.RandAccAddress(),
-		tm.Amount, tm.Fee, "test withdraw-tx")
+	trx := tx.NewWithdrawTx(tm.LockTime, tm.PubKey.ValidatorAddress(), ts.RandAccAddress(), tm.Amount, tm.Fee)
 	ts.HelperSignTransaction(tm.PrvKey, trx)
 
 	return trx

--- a/wallet/tx_builder.go
+++ b/wallet/tx_builder.go
@@ -96,7 +96,7 @@ func (m *txBuilder) build() (*tx.Tx, error) {
 	var trx *tx.Tx
 	switch m.typ {
 	case payload.TypeTransfer:
-		trx = tx.NewTransferTx(m.lockTime, *m.from, *m.to, m.amount, m.fee, m.memo)
+		trx = tx.NewTransferTx(m.lockTime, *m.from, *m.to, m.amount, m.fee, tx.WithMemo(m.memo))
 	case payload.TypeBond:
 		pub := m.pub
 		val, _ := m.client.getValidator(m.to.String())
@@ -104,13 +104,13 @@ func (m *txBuilder) build() (*tx.Tx, error) {
 			// validator exists
 			pub = nil
 		}
-		trx = tx.NewBondTx(m.lockTime, *m.from, *m.to, pub, m.amount, m.fee, m.memo)
+		trx = tx.NewBondTx(m.lockTime, *m.from, *m.to, pub, m.amount, m.fee, tx.WithMemo(m.memo))
 
 	case payload.TypeUnbond:
-		trx = tx.NewUnbondTx(m.lockTime, *m.from, m.memo)
+		trx = tx.NewUnbondTx(m.lockTime, *m.from, tx.WithMemo(m.memo))
 
 	case payload.TypeWithdraw:
-		trx = tx.NewWithdrawTx(m.lockTime, *m.from, *m.to, m.amount, m.fee, m.memo)
+		trx = tx.NewWithdrawTx(m.lockTime, *m.from, *m.to, m.amount, m.fee, tx.WithMemo(m.memo))
 
 	case payload.TypeSortition:
 		return nil, fmt.Errorf("unable to build sortition transactions")

--- a/www/grpc/transaction.go
+++ b/www/grpc/transaction.go
@@ -121,7 +121,7 @@ func (s *transactionServer) GetRawTransferTransaction(_ context.Context,
 	fee := s.getFee(req.Fee, amt)
 	lockTime := s.getLockTime(req.LockTime)
 
-	transferTx := tx.NewTransferTx(lockTime, sender, receiver, amt, fee, req.Memo)
+	transferTx := tx.NewTransferTx(lockTime, sender, receiver, amt, fee, tx.WithMemo(req.Memo))
 	rawTx, err := transferTx.Bytes()
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func (s *transactionServer) GetRawBondTransaction(_ context.Context,
 	fee := s.getFee(req.Fee, amt)
 	lockTime := s.getLockTime(req.LockTime)
 
-	bondTx := tx.NewBondTx(lockTime, sender, receiver, publicKey, amt, fee, req.Memo)
+	bondTx := tx.NewBondTx(lockTime, sender, receiver, publicKey, amt, fee, tx.WithMemo(req.Memo))
 	rawTx, err := bondTx.Bytes()
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (s *transactionServer) GetRawUnbondTransaction(_ context.Context,
 
 	lockTime := s.getLockTime(req.LockTime)
 
-	unbondTx := tx.NewUnbondTx(lockTime, validatorAddr, req.Memo)
+	unbondTx := tx.NewUnbondTx(lockTime, validatorAddr, tx.WithMemo(req.Memo))
 	rawTx, err := unbondTx.Bytes()
 	if err != nil {
 		return nil, err
@@ -208,7 +208,7 @@ func (s *transactionServer) GetRawWithdrawTransaction(_ context.Context,
 	fee := s.getFee(req.Fee, amt)
 	lockTime := s.getLockTime(req.LockTime)
 
-	withdrawTx := tx.NewWithdrawTx(lockTime, validatorAddr, accountAddr, amt, fee, req.Memo)
+	withdrawTx := tx.NewWithdrawTx(lockTime, validatorAddr, accountAddr, amt, fee, tx.WithMemo(req.Memo))
 	rawTx, err := withdrawTx.Bytes()
 	if err != nil {
 		return nil, err

--- a/www/grpc/wallet_test.go
+++ b/www/grpc/wallet_test.go
@@ -161,7 +161,8 @@ func TestLoadWallet(t *testing.T) {
 
 	t.Run("Sign raw transaction, OK", func(t *testing.T) {
 		wltAddr, _ := crypto.AddressFromString(wltAddrInfo.Address)
-		bondTx := tx.NewBondTx(td.RandHeight(), wltAddr, td.RandValAddress(), nil, td.RandAmount(), td.RandAmount(), "memo")
+		bondTx := tx.NewBondTx(td.RandHeight(), wltAddr, td.RandValAddress(), nil, td.RandAmount(),
+			td.RandAmount())
 
 		b, err := bondTx.Bytes()
 		assert.NoError(t, err)
@@ -183,7 +184,8 @@ func TestLoadWallet(t *testing.T) {
 
 	t.Run("Sign raw transaction using not loaded wallet", func(t *testing.T) {
 		wltAddr, _ := crypto.AddressFromString(wltAddrInfo.Address)
-		bondTx := tx.NewBondTx(td.RandHeight(), wltAddr, td.RandValAddress(), nil, td.RandAmount(), td.RandAmount(), "memo")
+		bondTx := tx.NewBondTx(td.RandHeight(), wltAddr, td.RandValAddress(), nil, td.RandAmount(),
+			td.RandAmount())
 
 		b, err := bondTx.Bytes()
 		assert.NoError(t, err)


### PR DESCRIPTION
## Description

Making `memo` field optional in the `newTx` and its callers functions, by using options pattern.

## Related issue(s)

- Fixes #1440 