### PR TITLE
fix(cli): build android version on go v1.23.2 pactus-daemon

### DIFF
--- a/.github/releasers/releaser_cli.sh
+++ b/.github/releasers/releaser_cli.sh
@@ -13,6 +13,7 @@ PACKAGE_NAME="pactus-cli_${VERSION}"
 
 for OS_ARCH in \
      "linux amd64" "linux arm64" \
+     "android arm64" \
      "freebsd amd64" "freebsd arm" \
      "darwin amd64" "darwin arm64" \
      "windows 386" "windows amd64"; do
@@ -32,9 +33,14 @@ for OS_ARCH in \
 
     echo "Building Pactus for ${OS}-${ARCH}..."
 
-    CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-daemon${EXE} ./cmd/daemon
-    CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-wallet${EXE} ./cmd/wallet
-    CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-shell${EXE}  ./cmd/shell
+    LD_FLAGS="-s -w"
+    if [[ ${OS} == "android" ]]; then
+        LD_FLAGS="${LD_FLAGS} -checklinkname=0"
+    fi
+
+    CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "${LD_FLAGS}" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-daemon${EXE} ./cmd/daemon
+    CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "${LD_FLAGS}" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-wallet${EXE} ./cmd/wallet
+    CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "${LD_FLAGS}" -trimpath -o ${BUILD_DIR}/${PACKAGE_NAME}/pactus-shell${EXE}  ./cmd/shell
 
     cd ${BUILD_DIR}
     if [ $OS = "windows" ]; then

--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
-	github.com/wlynxg/anet v0.0.4 // indirect
+	github.com/wlynxg/anet v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel v1.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -564,8 +564,8 @@ github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0/go.mod h1:x6AKhvS
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/wlynxg/anet v0.0.3/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
-github.com/wlynxg/anet v0.0.4 h1:0de1OFQxnNqAu+x2FAKKCVIrnfGKQbs7FQz++tB0+Uw=
-github.com/wlynxg/anet v0.0.4/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
+github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
+github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
## Description

Fixed build android version pactus-daemon for package anet in go v1.23.2.

## Related issue(s)

- Fixes #1506