### PR TITLE
fix(grpc): set Bond public key for decoded transaction

### DIFF
--- a/types/tx/tx_test.go
+++ b/types/tx/tx_test.go
@@ -94,7 +94,7 @@ func TestBasicCheck(t *testing.T) {
 
 	t.Run("LockTime is not defined", func(t *testing.T) {
 		trx := tx.NewTransferTx(0,
-			ts.RandAccAddress(), ts.RandAccAddress(), ts.RandAmount(), ts.RandAmount())
+			ts.RandAccAddress(), ts.RandAccAddress(), ts.RandAmount(), ts.RandFee())
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -106,7 +106,7 @@ func TestBasicCheck(t *testing.T) {
 		bigMemo := strings.Repeat("a", 65)
 
 		trx := tx.NewTransferTx(ts.RandHeight(),
-			ts.RandAccAddress(), ts.RandAccAddress(), ts.RandAmount(), ts.RandAmount(), tx.WithMemo(bigMemo))
+			ts.RandAccAddress(), ts.RandAccAddress(), ts.RandAmount(), ts.RandFee(), tx.WithMemo(bigMemo))
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -117,7 +117,7 @@ func TestBasicCheck(t *testing.T) {
 	t.Run("Invalid payload, Should returns error", func(t *testing.T) {
 		invAddr := ts.RandAccAddress()
 		invAddr[0] = 4
-		trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), invAddr, 1e9, ts.RandAmount())
+		trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), invAddr, 1e9, ts.RandFee())
 
 		err := trx.BasicCheck()
 		assert.ErrorIs(t, err, tx.BasicCheckError{
@@ -430,7 +430,7 @@ func TestFlagNotSigned(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	trx := tx.NewTransferTx(ts.RandHeight(), ts.RandAccAddress(), ts.RandAccAddress(),
-		ts.RandAmount(), ts.RandAmount())
+		ts.RandAmount(), ts.RandFee())
 	assert.False(t, trx.IsSigned(), "FlagNotSigned should not be set for new transactions")
 
 	trx.SetSignature(ts.RandBLSSignature())
@@ -444,7 +444,7 @@ func TestInvalidSignerSignature(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	trx := tx.NewTransferTx(ts.RandHeight(), crypto.TreasuryAddress, ts.RandAccAddress(),
-		ts.RandAmount(), ts.RandAmount())
+		ts.RandAmount(), ts.RandFee())
 	trx.SetSignature(ts.RandBLSSignature())
 
 	bytes, _ := trx.Bytes()
@@ -456,7 +456,7 @@ func TestInvalidSignerPublicKey(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	trx := tx.NewTransferTx(ts.RandHeight(), crypto.TreasuryAddress, ts.RandAccAddress(),
-		ts.RandAmount(), ts.RandAmount())
+		ts.RandAmount(), ts.RandFee())
 	pub, _ := ts.RandBLSKeyPair()
 	trx.SetSignature(ts.RandBLSSignature())
 	trx.SetPublicKey(pub)

--- a/util/testsuite/testsuite.go
+++ b/util/testsuite/testsuite.go
@@ -157,15 +157,15 @@ func (ts *TestSuite) RandRound() int16 {
 	return ts.RandInt16(10)
 }
 
-// RandAmount returns a random amount between [0, maxAmount).
-// If maxAmount is not set, it defaults to 1000e9.
-func (ts *TestSuite) RandAmount(maxAmount ...amount.Amount) amount.Amount {
-	max := amount.Amount(1000e9) // default max amount
-	if len(maxAmount) > 0 {
-		max = maxAmount[0]
+// RandAmount returns a random amount between [0, max).
+// If max is not set, it defaults to 1000e9.
+func (ts *TestSuite) RandAmount(max ...amount.Amount) amount.Amount {
+	maxAmt := amount.Amount(1000e9) // default max amount
+	if len(max) > 0 {
+		maxAmt = max[0]
 	}
 
-	return ts.RandAmountRange(0, max)
+	return ts.RandAmountRange(0, maxAmt)
 }
 
 // RandAmountRange returns a random amount between [min, max).
@@ -175,15 +175,15 @@ func (ts *TestSuite) RandAmountRange(min, max amount.Amount) amount.Amount {
 	return amt + min
 }
 
-// RandAmount returns a random amount between [0, maxAmount).
-// If maxAmount is not set, it defaults to 1e9.
-func (ts *TestSuite) RandFee(maxFee ...amount.Amount) amount.Amount {
-	max := amount.Amount(1e9) // default max fee
-	if len(maxFee) > 0 {
-		max = maxFee[0]
+// RandFee returns a random fee between [0, max).
+// If max is not set, it defaults to 1e9.
+func (ts *TestSuite) RandFee(max ...amount.Amount) amount.Amount {
+	maxFee := amount.Amount(1e9) // default max fee
+	if len(max) > 0 {
+		maxFee = max[0]
 	}
 
-	return ts.RandAmountRange(0, max)
+	return ts.RandAmountRange(0, maxFee)
 }
 
 // RandBytes returns a slice of random bytes of the given length.

--- a/www/grpc/transaction.go
+++ b/www/grpc/transaction.go
@@ -267,13 +267,21 @@ func transactionToProto(trx *tx.Tx) *pactus.TransactionInfo {
 		}
 	case payload.TypeBond:
 		pld := trx.Payload().(*payload.BondPayload)
+
+		publicKeyStr := ""
+		if pld.PublicKey != nil {
+			publicKeyStr = pld.PublicKey.String()
+		}
+
 		trxInfo.Payload = &pactus.TransactionInfo_Bond{
 			Bond: &pactus.PayloadBond{
-				Sender:   pld.From.String(),
-				Receiver: pld.To.String(),
-				Stake:    pld.Stake.ToNanoPAC(),
+				Sender:    pld.From.String(),
+				Receiver:  pld.To.String(),
+				Stake:     pld.Stake.ToNanoPAC(),
+				PublicKey: publicKeyStr,
 			},
 		}
+
 	case payload.TypeSortition:
 		pld := trx.Payload().(*payload.SortitionPayload)
 		trxInfo.Payload = &pactus.TransactionInfo_Sortition{


### PR DESCRIPTION
## Description

This PR verifies whether the Bond transaction includes the public key and, if so, sets it for the proto payload. Previously, the Validator public key was missed even when the transaction has one.

## Related issue(s)

- Fixes #1576 