### PR TITLE
chore(grpc): remove trailing spaces from gRPC doc template

### DIFF
--- a/www/grpc/buf/grpc-md.tmpl
+++ b/www/grpc/buf/grpc-md.tmpl
@@ -16,7 +16,7 @@ Each PAC is equivalent to 1,000,000,000 or 10<sup>9</sup> NanoPACs.
   {{range .Files}}{{- print "" -}}
     {{range .Services}}{{- print "" -}}
     <li> {{.Name}} Service
-      <ul> {{$service_name := .FullName}}
+      <ul>{{$service_name := .FullName}}
         {{range .Methods}}{{- print "" -}}
         <li>
           <a href="#{{$service_name}}.{{.Name}}">

--- a/www/grpc/buf/grpc-md.tmpl
+++ b/www/grpc/buf/grpc-md.tmpl
@@ -56,8 +56,8 @@ Each PAC is equivalent to 1,000,000,000 or 10<sup>9</sup> NanoPACs.
     <td class="fw-bold">{{.Name}}</td>
     <td>{{.Label}} {{.LongType}}</td>
     <td>
-    {{if .IsEnum}}(Enum) {{end}}{{- print "" -}}
-    {{if .IsOneOf}}(OneOf) {{end}}{{- print "" -}}
+    {{if .IsEnum}}(Enum){{end}}{{- print "" -}}
+    {{if .IsOneOf}}(OneOf){{end}}{{- print "" -}}
     {{if (index .Options "deprecated"|default false)}}<strong>(Deprecated) </strong>{{end}}{{- print "" -}}
     {{.Description}}
     {{if .DefaultValue}}Default: {{.DefaultValue}}{{end}}{{- print "" -}}
@@ -91,8 +91,8 @@ Message has no fields.
     <td class="fw-bold">{{.Name}}</td>
     <td>{{.Label}} {{.LongType}}</td>
     <td>
-    {{if .IsEnum}}(Enum) {{end}}{{- print "" -}}
-    {{if .IsOneOf}}(OneOf) {{end}}{{- print "" -}}
+    {{if .IsEnum}}(Enum){{end}}{{- print "" -}}
+    {{if .IsOneOf}}(OneOf){{end}}{{- print "" -}}
     {{if (index .Options "deprecated"|default false)}}<strong>(Deprecated) </strong>{{end}}{{- print "" -}}
     {{.Description}}
     {{if .DefaultValue}}Default: {{.DefaultValue}}{{end}}{{- print "" -}}
@@ -111,8 +111,8 @@ Message has no fields.
         <td class="fw-bold">{{$msg0.Name}}{{if $msg0.IsRepeated}}[]{{end}}.{{.Name}}</td>
         <td>{{.Label}} {{.LongType}}</td>
         <td>
-        {{if .IsEnum}}(Enum) {{end}}{{- print "" -}}
-        {{if .IsOneOf}}(OneOf) {{end}}{{- print "" -}}
+        {{if .IsEnum}}(Enum){{end}}{{- print "" -}}
+        {{if .IsOneOf}}(OneOf){{end}}{{- print "" -}}
         {{if (index .Options "deprecated"|default false)}}<strong>(Deprecated) </strong>{{end}}{{- print "" -}}
         {{.Description}}
         {{if .DefaultValue}}Default: {{.DefaultValue}}{{end}}{{- print "" -}}
@@ -131,8 +131,8 @@ Message has no fields.
             <td class="fw-bold">{{$msg0.Name}}{{if $msg0.IsRepeated}}[]{{end}}.{{$msg1.Name}}{{if $msg1.IsRepeated}}[]{{end}}.{{.Name}}</td>
             <td>{{.Label}} {{.LongType}}</td>
             <td>
-            {{if .IsEnum}}(Enum) {{end}}{{- print "" -}}
-            {{if .IsOneOf}}(OneOf) {{end}}{{- print "" -}}
+            {{if .IsEnum}}(Enum){{end}}{{- print "" -}}
+            {{if .IsOneOf}}(OneOf){{end}}{{- print "" -}}
             {{if (index .Options "deprecated"|default false)}}<strong>(Deprecated) </strong>{{end}}{{- print "" -}}
             {{.Description}}
             {{if .DefaultValue}}Default: {{.DefaultValue}}{{end}}{{- print "" -}}
