### PR TITLE
feat(wallet): create single ed25519 reward address for all validators

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -584,8 +584,17 @@ func MakeRewardAddresses(walletInstance *wallet.Wallet,
 
 			addrInfo := walletInstance.AddressFromPath(accAddrPath.String())
 			if addrInfo == nil {
-				return nil, fmt.Errorf("unable to find reward address for: %s [%s]",
-					valAddrsInfo[i].Address, accAddrPath)
+				accAddrPath = addresspath.NewPath(
+					vault.PurposeBIP44+hdkeychain.HardenedKeyStart,
+					valAddrPath.CoinType(),
+					uint32(crypto.AddressTypeEd25519Account)+hdkeychain.HardenedKeyStart,
+					0+hdkeychain.HardenedKeyStart)
+
+				addrInfo = walletInstance.AddressFromPath(accAddrPath.String())
+				if addrInfo == nil {
+					return nil, fmt.Errorf("unable to find reward address for: %s [%s]",
+						valAddrsInfo[i].Address, accAddrPath)
+				}
 			}
 
 			addr, _ := crypto.AddressFromString(addrInfo.Address)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -316,7 +316,7 @@ func CreateNode(numValidators int, chain genesis.ChainType, workingDir string,
 	if err != nil {
 		return nil, "", err
 	}
-	rewardAddress := addressInfo.Address
+	rewardAddr := addressInfo.Address
 
 	confPath := PactusConfigPath(workingDir)
 	genPath := PactusGenesisPath(workingDir)
@@ -364,12 +364,12 @@ func CreateNode(numValidators int, chain genesis.ChainType, workingDir string,
 		return nil, "", err
 	}
 
-	return validatorAddrs, rewardAddress, nil
+	return validatorAddrs, rewardAddr, nil
 }
 
 // StartNode starts the node from the given working directory.
 // The passwordFetcher will be used to fetch the password for the default_wallet if it is encrypted.
-// It returns an error if the genesis doc or default_wallet can't be found inside the working directory.
+// It returns an error if the genesis doc or default_wallet can't be found inside the working directory.1234
 // TODO: write test for me.
 func StartNode(workingDir string, passwordFetcher func(*wallet.Wallet) (string, bool)) (
 	*node.Node, *wallet.Wallet, error,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -369,7 +369,7 @@ func CreateNode(numValidators int, chain genesis.ChainType, workingDir string,
 
 // StartNode starts the node from the given working directory.
 // The passwordFetcher will be used to fetch the password for the default_wallet if it is encrypted.
-// It returns an error if the genesis doc or default_wallet can't be found inside the working directory.1234
+// It returns an error if the genesis doc or default_wallet can't be found inside the working directory.
 // TODO: write test for me.
 func StartNode(workingDir string, passwordFetcher func(*wallet.Wallet) (string, bool)) (
 	*node.Node, *wallet.Wallet, error,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -312,11 +312,11 @@ func CreateNode(numValidators int, chain genesis.ChainType, workingDir string,
 	}
 
 	addressInfo, err := walletInstance.NewEd25519AccountAddress(
-		"Reward address ", "")
+		"Reward address", "")
 	if err != nil {
 		return nil, "", err
 	}
-	rewardAddrs := addressInfo.Address
+	rewardAddress := addressInfo.Address
 
 	confPath := PactusConfigPath(workingDir)
 	genPath := PactusGenesisPath(workingDir)
@@ -364,7 +364,7 @@ func CreateNode(numValidators int, chain genesis.ChainType, workingDir string,
 		return nil, "", err
 	}
 
-	return validatorAddrs, rewardAddrs, nil
+	return validatorAddrs, rewardAddress, nil
 }
 
 // StartNode starts the node from the given working directory.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -299,7 +299,7 @@ func TestCreateNode(t *testing.T) {
 		mnemonic       string
 		withErr        bool
 		validatorAddrs []string
-		rewardAddrs    []string
+		rewardAddrs    string
 	}{
 		{
 			name:           "Create node for Mainnet",
@@ -308,7 +308,7 @@ func TestCreateNode(t *testing.T) {
 			workingDir:     util.TempDirPath(),
 			mnemonic:       "legal winner thank year wave sausage worth useful legal winner thank yellow",
 			validatorAddrs: []string{"pc1pqpu5tkuctj6ecxjs85f9apm802hhc65amwhuyw"},
-			rewardAddrs:    []string{"pc1zmpnme0xrgzhml77e3k70ey9hwwwsfed6l04pqc"},
+			rewardAddrs:    "pc1rkg0nhswqj85wnz9sm0g9kfkxj68lfx9lhftl8n",
 			withErr:        false,
 		},
 		{
@@ -318,7 +318,7 @@ func TestCreateNode(t *testing.T) {
 			workingDir:     util.TempDirPath(),
 			mnemonic:       "legal winner thank year wave sausage worth useful legal winner thank yellow",
 			validatorAddrs: []string{"tpc1p54ex6jvqkz6qyld5wgm77qm7walgy664hxz2pc"},
-			rewardAddrs:    []string{"tpc1zlkjrgfkrh7f9enpt730tp5vgx7tgtqzplhfksa"},
+			rewardAddrs:    "tpc1rps3xncfvepre5w754xtxxqmrmhwuackjvaft5y",
 			withErr:        false,
 		},
 
@@ -334,13 +334,8 @@ func TestCreateNode(t *testing.T) {
 				"tpc1pe5px2dddn6g4zgnu3wpwgrqpdjrufvda57a4wm",
 				"tpc1p8yyhysp380j9q9gxa6vlhstgkd94238kunttpr",
 			},
-			rewardAddrs: []string{
-				"tpc1zlkjrgfkrh7f9enpt730tp5vgx7tgtqzplhfksa",
-				"tpc1ztzwc9x98j88wctmzm5t09z592lqw0sqc3rn6lu",
-				"tpc1zslef8hjkwqxdcekcqxra6djgjr5gryrj8l3fyf",
-				"tpc1zru3xxmgz5dqqkv0mesqq3t3luepzg3e6jeqkeu",
-			},
-			withErr: false,
+			rewardAddrs: "tpc1rps3xncfvepre5w754xtxxqmrmhwuackjvaft5y",
+			withErr:     false,
 		},
 		{
 			name:           "Localnet with one validator",
@@ -349,7 +344,7 @@ func TestCreateNode(t *testing.T) {
 			workingDir:     util.TempDirPath(),
 			mnemonic:       "legal winner thank year wave sausage worth useful legal winner thank yellow",
 			validatorAddrs: nil,
-			rewardAddrs:    nil,
+			rewardAddrs:    "",
 			withErr:        true,
 		},
 		{
@@ -359,7 +354,7 @@ func TestCreateNode(t *testing.T) {
 			workingDir:     util.TempDirPath(),
 			mnemonic:       "",
 			validatorAddrs: nil,
-			rewardAddrs:    nil,
+			rewardAddrs:    "",
 			withErr:        true,
 		},
 	}

--- a/cmd/daemon/init.go
+++ b/cmd/daemon/init.go
@@ -109,7 +109,7 @@ func buildInitCmd(parentCmd *cobra.Command) {
 		}
 		cmd.PrintLine()
 
-		cmd.PrintInfoMsgBoldf("Reward addresses:")
+		cmd.PrintInfoMsgBoldf("Reward address:")
 		cmd.PrintInfoMsgf("%s", rewardAddrs)
 
 		cmd.PrintLine()

--- a/cmd/daemon/init.go
+++ b/cmd/daemon/init.go
@@ -110,9 +110,7 @@ func buildInitCmd(parentCmd *cobra.Command) {
 		cmd.PrintLine()
 
 		cmd.PrintInfoMsgBoldf("Reward addresses:")
-		for i, addr := range rewardAddrs {
-			cmd.PrintInfoMsgf("%v- %s", i+1, addr)
-		}
+		cmd.PrintInfoMsgf("%s", rewardAddrs)
 
 		cmd.PrintLine()
 		cmd.PrintInfoMsgBoldf("Network: %v", chain.String())

--- a/cmd/gtk/startup_assistant.go
+++ b/cmd/gtk/startup_assistant.go
@@ -333,9 +333,7 @@ func startupAssistant(workingDir string, chainType genesis.ChainType) bool {
 			}
 
 			nodeInfo += "\nReward addresses:\n"
-			for i, addr := range rewardAddrs {
-				nodeInfo += fmt.Sprintf("%v- %s\n", i+1, addr)
-			}
+			nodeInfo += fmt.Sprintf("%s", rewardAddrs)
 
 			setTextViewContent(txtNodeInfo, nodeInfo)
 		}

--- a/cmd/gtk/startup_assistant.go
+++ b/cmd/gtk/startup_assistant.go
@@ -332,7 +332,7 @@ func startupAssistant(workingDir string, chainType genesis.ChainType) bool {
 				nodeInfo += fmt.Sprintf("%v- %s\n", i+1, addr)
 			}
 
-			nodeInfo += "\nReward addresses:\n"
+			nodeInfo += "\nReward address:\n"
 			nodeInfo += fmt.Sprintf("%s", rewardAddrs)
 
 			setTextViewContent(txtNodeInfo, nodeInfo)


### PR DESCRIPTION
## Description
In these changes, we create 1 reward address (ed25519) instead 7-32 addresses for all validators when initializing a node.

## Related issue(s)

If this Pull Request is related to an issue, mention it here.
- Fixes #1556