### PR TITLE
chore(deps): upgrade go to 1.23.2 to fix libp2p issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pactus-project/pactus
 
-go 1.23.1
+go 1.23.2
 
 require (
 	github.com/NathanBaulch/protoc-gen-cobra v1.2.1


### PR DESCRIPTION
## Description

Upgrade go to v1.23.2 to fix issue go-libp2p https://github.com/libp2p/go-libp2p/issues/2968