@@ -161,7 +161,7 @@ Message has no fields.
   <thead>
     <tr><td>.proto Type</td><td>Go</td><td>C++</td><td>Rust</td><td>Java</td><td>Python</td><td>C#</td></tr>
   </thead>
-  <tbody class="table-group-divider"> {{range .Scalars}}
+  <tbody class="table-group-divider">{{range .Scalars}}
       <tr id="{{.ProtoType}}">
         <td class="fw-bold">{{.ProtoType}}</td>
         <td>{{.GoType}}</td>
@@ -170,6 +170,6 @@ Message has no fields.
         <td>{{.JavaType}}</td>
         <td>{{.PythonType}}</td>
         <td>{{.CSharp}}</td>
-      </tr> {{end}}
+      </tr>{{end}}
   </tbody>
 </table>

--- a/www/grpc/buf/json-rpc-md.tmpl
+++ b/www/grpc/buf/json-rpc-md.tmpl
@@ -67,7 +67,7 @@ curl --location 'http://localhost:8545/' \
   {{range .Files}}{{- print "" -}}
     {{range .Services}}{{- print "" -}}
     <li> {{.Name}} Service
-      <ul> {{$service_name := .JSONName}}
+      <ul>{{$service_name := .JSONName}}
         {{range .Methods}}{{- print "" -}}
         <li>
           <a href="#{{.JSONName}}">
@@ -107,8 +107,8 @@ curl --location 'http://localhost:8545/' \
     <td class="fw-bold">{{.JSONName}}</td>
     <td>{{.Label}} {{.JSONType}}</td>
     <td>
-    {{if .IsEnum}}(Enum) {{end}}{{- print "" -}}
-    {{if .IsOneOf}}(OneOf) {{end}}{{- print "" -}}
+    {{if .IsEnum}}(Enum){{end}}{{- print "" -}}
+    {{if .IsOneOf}}(OneOf){{end}}{{- print "" -}}
     {{if (index .Options "deprecated"|default false)}}<strong>(Deprecated) </strong>{{end}}{{- print "" -}}
     {{.Description}}
     {{if .DefaultValue}}Default: {{.DefaultValue}}{{end}}{{- print "" -}}
@@ -142,8 +142,8 @@ Parameters has no fields.
     <td class="fw-bold">{{.Name}}</td>
     <td>{{.Label}} {{.JSONType}}</td>
     <td>
-    {{if .IsEnum}}(Enum) {{end}}{{- print "" -}}
-    {{if .IsOneOf}}(OneOf) {{end}}{{- print "" -}}
+    {{if .IsEnum}}(Enum){{end}}{{- print "" -}}
+    {{if .IsOneOf}}(OneOf){{end}}{{- print "" -}}
     {{if (index .Options "deprecated"|default false)}}<strong>(Deprecated) </strong>{{end}}{{- print "" -}}
     {{.Description}}
     {{if .DefaultValue}}Default: {{.DefaultValue}}{{end}}{{- print "" -}}
@@ -162,8 +162,8 @@ Parameters has no fields.
         <td class="fw-bold">{{$msg0.Name}}{{if $msg0.IsRepeated}}[]{{end}}.{{.Name}}</td>
         <td>{{.Label}} {{.JSONType}}</td>
         <td>
-        {{if .IsEnum}}(Enum) {{end}}{{- print "" -}}
-        {{if .IsOneOf}}(OneOf) {{end}}{{- print "" -}}
+        {{if .IsEnum}}(Enum){{end}}{{- print "" -}}
+        {{if .IsOneOf}}(OneOf){{end}}{{- print "" -}}
         {{if (index .Options "deprecated"|default false)}}<strong>(Deprecated) </strong>{{end}}{{- print "" -}}
         {{.Description}}
         {{if .DefaultValue}}Default: {{.DefaultValue}}{{end}}{{- print "" -}}
@@ -182,8 +182,8 @@ Parameters has no fields.
             <td class="fw-bold">{{$msg0.Name}}{{if $msg0.IsRepeated}}[]{{end}}.{{$msg1.Name}}{{if $msg1.IsRepeated}}[]{{end}}.{{.Name}}</td>
             <td>{{.Label}} {{.JSONType}}</td>
             <td>
