### PR TITLE
fix(http): add pprof link in http web interface

### DIFF
--- a/www/http/server.go
+++ b/www/http/server.go
@@ -98,6 +98,9 @@ func (s *Server) StartServer(grpcServer string) error {
 		http.HandleFunc("/debug/pprof/profile", pprof.Profile)
 		http.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		http.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		s.router.HandleFunc("/debug/pprof", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/debug/pprof/", http.StatusPermanentRedirect)
+		})
 	}
 
 	if s.enableAuth {


### PR DESCRIPTION
## Description

Show `/debug/pprof` in web link list in http.

![image](https://github.com/user-attachments/assets/55eb9e48-13d6-4d16-9bb9-ecc49340556a)
