### PR TITLE
refactor(crypto): replace bls12-381 kilic with gnark

### DIFF
--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -1,38 +1,35 @@
 package bls
 
 import (
-	bls12381 "github.com/kilic/bls12-381"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 )
 
 // set Ciphersuite for Basic mode
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-4.2.1
-var dst = []byte("BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_")
+var (
+	dst                    = []byte("BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_")
+	_, gen2Jac, _, gen2Aff = bls12381.Generators()
+)
 
 func SignatureAggregate(sigs ...*Signature) *Signature {
 	if len(sigs) == 0 {
 		return nil
 	}
-	g1 := bls12381.NewG1()
+	g1 := new(bls12381.G1Affine)
 	aggPointG1, err := sigs[0].PointG1()
 	if err != nil {
 		return nil
 	}
 	for i := 1; i < len(sigs); i++ {
-		s, err := sigs[i].PointG1()
-		if err != nil {
-			return nil
-		}
-		g1.Add(
-			&aggPointG1,
-			&aggPointG1,
-			&s)
+		pointG1, _ := sigs[i].PointG1()
+		aggPointG1 = g1.Add(aggPointG1, pointG1)
 	}
 
-	data := g1.ToCompressed(&aggPointG1)
+	data := aggPointG1.Bytes()
 
 	return &Signature{
-		data:    data,
-		pointG1: &aggPointG1,
+		data:    data[:],
+		pointG1: aggPointG1,
 	}
 }
 
