### PR TITLE
fix(sync): set last support version to 1.5.0

### DIFF
--- a/sync/config.go
+++ b/sync/config.go
@@ -32,10 +32,11 @@ func DefaultConfig() *Config {
 		BlockPerMessage: 60,
 		PruneWindow:     86_400, // Default retention blocks in prune mode
 		Firewall:        firewall.DefaultConfig(),
+		// v1.5.0 is the hard-fork for Ed25519 support.
 		LatestSupportingVer: version.Version{
 			Major: 1,
-			Minor: 1,
-			Patch: 8,
+			Minor: 5,
+			Patch: 0,
 		},
 	}
 }

--- a/sync/handler_blocks_request.go
+++ b/sync/handler_blocks_request.go
@@ -67,8 +67,8 @@ func (handler *blocksRequestHandler) ParseMessage(m message.Message, pid peer.ID
 	height := msg.From
 	count := msg.Count
 	for {
-		blockToRead := util.Min(handler.config.BlockPerMessage, count)
-		blocksData := handler.prepareBlocks(height, blockToRead)
+		blockCount := util.Min(handler.config.BlockPerMessage, count)
+		blocksData := handler.prepareBlocks(height, blockCount)
 		if len(blocksData) == 0 {
 			break
 		}


### PR DESCRIPTION
## Description

This PR sets the last supported version to 1.5.0, which includes the hard fork for Ed25519 curve support. 
Peers using a lower version will have their hello messages rejected.