-            {{if .IsEnum}}(Enum) {{end}}{{- print "" -}}
-            {{if .IsOneOf}}(OneOf) {{end}}{{- print "" -}}
+            {{if .IsEnum}}(Enum){{end}}{{- print "" -}}
+            {{if .IsOneOf}}(OneOf){{end}}{{- print "" -}}
             {{if (index .Options "deprecated"|default false)}}<strong>(Deprecated) </strong>{{end}}{{- print "" -}}
             {{.Description}}
             {{if .DefaultValue}}Default: {{.DefaultValue}}{{end}}{{- print "" -}}

--- a/www/grpc/gen/docs/grpc.md
+++ b/www/grpc/gen/docs/grpc.md
@@ -14,7 +14,7 @@ Each PAC is equivalent to 1,000,000,000 or 10<sup>9</sup> NanoPACs.
 <div id="toc-container">
   <ul class="">
   <li> Transaction Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.Transaction.GetTransaction">
           <span class="rpc-badge"></span> GetTransaction</a>
@@ -50,7 +50,7 @@ Each PAC is equivalent to 1,000,000,000 or 10<sup>9</sup> NanoPACs.
         </ul>
     </li>
     <li> Blockchain Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.Blockchain.GetBlock">
           <span class="rpc-badge"></span> GetBlock</a>
@@ -98,7 +98,7 @@ Each PAC is equivalent to 1,000,000,000 or 10<sup>9</sup> NanoPACs.
         </ul>
     </li>
     <li> Network Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.Network.GetNetworkInfo">
           <span class="rpc-badge"></span> GetNetworkInfo</a>
@@ -110,7 +110,7 @@ Each PAC is equivalent to 1,000,000,000 or 10<sup>9</sup> NanoPACs.
         </ul>
     </li>
     <li> Utils Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.Utils.SignMessageWithPrivateKey">
           <span class="rpc-badge"></span> SignMessageWithPrivateKey</a>
@@ -122,7 +122,7 @@ Each PAC is equivalent to 1,000,000,000 or 10<sup>9</sup> NanoPACs.
         </ul>
     </li>
     <li> Wallet Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.Wallet.CreateWallet">
           <span class="rpc-badge"></span> CreateWallet</a>

--- a/www/grpc/gen/docs/grpc.md
+++ b/www/grpc/gen/docs/grpc.md
@@ -198,7 +198,7 @@ parameters.</p>
     <td class="fw-bold">verbosity</td>
     <td> TransactionVerbosity</td>
     <td>
-    (Enum) The verbosity level for transaction details.
+    (Enum)The verbosity level for transaction details.
     <br>Available values:<ul>
       <li>TRANSACTION_DATA = 0 (Request transaction data only.)</li>
       <li>TRANSACTION_INFO = 1 (Request detailed transaction information.)</li>
@@ -281,7 +281,7 @@ parameters.</p>
         <td class="fw-bold">transaction.payload_type</td>
         <td> PayloadType</td>
         <td>
-        (Enum) The type of transaction payload.
+        (Enum)The type of transaction payload.
         <br>Available values:<ul>
           <li>UNKNOWN = 0 (Unknown payload type.)</li>
           <li>TRANSFER_PAYLOAD = 1 (Transfer payload type.)</li>
@@ -296,7 +296,7 @@ parameters.</p>
         <td class="fw-bold">transaction.transfer</td>
         <td> PayloadTransfer</td>
         <td>
-        (OneOf) Transfer transaction payload.
+        (OneOf)Transfer transaction payload.
         </td>
       </tr>
          <tr>
@@ -324,7 +324,7 @@ parameters.</p>
         <td class="fw-bold">transaction.bond</td>
         <td> PayloadBond</td>
         <td>
-        (OneOf) Bond transaction payload.
+        (OneOf)Bond transaction payload.
         </td>
       </tr>
          <tr>
@@ -359,7 +359,7 @@ parameters.</p>
         <td class="fw-bold">transaction.sortition</td>
         <td> PayloadSortition</td>
         <td>
-        (OneOf) Sortition transaction payload.
+        (OneOf)Sortition transaction payload.
         </td>
       </tr>
          <tr>
@@ -380,7 +380,7 @@ parameters.</p>
         <td class="fw-bold">transaction.unbond</td>
         <td> PayloadUnbond</td>
         <td>
