### PR TITLE
feat(daemon): warn at pruning a prune node attempt

### DIFF
--- a/cmd/daemon/prune.go
+++ b/cmd/daemon/prune.go
@@ -95,6 +95,11 @@ func buildPruneCmd(parentCmd *cobra.Command) {
 			cmd.PrintLine()
 			cmd.PrintInfoMsgf("❌ The operation canceled.")
 			cmd.PrintLine()
+		} else if prunedCount == 0 {
+			cmd.PrintLine()
+			cmd.PrintInfoMsgf("⚠️ Your node is not passed the retention_days set in config or it's already a pruned node.")
+			cmd.PrintLine()
+			cmd.PrintInfoMsgf("Make sure you try to prune a node after retention_days specified in config.toml")
 		} else {
 			cmd.PrintLine()
 			cmd.PrintInfoMsgf("✅ Your node successfully pruned and changed to prune mode.")


### PR DESCRIPTION
## Description

This is not a logic change, this change only helps the user to understand what exactly happens when they try to prune a database that is not passed `retention_days`, is already pruned, or is at genesis.

I added this since I was working on the previous PR when I was trying to Prune my recently started node and it was telling me it's pruned successfully!!!
But after a check I saw it's still a full node. Then I remembered It needs to pass the retention_days first. so it's a helpful message.

This can improve both UX and DX.