### PR TITLE
fix(gtk): increase window width to show availability score

### DIFF
--- a/cmd/gtk/assets/ui/main_window.ui
+++ b/cmd/gtk/assets/ui/main_window.ui
@@ -5,7 +5,7 @@
   <object class="GtkApplicationWindow" id="id_main_window">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Pactus GUI</property>
-    <property name="default-width">800</property>
+    <property name="default-width">880</property>
     <property name="default-height">440</property>
     <child>
       <object class="GtkBox">


### PR DESCRIPTION
## Description

Fix width of main window gtk for show correct availability score.

**Before:**
![Screenshot from 2024-10-07 14-38-12](https://github.com/user-attachments/assets/1dbcd910-05f0-4fdb-a745-5159345471a1)


**After:**
![Screenshot from 2024-10-07 14-37-39](https://github.com/user-attachments/assets/07390ee3-2e88-4378-b96e-ef6bcb2b8484)