-        (OneOf) Unbond transaction payload.
+        (OneOf)Unbond transaction payload.
         </td>
       </tr>
          <tr>
@@ -394,7 +394,7 @@ parameters.</p>
         <td class="fw-bold">transaction.withdraw</td>
         <td> PayloadWithdraw</td>
         <td>
-        (OneOf) Withdraw transaction payload.
+        (OneOf)Withdraw transaction payload.
         </td>
       </tr>
          <tr>
@@ -465,7 +465,7 @@ and payload type.</p>
     <td class="fw-bold">payload_type</td>
     <td> PayloadType</td>
     <td>
-    (Enum) The type of transaction payload.
+    (Enum)The type of transaction payload.
     <br>Available values:<ul>
       <li>UNKNOWN = 0 (Unknown payload type.)</li>
       <li>TRANSFER_PAYLOAD = 1 (Transfer payload type.)</li>
@@ -582,28 +582,28 @@ and payload type.</p>
     <td class="fw-bold">transfer</td>
     <td> PayloadTransfer</td>
     <td>
-    (OneOf) 
+    (OneOf)
     </td>
   </tr>
   <tr>
     <td class="fw-bold">bond</td>
     <td> PayloadBond</td>
     <td>
-    (OneOf) 
+    (OneOf)
     </td>
   </tr>
   <tr>
     <td class="fw-bold">unbond</td>
     <td> PayloadUnbond</td>
     <td>
-    (OneOf) 
+    (OneOf)
     </td>
   </tr>
   <tr>
     <td class="fw-bold">withdraw</td>
     <td> PayloadWithdraw</td>
     <td>
-    (OneOf) 
+    (OneOf)
     </td>
   </tr>
   </tbody>
@@ -969,7 +969,7 @@ parameters.</p>
     <td class="fw-bold">verbosity</td>
     <td> BlockVerbosity</td>
     <td>
-    (Enum) The verbosity level for block information.
+    (Enum)The verbosity level for block information.
     <br>Available values:<ul>
       <li>BLOCK_DATA = 0 (Request only block data.)</li>
       <li>BLOCK_INFO = 1 (Request block information and transaction IDs.)</li>
@@ -1152,7 +1152,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].payload_type</td>
         <td> PayloadType</td>
         <td>
-        (Enum) The type of transaction payload.
+        (Enum)The type of transaction payload.
         <br>Available values:<ul>
           <li>UNKNOWN = 0 (Unknown payload type.)</li>
           <li>TRANSFER_PAYLOAD = 1 (Transfer payload type.)</li>
@@ -1167,7 +1167,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].transfer</td>
         <td> PayloadTransfer</td>
         <td>
-        (OneOf) Transfer transaction payload.
+        (OneOf)Transfer transaction payload.
         </td>
       </tr>
          <tr>
@@ -1195,7 +1195,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].bond</td>
         <td> PayloadBond</td>
         <td>
-        (OneOf) Bond transaction payload.
+        (OneOf)Bond transaction payload.
         </td>
       </tr>
          <tr>
@@ -1230,7 +1230,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].sortition</td>
         <td> PayloadSortition</td>
         <td>
-        (OneOf) Sortition transaction payload.
+        (OneOf)Sortition transaction payload.
         </td>
       </tr>
          <tr>
@@ -1251,7 +1251,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].unbond</td>
         <td> PayloadUnbond</td>
         <td>
-        (OneOf) Unbond transaction payload.
+        (OneOf)Unbond transaction payload.
         </td>
       </tr>
          <tr>
@@ -1265,7 +1265,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].withdraw</td>
         <td> PayloadWithdraw</td>
         <td>
-        (OneOf) Withdraw transaction payload.
+        (OneOf)Withdraw transaction payload.
         </td>
       </tr>
          <tr>
@@ -1640,7 +1640,7 @@ committee.
             <td class="fw-bold">instances[].votes[].type</td>
             <td> VoteType</td>
             <td>
-            (Enum) The type of the vote.
+            (Enum)The type of the vote.
             <br>Available values:<ul>
               <li>VOTE_UNKNOWN = 0 (Unknown vote type.)</li>
               <li>VOTE_PREPARE = 1 (Prepare vote type.)</li>