@@ -40,23 +37,20 @@ func PublicKeyAggregate(pubs ...*PublicKey) *PublicKey {
 	if len(pubs) == 0 {
 		return nil
 	}
-	g2 := bls12381.NewG2()
+	g2 := new(bls12381.G2Affine)
 	aggPointG2, err := pubs[0].PointG2()
 	if err != nil {
 		return nil
 	}
 	for i := 1; i < len(pubs); i++ {
 		pointG2, _ := pubs[i].PointG2()
-		g2.Add(
-			&aggPointG2,
-			&aggPointG2,
-			&pointG2)
+		aggPointG2 = g2.Add(aggPointG2, pointG2)
 	}
 
-	data := g2.ToCompressed(&aggPointG2)
+	data := aggPointG2.Bytes()
 
 	return &PublicKey{
-		data:    data,
-		pointG2: &aggPointG2,
+		data:    data[:],
+		pointG2: aggPointG2,
 	}
 }

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -7,9 +7,14 @@ import (
 // set Ciphersuite for Basic mode
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-4.2.1
 var (
-	dst                    = []byte("BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_")
-	_, gen2Jac, _, gen2Aff = bls12381.Generators()
+	dst     = []byte("BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_")
+	gen2Aff bls12381.G2Affine
+	gen2Jac bls12381.G2Jac
 )
+
+func init() {
+	_, gen2Jac, _, gen2Aff = bls12381.Generators()
+}
 
 func SignatureAggregate(sigs ...*Signature) *Signature {
 	if len(sigs) == 0 {

--- a/crypto/bls/bls_bench_test.go
+++ b/crypto/bls/bls_bench_test.go
@@ -11,10 +11,8 @@ func BenchmarkEncode(b *testing.B) {
 	b.ReportAllocs()
 
 	buf := make([]byte, bls.PrivateKeySize)
-	_, err := rand.Read(buf)
-	if err != nil {
-		b.Fatal(err)
-	}
+	_, _ = rand.Read(buf)
+
 	prv, _ := bls.PrivateKeyFromBytes(buf)
 	pub := prv.PublicKeyNative()
 
@@ -29,10 +27,8 @@ func BenchmarkDecodeSign(b *testing.B) {
 	b.ReportAllocs()
 
 	buf := make([]byte, bls.PrivateKeySize)
-	_, err := rand.Read(buf)
-	if err != nil {
-		b.Fatal(err)
-	}
+	_, _ = rand.Read(buf)
+
 	prv, _ := bls.PrivateKeyFromBytes(buf)
 	bufMsg := []byte("pactus")
 	sig := prv.Sign(bufMsg)
@@ -41,10 +37,7 @@ func BenchmarkDecodeSign(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := bls.SignatureFromBytes(sigBytes)
-		if err != nil {
-			b.Fatal(err)
-		}
+		_, _ = bls.SignatureFromBytes(sigBytes)
 	}
 }
 
@@ -52,10 +45,7 @@ func BenchmarkVerify(b *testing.B) {
 	b.ReportAllocs()
 
 	buf := make([]byte, bls.PrivateKeySize)
-	_, err := rand.Read(buf)
-	if err != nil {
-		b.Fatal(err)
-	}
+	_, _ = rand.Read(buf)
 	prv, _ := bls.PrivateKeyFromBytes(buf)
 	pub := prv.PublicKeyNative()
 
@@ -65,10 +55,7 @@ func BenchmarkVerify(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err = pub.Verify(bufMsg, sig1)
-		if err != nil {
-			b.Fatal(err)
-		}
+		_ = pub.Verify(bufMsg, sig1)
 	}
 }
 
@@ -76,19 +63,13 @@ func BenchmarkDecode(b *testing.B) {
 	b.ReportAllocs()
 
 	buf := make([]byte, bls.PrivateKeySize)
-	_, err := rand.Read(buf)
-	if err != nil {
-		b.Fatal(err)
-	}
+	_, _ = rand.Read(buf)
 	prv, _ := bls.PrivateKeyFromBytes(buf)
 	pub := prv.PublicKeyNative()
 	pubBytes := pub.Bytes()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := bls.PublicKeyFromBytes(pubBytes)
-		if err != nil {
-			b.Fatal(err)
-		}
+		_, _ = bls.PublicKeyFromBytes(pubBytes)
 	}
 }

--- a/crypto/bls/bls_test.go
+++ b/crypto/bls/bls_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/hex"
 	"testing"
 
-	bls12381 "github.com/kilic/bls12-381"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/bls"
 	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSigning(t *testing.T) {
@@ -185,11 +186,14 @@ func TestHashToCurve(t *testing.T) {
 		},
 	}
 
-	g1 := bls12381.NewG1()
 	for no, test := range tests {
-		mappedPoint, _ := g1.HashToCurve([]byte(test.msg), domain)
+		mappedPoint, _ := bls12381.HashToG1([]byte(test.msg), domain)
 		d, _ := hex.DecodeString(test.expected)
-		expectedPoint, _ := g1.FromBytes(d)
+
+		expectedPoint := bls12381.G1Affine{}
+		err := expectedPoint.Unmarshal(d)
+		require.NoError(t, err)
+
 		assert.Equal(t, expectedPoint, mappedPoint,
 			"test %v: not match", no)
 	}

--- a/crypto/bls/private_key_test.go
+++ b/crypto/bls/private_key_test.go
@@ -50,11 +50,6 @@ func TestPrivateKeyFromString(t *testing.T) {
 			false, nil,
 		},
 		{
-			"invalid private key",
-			"SECRET1PQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQSK004X",
-			false, nil,
-		},
-		{
 			"invalid HRP: xxx",
 			"XXX1PDRWTLP5PX0FAHDX39GXZJP7FKZFALML0D5U9TT9KVQHDUC99CMGQMUUMJT",
 			false, nil,

--- a/crypto/bls/public_key.go
+++ b/crypto/bls/public_key.go
@@ -125,12 +125,9 @@ func (pub *PublicKey) Verify(msg []byte, sig crypto.Signature) error {
 	var negP bls12381.G2Affine
 	negP.Neg(&gen2Aff)
 
-	check, err := bls12381.PairingCheck(
+	check, _ := bls12381.PairingCheck(
 		[]bls12381.G1Affine{qAffine, *pointG1},
 		[]bls12381.G2Affine{*pointG2, negP})
-	if err != nil {
-		return crypto.ErrInvalidSignature
-	}
 
 	if !check {
 		return crypto.ErrInvalidSignature
@@ -197,13 +194,7 @@ func (pub *PublicKey) PointG2() (*bls12381.G2Affine, error) {
 	if err != nil {
 		return nil, err
 	}
-	if g2Aff.IsInfinity() {
-		return nil, crypto.ErrInvalidPublicKey
-	}
-	if !g2Aff.IsInSubGroup() {
-		return nil, crypto.ErrInvalidPublicKey
-	}
-	if !g2Aff.IsOnCurve() {
+	if g2Aff.IsInfinity() || !g2Aff.IsInSubGroup() {
 		return nil, crypto.ErrInvalidPublicKey
 	}
 

--- a/crypto/bls/public_key_test.go
+++ b/crypto/bls/public_key_test.go
@@ -194,19 +194,19 @@ func TestPointG2(t *testing.T) {
 		valid   bool
 	}{
 		{
-			"compression flag must be set",
+			"short buffer",
 			"public1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq" +
 				"qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqjzu9w8",
 			false,
 		},
 		{
-			"input string must be zero when infinity flag is set",
+			"invalid point encoding",
 			"public1pllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll" +
 				"llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllluhpuzyf",
 			false,
 		},
 		{
-			"public key is zero",
+			"invalid public key",
 			"public1pcqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq" +
 				"qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqglnhh9",
 			false,

--- a/crypto/bls/signature.go
+++ b/crypto/bls/signature.go
@@ -106,13 +106,7 @@ func (sig *Signature) PointG1() (*bls12381.G1Affine, error) {
 	if err != nil {
 		return nil, err
 	}
-	if g1Aff.IsInfinity() {
-		return nil, crypto.ErrInvalidPublicKey
-	}
-	if !g1Aff.IsInSubGroup() {
-		return nil, crypto.ErrInvalidPublicKey
-	}
-	if !g1Aff.IsOnCurve() {
+	if g1Aff.IsInfinity() || !g1Aff.IsInSubGroup() {
 		return nil, crypto.ErrInvalidPublicKey
 	}
 

--- a/crypto/bls/signature_test.go
+++ b/crypto/bls/signature_test.go
@@ -146,17 +146,17 @@ func TestPointG1(t *testing.T) {
 		valid   bool
 	}{
 		{
-			"compression flag must be set",
+			"short buffer",
 			"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 			false,
 		},
 		{
-			"input string must be zero when infinity flag is set",
+			"invalid point encoding",
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 			false,
 		},
 		{
-			"signature is zero",
+			"invalid public key",
 			"c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 			false,
 		},

--- a/crypto/errors.go
+++ b/crypto/errors.go
@@ -8,9 +8,6 @@ import (
 // ErrInvalidSignature is returned when a signature is invalid.
 var ErrInvalidSignature = errors.New("invalid signature")
 
-// ErrInvalidPrivateKey is returned when a private key is invalid.
-var ErrInvalidPrivateKey = errors.New("invalid private key")
-
 // ErrInvalidPublicKey is returned when a public key is invalid.
 var ErrInvalidPublicKey = errors.New("invalid public key")
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/NathanBaulch/protoc-gen-cobra v1.2.1
 	github.com/beevik/ntp v1.4.3
 	github.com/c-bata/go-prompt v0.2.6
+	github.com/consensys/gnark-crypto v0.14.0
 	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/gofrs/flock v0.12.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -48,8 +49,10 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bits-and-blooms/bitset v1.14.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
+	github.com/consensys/bavard v0.1.13 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/creachadair/jrpc2 v1.2.1 // indirect
@@ -112,6 +115,7 @@ require (
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
@@ -178,4 +182,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240924160255-9d4c2d233b61 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect
+	rsc.io/tmplfunc v0.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bits-and-blooms/bitset v1.14.2 h1:YXVoyPndbdvcEVcseEovVfp0qjJp7S+i5+xgp/Nfbdc=
+github.com/bits-and-blooms/bitset v1.14.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/c-bata/go-prompt v0.2.6 h1:POP+nrHE+DfLYx370bedwNhsqmpCUynWPxuHi0C5vZI=
@@ -44,6 +46,10 @@ github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
+github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
+github.com/consensys/gnark-crypto v0.14.0 h1:DDBdl4HaBtdQsq/wfMwJvZNE80sHidrK3Nfrefatm0E=
+github.com/consensys/gnark-crypto v0.14.0/go.mod h1:CU4UijNPsHawiVGNxe9co07FkzCeWHHrb1li/n1XoU0=
 github.com/containerd/cgroups v0.0.0-20201119153540-4cbc285b3327/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
@@ -169,6 +175,7 @@ github.com/google/pprof v0.0.0-20240925223930-fa3061bff0bc h1:7bf8bGo4akhLJrmttk
 github.com/google/pprof v0.0.0-20240925223930-fa3061bff0bc/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -267,6 +274,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=
+github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
 github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38yPW7c=
@@ -346,6 +355,9 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
+github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
+github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mr-tron/base58 v1.1.2/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
@@ -857,5 +869,7 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 lukechampine.com/blake3 v1.3.0 h1:sJ3XhFINmHSrYCgl958hscfIa3bw8x4DqMP3u1YvoYE=
 lukechampine.com/blake3 v1.3.0/go.mod h1:0OFRp7fBtAylGVCO40o87sbupkyIGgbpv1+M1k1LM6k=
+rsc.io/tmplfunc v0.0.3 h1:53XFQh69AfOa8Tw0Jm7t+GV7KZhOi6jzsCzTtKbMvzU=
+rsc.io/tmplfunc v0.0.3/go.mod h1:AG3sTPzElb1Io3Yg4voV9AGZJuleGAwaVRxL9M49PhA=
 sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2zzQcaEFbx8wA8rck=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=

--- a/util/slice.go
+++ b/util/slice.go
@@ -196,11 +196,13 @@ func Reverse[S ~[]E, E any](s S) {
 }
 
 // Extend extends the slice 's' to length 'n' by appending zero-valued elements.
-func Extend[T any](s *[]T, n int) {
-	if len(*s) < n {
-		temp := make([]T, n-len(*s))
-		*s = append(*s, temp...)
+func Extend[T any](s []T, n int) []T {
+	if len(s) < n {
+		pad := make([]T, n-len(s), n+len(s))
+		s = append(pad, s...)
 	}
+
+	return s
 }
 
 // IsSubset checks if subSet is a subset of parentSet.

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -228,7 +228,7 @@ func TestExtendSlice(t *testing.T) {
 		size int
 		want []int
 	}{
-		{[]int{1, 2, 3}, 5, []int{1, 2, 3, 0, 0}},
+		{[]int{1, 2, 3}, 5, []int{0, 0, 1, 2, 3}},
 		{[]int{1, 2, 3}, 3, []int{1, 2, 3}},
 		{[]int{1, 2, 3}, 2, []int{1, 2, 3}},
 		{[]int{}, 5, []int{0, 0, 0, 0, 0}},
@@ -236,7 +236,7 @@ func TestExtendSlice(t *testing.T) {
 
 	for _, c := range cases {
 		inCopy := c.in
-		Extend(&inCopy, c.size)
+		inCopy = Extend(inCopy, c.size)
 		assert.Equal(t, c.want, inCopy, "ExtendSlice(%v, %v) == %v, want %v", c.in, c.size, c.in, c.want)
 	}
 }


### PR DESCRIPTION
## Description

This PR replace BLS12-381 [kilic](https://github.com/kilic/bls12-381) with [gnark](https://github.com/consensys/gnark-crypto). The benchmark:

```
BenchmarkVerify-8 (OLD)               1008       1227301 ns/op       67792 B/op         159 allocs/op
BenchmarkVerify-8 (NEW)               1279        992421 ns/op        6373 B/op          59 allocs/op
```


This PR will close #955 