### PR TITLE
fix(consensus): send decided vote for previous round on query vote

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -514,13 +514,13 @@ func (cs *consensus) HandleQueryVote(height uint32, round int16) *vote.Vote {
 	votes := []*vote.Vote{}
 	switch {
 	case round < cs.round:
-		// Past round: Only broadcast cp:decided votes
-		vs := cs.log.CPDecidedVoteSet(round)
+		// Past round: broadcast cp:decided votes for the previous round.
+		vs := cs.log.CPDecidedVoteSet(cs.round - 1)
 		votes = append(votes, vs.AllVotes()...)
 
 	case round == cs.round:
 		// Current round
-		m := cs.log.RoundMessages(round)
+		m := cs.log.RoundMessages(cs.round)
 		votes = append(votes, m.AllVotes()...)
 
 	case round > cs.round:

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -514,7 +514,8 @@ func (cs *consensus) HandleQueryVote(height uint32, round int16) *vote.Vote {
 	votes := []*vote.Vote{}
 	switch {
 	case round < cs.round:
-		// Past round: broadcast cp:decided votes for the previous round.
+		// A validator requests votes for past rounds.
+		// Sending cp:decide for the last round helps them advance to the current round.
 		vs := cs.log.CPDecidedVoteSet(cs.round - 1)
 		votes = append(votes, vs.AllVotes()...)
 

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -399,8 +399,7 @@ func (td *testData) makeProposal(t *testing.T, height uint32, round int16) *prop
 }
 
 func (td *testData) makeMainVoteCertificate(t *testing.T,
-	height uint32, round, cpRound int16,
-) *certificate.VoteCertificate {
+	height uint32, round, cpRound int16) *certificate.VoteCertificate {
 	t.Helper()
 
 	// === make valid certificate

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -399,7 +399,8 @@ func (td *testData) makeProposal(t *testing.T, height uint32, round int16) *prop
 }
 
 func (td *testData) makeMainVoteCertificate(t *testing.T,
-	height uint32, round, cpRound int16) *certificate.VoteCertificate {
+	height uint32, round, cpRound int16,
+) *certificate.VoteCertificate {
 	t.Helper()
 
 	// === make valid certificate

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -623,9 +623,6 @@ func TestHandleQueryVote(t *testing.T) {
 	assert.Nil(t, td.consP.HandleQueryVote(height, 0))
 
 	// Add some votes for Round 0
-	td.addPrepareVote(td.consP, td.RandHash(), height, 0, tIndexX)
-	td.addCPPreVote(td.consP, hash.UndefHash, height, 0, vote.CPValueYes,
-		&vote.JustInitYes{}, tIndexX)
 	td.addCPDecidedVote(td.consP, hash.UndefHash, height, 0, vote.CPValueYes,
 		&vote.JustDecided{QCert: td.makeMainVoteCertificate(t, height, 0, cpRound)}, tIndexY)
 

--- a/consensus/cp.go
+++ b/consensus/cp.go
@@ -36,7 +36,7 @@ func (*changeProposer) checkCPValue(vote *vote.Vote, allowedValues ...vote.CPVal
 	}
 }
 
-func (cp *changeProposer) checkJustInitZero(just vote.Just, blockHash hash.Hash) error {
+func (cp *changeProposer) checkJustInitNo(just vote.Just, blockHash hash.Hash) error {
 	j, ok := just.(*vote.JustInitNo)
 	if !ok {
 		return InvalidJustificationError{
@@ -56,7 +56,7 @@ func (cp *changeProposer) checkJustInitZero(just vote.Just, blockHash hash.Hash)
 	return nil
 }
 
-func (*changeProposer) checkJustInitOne(just vote.Just) error {
+func (*changeProposer) checkJustInitYes(just vote.Just) error {
 	_, ok := just.(*vote.JustInitYes)
 	if !ok {
 		return InvalidJustificationError{
@@ -150,12 +150,12 @@ func (cp *changeProposer) checkJustMainVoteConflict(just vote.Just,
 	}
 
 	if cpRound == 0 {
-		err := cp.checkJustInitZero(j.JustNo, blockHash)
+		err := cp.checkJustInitNo(j.JustNo, blockHash)
 		if err != nil {
 			return err
 		}
 
-		err = cp.checkJustInitOne(j.JustYes)
+		err = cp.checkJustInitYes(j.JustYes)
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ func (cp *changeProposer) checkJustPreVote(vte *vote.Vote) error {
 				return err
 			}
 
-			return cp.checkJustInitZero(just, vte.BlockHash())
+			return cp.checkJustInitNo(just, vte.BlockHash())
 
 		case vote.JustTypeInitYes:
 			err := cp.checkCPValue(vte, vote.CPValueYes)
@@ -209,7 +209,7 @@ func (cp *changeProposer) checkJustPreVote(vte *vote.Vote) error {
 				return err
 			}
 
-			return cp.checkJustInitOne(just)
+			return cp.checkJustInitYes(just)
 		default:
 			return InvalidJustificationError{
 				JustType: just.Type(),


### PR DESCRIPTION
## Description

Upon receiving a QueryVote, if there is any decided vote for the last round, it should be broadcasted. Previously, it broadcast the decided vote for the query round. This helps validators who are behind the network to sync faster.