@@ -2053,7 +2053,7 @@ address.</p>
     <td class="fw-bold">payload_type</td>
     <td> PayloadType</td>
     <td>
-    (Enum) The type of transactions to retrieve from the transaction pool. 0 means all
+    (Enum)The type of transactions to retrieve from the transaction pool. 0 means all
 types.
     <br>Available values:<ul>
       <li>UNKNOWN = 0 (Unknown payload type.)</li>
@@ -2127,7 +2127,7 @@ types.
         <td class="fw-bold">txs[].payload_type</td>
         <td> PayloadType</td>
         <td>
-        (Enum) The type of transaction payload.
+        (Enum)The type of transaction payload.
         <br>Available values:<ul>
           <li>UNKNOWN = 0 (Unknown payload type.)</li>
           <li>TRANSFER_PAYLOAD = 1 (Transfer payload type.)</li>
@@ -2142,7 +2142,7 @@ types.
         <td class="fw-bold">txs[].transfer</td>
         <td> PayloadTransfer</td>
         <td>
-        (OneOf) Transfer transaction payload.
+        (OneOf)Transfer transaction payload.
         </td>
       </tr>
          <tr>
@@ -2170,7 +2170,7 @@ types.
         <td class="fw-bold">txs[].bond</td>
         <td> PayloadBond</td>
         <td>
-        (OneOf) Bond transaction payload.
+        (OneOf)Bond transaction payload.
         </td>
       </tr>
          <tr>
@@ -2205,7 +2205,7 @@ types.
         <td class="fw-bold">txs[].sortition</td>
         <td> PayloadSortition</td>
         <td>
-        (OneOf) Sortition transaction payload.
+        (OneOf)Sortition transaction payload.
         </td>
       </tr>
          <tr>
@@ -2226,7 +2226,7 @@ types.
         <td class="fw-bold">txs[].unbond</td>
         <td> PayloadUnbond</td>
         <td>
-        (OneOf) Unbond transaction payload.
+        (OneOf)Unbond transaction payload.
         </td>
       </tr>
          <tr>
@@ -2240,7 +2240,7 @@ types.
         <td class="fw-bold">txs[].withdraw</td>
         <td> PayloadWithdraw</td>
         <td>
-        (OneOf) Withdraw transaction payload.
+        (OneOf)Withdraw transaction payload.
         </td>
       </tr>
          <tr>
@@ -3061,7 +3061,7 @@ public key.</p>
     <td class="fw-bold">address_type</td>
     <td> AddressType</td>
     <td>
-    (Enum) The type of address to generate.
+    (Enum)The type of address to generate.
     <br>Available values:<ul>
       <li>ADDRESS_TYPE_TREASURY = 0 (Treasury address type.
 Should not be used to generate new addresses.)</li>
@@ -3283,7 +3283,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
   <thead>
     <tr><td>.proto Type</td><td>Go</td><td>C++</td><td>Rust</td><td>Java</td><td>Python</td><td>C#</td></tr>
   </thead>
-  <tbody class="table-group-divider"> 
+  <tbody class="table-group-divider">
       <tr id="double">
         <td class="fw-bold">double</td>
         <td>float64</td>
@@ -3292,7 +3292,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>double</td>
         <td>float</td>
         <td>double</td>
-      </tr> 
+      </tr>
       <tr id="float">
         <td class="fw-bold">float</td>
         <td>float32</td>
@@ -3301,7 +3301,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>float</td>
         <td>float</td>
         <td>float</td>
-      </tr> 
+      </tr>
       <tr id="int32">
         <td class="fw-bold">int32</td>
         <td>int32</td>
@@ -3310,7 +3310,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>int</td>
         <td>int</td>
         <td>int</td>
-      </tr> 
+      </tr>
       <tr id="int64">
         <td class="fw-bold">int64</td>
         <td>int64</td>
@@ -3319,7 +3319,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>long</td>
         <td>int/long</td>
         <td>long</td>
-      </tr> 
+      </tr>
       <tr id="uint32">
         <td class="fw-bold">uint32</td>
         <td>uint32</td>
@@ -3328,7 +3328,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>int</td>
         <td>int/long</td>
         <td>uint</td>
