### PR TITLE
fix(deps): go version docker image to build go v1.23.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.1-alpine3.19 as builder
+FROM golang:1.23.2-alpine3.19 as builder
 
 RUN apk add --no-cache git gmp-dev build-base g++ openssl-dev
 ADD . /pactus


### PR DESCRIPTION
## Description

Updated go version docker image to build go v1.23.2