### PR TITLE
test(consensus): fix occasional failure in Byzantine test

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -1003,7 +1003,7 @@ func checkConsensus(td *testData, height uint32, byzVotes []*vote.Vote) (
 			m := rndMsg.message.(*message.QueryProposalMessage)
 			if m.Height == height {
 				for _, cons := range instances {
-					p := cons.HandleQueryProposal(m.Height, m.Round)
+					p := cons.Proposal()
 					if p != nil {
 						td.consMessages = append(td.consMessages, consMessage{
 							sender:  cons.valKey.Address(),


### PR DESCRIPTION
## Description

This PR fixes a random test failure in `TestByzantine`, as explained in #1452.
This situation is highly unlikely to occur on the mainnet, and even if it does, restarting any node will resolve the consensus halt.
To avoid adding unnecessary complexity to the codebase, we may choose not to address this issue further.

## Related issue(s)

- Fixes #1452