-      </tr> 
+      </tr>
       <tr id="uint64">
         <td class="fw-bold">uint64</td>
         <td>uint64</td>
@@ -3337,7 +3337,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>long</td>
         <td>int/long</td>
         <td>ulong</td>
-      </tr> 
+      </tr>
       <tr id="sint32">
         <td class="fw-bold">sint32</td>
         <td>int32</td>
@@ -3346,7 +3346,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>int</td>
         <td>int</td>
         <td>int</td>
-      </tr> 
+      </tr>
       <tr id="sint64">
         <td class="fw-bold">sint64</td>
         <td>int64</td>
@@ -3355,7 +3355,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>long</td>
         <td>int/long</td>
         <td>long</td>
-      </tr> 
+      </tr>
       <tr id="fixed32">
         <td class="fw-bold">fixed32</td>
         <td>uint32</td>
@@ -3364,7 +3364,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>int</td>
         <td>int</td>
         <td>uint</td>
-      </tr> 
+      </tr>
       <tr id="fixed64">
         <td class="fw-bold">fixed64</td>
         <td>uint64</td>
@@ -3373,7 +3373,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>long</td>
         <td>int/long</td>
         <td>ulong</td>
-      </tr> 
+      </tr>
       <tr id="sfixed32">
         <td class="fw-bold">sfixed32</td>
         <td>int32</td>
@@ -3382,7 +3382,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>int</td>
         <td>int</td>
         <td>int</td>
-      </tr> 
+      </tr>
       <tr id="sfixed64">
         <td class="fw-bold">sfixed64</td>
         <td>int64</td>
@@ -3391,7 +3391,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>long</td>
         <td>int/long</td>
         <td>long</td>
-      </tr> 
+      </tr>
       <tr id="bool">
         <td class="fw-bold">bool</td>
         <td>bool</td>
@@ -3400,7 +3400,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>boolean</td>
         <td>boolean</td>
         <td>bool</td>
-      </tr> 
+      </tr>
       <tr id="string">
         <td class="fw-bold">string</td>
         <td>string</td>
@@ -3409,7 +3409,7 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>String</td>
         <td>str/unicode</td>
         <td>string</td>
-      </tr> 
+      </tr>
       <tr id="bytes">
         <td class="fw-bold">bytes</td>
         <td>[]byte</td>
@@ -3418,6 +3418,6 @@ Note: Generating a new Ed25519 address requires the wallet password.)</li>
         <td>ByteString</td>
         <td>str</td>
         <td>ByteString</td>
-      </tr> 
+      </tr>
   </tbody>
 </table>

--- a/www/grpc/gen/docs/json-rpc.md
+++ b/www/grpc/gen/docs/json-rpc.md
@@ -65,7 +65,7 @@ curl --location 'http://localhost:8545/' \
 <div id="toc-container">
   <ul class="">
   <li> Transaction Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.transaction.get_transaction">
           <span class="rpc-badge"></span> pactus.transaction.get_transaction</a>
@@ -101,7 +101,7 @@ curl --location 'http://localhost:8545/' \
         </ul>
     </li>
     <li> Blockchain Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.blockchain.get_block">
           <span class="rpc-badge"></span> pactus.blockchain.get_block</a>
@@ -149,7 +149,7 @@ curl --location 'http://localhost:8545/' \
         </ul>
     </li>
     <li> Network Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.network.get_network_info">
           <span class="rpc-badge"></span> pactus.network.get_network_info</a>
@@ -161,7 +161,7 @@ curl --location 'http://localhost:8545/' \
         </ul>
     </li>
     <li> Utils Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.utils.sign_message_with_private_key">
           <span class="rpc-badge"></span> pactus.utils.sign_message_with_private_key</a>
@@ -173,7 +173,7 @@ curl --location 'http://localhost:8545/' \
         </ul>
     </li>
     <li> Wallet Service
-      <ul> 
+      <ul>
         <li>
           <a href="#pactus.wallet.create_wallet">
           <span class="rpc-badge"></span> pactus.wallet.create_wallet</a>
@@ -249,7 +249,7 @@ parameters.</p>
     <td class="fw-bold">verbosity</td>
     <td> numeric</td>
     <td>
