### PR TITLE
chore(txpool): rename ConsumptionBlocks to ConsumptionWindow

### DIFF
--- a/txpool/config.go
+++ b/txpool/config.go
@@ -5,9 +5,11 @@ import (
 )
 
 type Config struct {
-	MaxSize           int        `toml:"max_size"`
-	Fee               *FeeConfig `toml:"fee"`
-	ConsumptionBlocks uint32     `toml:"-"` // Private configs
+	MaxSize int        `toml:"max_size"`
+	Fee     *FeeConfig `toml:"fee"`
+
+	// Private configs
+	ConsumptionWindow uint32 `toml:"-"`
 }
 
 type FeeConfig struct {
@@ -20,7 +22,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		MaxSize:           1000,
 		Fee:               DefaultFeeConfig(),
-		ConsumptionBlocks: 8640,
+		ConsumptionWindow: 8640,
 	}
 }
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -31,7 +31,7 @@ type testData struct {
 func testConfig() *Config {
 	return &Config{
 		MaxSize:           10,
-		ConsumptionBlocks: 3,
+		ConsumptionWindow: 3,
 		Fee: &FeeConfig{
 			FixedFee:   0.000001,
 			DailyLimit: 280,


### PR DESCRIPTION
## Description

For better clarity, `ConsumptionBlocks` has been renamed to `ConsumptionWindow`. This change implies that consumption is measured within a specific window.