-    (Enum) The verbosity level for transaction details.
+    (Enum)The verbosity level for transaction details.
     <br>Available values:<ul>
       <li>TRANSACTION_DATA = 0 (Request transaction data only.)</li>
       <li>TRANSACTION_INFO = 1 (Request detailed transaction information.)</li>
@@ -332,7 +332,7 @@ parameters.</p>
         <td class="fw-bold">transaction.payload_type</td>
         <td> numeric</td>
         <td>
-        (Enum) The type of transaction payload.
+        (Enum)The type of transaction payload.
         <br>Available values:<ul>
           <li>UNKNOWN = 0 (Unknown payload type.)</li>
           <li>TRANSFER_PAYLOAD = 1 (Transfer payload type.)</li>
@@ -347,7 +347,7 @@ parameters.</p>
         <td class="fw-bold">transaction.transfer</td>
         <td> object</td>
         <td>
-        (OneOf) Transfer transaction payload.
+        (OneOf)Transfer transaction payload.
         </td>
       </tr>
          <tr>
@@ -375,7 +375,7 @@ parameters.</p>
         <td class="fw-bold">transaction.bond</td>
         <td> object</td>
         <td>
-        (OneOf) Bond transaction payload.
+        (OneOf)Bond transaction payload.
         </td>
       </tr>
          <tr>
@@ -410,7 +410,7 @@ parameters.</p>
         <td class="fw-bold">transaction.sortition</td>
         <td> object</td>
         <td>
-        (OneOf) Sortition transaction payload.
+        (OneOf)Sortition transaction payload.
         </td>
       </tr>
          <tr>
@@ -431,7 +431,7 @@ parameters.</p>
         <td class="fw-bold">transaction.unbond</td>
         <td> object</td>
         <td>
-        (OneOf) Unbond transaction payload.
+        (OneOf)Unbond transaction payload.
         </td>
       </tr>
          <tr>
@@ -445,7 +445,7 @@ parameters.</p>
         <td class="fw-bold">transaction.withdraw</td>
         <td> object</td>
         <td>
-        (OneOf) Withdraw transaction payload.
+        (OneOf)Withdraw transaction payload.
         </td>
       </tr>
          <tr>
@@ -516,7 +516,7 @@ and payload type.</p>
     <td class="fw-bold">payload_type</td>
     <td> numeric</td>
     <td>
-    (Enum) The type of transaction payload.
+    (Enum)The type of transaction payload.
     <br>Available values:<ul>
       <li>UNKNOWN = 0 (Unknown payload type.)</li>
       <li>TRANSFER_PAYLOAD = 1 (Transfer payload type.)</li>
@@ -633,28 +633,28 @@ and payload type.</p>
     <td class="fw-bold">transfer</td>
     <td> object</td>
     <td>
-    (OneOf) 
+    (OneOf)
     </td>
   </tr>
   <tr>
     <td class="fw-bold">bond</td>
     <td> object</td>
     <td>
-    (OneOf) 
+    (OneOf)
     </td>
   </tr>
   <tr>
     <td class="fw-bold">unbond</td>
     <td> object</td>
     <td>
-    (OneOf) 
+    (OneOf)
     </td>
   </tr>
   <tr>
     <td class="fw-bold">withdraw</td>
     <td> object</td>
     <td>
-    (OneOf) 
+    (OneOf)
     </td>
   </tr>
   </tbody>
@@ -1020,7 +1020,7 @@ parameters.</p>
     <td class="fw-bold">verbosity</td>
     <td> numeric</td>
     <td>
-    (Enum) The verbosity level for block information.
+    (Enum)The verbosity level for block information.
     <br>Available values:<ul>
       <li>BLOCK_DATA = 0 (Request only block data.)</li>
       <li>BLOCK_INFO = 1 (Request block information and transaction IDs.)</li>
@@ -1203,7 +1203,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].payload_type</td>
         <td> numeric</td>
         <td>
-        (Enum) The type of transaction payload.
+        (Enum)The type of transaction payload.
         <br>Available values:<ul>
           <li>UNKNOWN = 0 (Unknown payload type.)</li>
           <li>TRANSFER_PAYLOAD = 1 (Transfer payload type.)</li>
@@ -1218,7 +1218,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].transfer</td>
         <td> object</td>
         <td>
-        (OneOf) Transfer transaction payload.
+        (OneOf)Transfer transaction payload.
         </td>
       </tr>
          <tr>
@@ -1246,7 +1246,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].bond</td>
         <td> object</td>
         <td>
-        (OneOf) Bond transaction payload.
+        (OneOf)Bond transaction payload.
         </td>
       </tr>
          <tr>
@@ -1281,7 +1281,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].sortition</td>
         <td> object</td>
         <td>
-        (OneOf) Sortition transaction payload.
+        (OneOf)Sortition transaction payload.
         </td>
       </tr>
          <tr>
@@ -1302,7 +1302,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].unbond</td>
         <td> object</td>
         <td>
-        (OneOf) Unbond transaction payload.
+        (OneOf)Unbond transaction payload.
         </td>
       </tr>
          <tr>
@@ -1316,7 +1316,7 @@ BLOCK_TRANSACTIONS.
         <td class="fw-bold">txs[].withdraw</td>
         <td> object</td>
         <td>
-        (OneOf) Withdraw transaction payload.
+        (OneOf)Withdraw transaction payload.
         </td>
       </tr>
          <tr>
@@ -1691,7 +1691,7 @@ committee.
             <td class="fw-bold">instances[].votes[].type</td>
             <td> numeric</td>
             <td>
-            (Enum) The type of the vote.
+            (Enum)The type of the vote.
             <br>Available values:<ul>
               <li>VOTE_UNKNOWN = 0 (Unknown vote type.)</li>
               <li>VOTE_PREPARE = 1 (Prepare vote type.)</li>
@@ -2104,7 +2104,7 @@ address.</p>
     <td class="fw-bold">payload_type</td>
     <td> numeric</td>
     <td>
-    (Enum) The type of transactions to retrieve from the transaction pool. 0 means all
+    (Enum)The type of transactions to retrieve from the transaction pool. 0 means all
 types.
     <br>Available values:<ul>
       <li>UNKNOWN = 0 (Unknown payload type.)</li>
@@ -2178,7 +2178,7 @@ types.
         <td class="fw-bold">txs[].payload_type</td>
         <td> numeric</td>
         <td>
-        (Enum) The type of transaction payload.
+        (Enum)The type of transaction payload.
         <br>Available values:<ul>
           <li>UNKNOWN = 0 (Unknown payload type.)</li>
           <li>TRANSFER_PAYLOAD = 1 (Transfer payload type.)</li>
@@ -2193,7 +2193,7 @@ types.
         <td class="fw-bold">txs[].transfer</td>
         <td> object</td>
         <td>
-        (OneOf) Transfer transaction payload.
+        (OneOf)Transfer transaction payload.
         </td>
       </tr>
          <tr>
@@ -2221,7 +2221,7 @@ types.
         <td class="fw-bold">txs[].bond</td>
         <td> object</td>
         <td>
-        (OneOf) Bond transaction payload.
+        (OneOf)Bond transaction payload.
         </td>
       </tr>
          <tr>
@@ -2256,7 +2256,7 @@ types.
         <td class="fw-bold">txs[].sortition</td>
         <td> object</td>
         <td>
-        (OneOf) Sortition transaction payload.
+        (OneOf)Sortition transaction payload.
         </td>
       </tr>
          <tr>
@@ -2277,7 +2277,7 @@ types.
         <td class="fw-bold">txs[].unbond</td>
         <td> object</td>
         <td>
-        (OneOf) Unbond transaction payload.
+        (OneOf)Unbond transaction payload.
         </td>
       </tr>
          <tr>
@@ -2291,7 +2291,7 @@ types.
         <td class="fw-bold">txs[].withdraw</td>
         <td> object</td>
         <td>
-        (OneOf) Withdraw transaction payload.
+        (OneOf)Withdraw transaction payload.
         </td>
       </tr>
          <tr>
@@ -3112,7 +3112,7 @@ public key.</p>
     <td class="fw-bold">address_type</td>
     <td> numeric</td>
     <td>
-    (Enum) The type of address to generate.
+    (Enum)The type of address to generate.
     <br>Available values:<ul>
       <li>ADDRESS_TYPE_TREASURY = 0 (Treasury address type.
 Should not be used to generate new addresses.)</li>


### PR DESCRIPTION
## Description

Remove trailing spaces in generated and template of gRPC documentation.