### PR TITLE
fix(wallet-cmd): add testnet flag for import and export address using private key

### DIFF
--- a/cmd/wallet/address.go
+++ b/cmd/wallet/address.go
@@ -139,12 +139,19 @@ func buildPrivateKeyCmd(parentCmd *cobra.Command) {
 		Short: "displays the private key for a specified address",
 		Args:  cobra.ExactArgs(1),
 	}
+
+	testnetOpt := privateKeyCmd.Flags().Bool("testnet", false,
+		"get address private key for the testnet environment")
 	parentCmd.AddCommand(privateKeyCmd)
 
 	passOpt := addPasswordOption(privateKeyCmd)
 
 	privateKeyCmd.Run = func(_ *cobra.Command, args []string) {
 		addr := args[0]
+
+		if *testnetOpt {
+			crypto.ToTestnetHRP()
+		}
 
 		wlt, err := openWallet()
 		cmd.FatalErrorCheck(err)
@@ -165,6 +172,7 @@ func buildPublicKeyCmd(parentCmd *cobra.Command) {
 		Short: "displays the public key for a specified address",
 		Args:  cobra.ExactArgs(1),
 	}
+
 	parentCmd.AddCommand(publicKeyCmd)
 
 	publicKeyCmd.Run = func(_ *cobra.Command, args []string) {
@@ -197,7 +205,7 @@ func buildImportPrivateKeyCmd(parentCmd *cobra.Command) {
 	parentCmd.AddCommand(importPrivateKeyCmd)
 
 	testnetOpt := importPrivateKeyCmd.Flags().Bool("testnet", false,
-		"create a wallet for the testnet environment")
+		"import address for the testnet environment")
 	passOpt := addPasswordOption(importPrivateKeyCmd)
 
 	importPrivateKeyCmd.Run = func(_ *cobra.Command, _ []string) {

--- a/cmd/wallet/address.go
+++ b/cmd/wallet/address.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/pactus-project/pactus/cmd"
+	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/bls"
 	"github.com/pactus-project/pactus/wallet"
 	"github.com/pactus-project/pactus/wallet/vault"
@@ -195,10 +196,16 @@ func buildImportPrivateKeyCmd(parentCmd *cobra.Command) {
 	}
 	parentCmd.AddCommand(importPrivateKeyCmd)
 
+	testnetOpt := importPrivateKeyCmd.Flags().Bool("testnet", false,
+		"create a wallet for the testnet environment")
 	passOpt := addPasswordOption(importPrivateKeyCmd)
 
 	importPrivateKeyCmd.Run = func(_ *cobra.Command, _ []string) {
 		prvStr := cmd.PromptInput("Private Key")
+
+		if *testnetOpt {
+			crypto.ToTestnetHRP()
+		}
 
 		wlt, err := openWallet()
 		cmd.FatalErrorCheck(err)

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -12,3 +12,12 @@ var (
 	// XPrivateKeyHRP is the Human Readable Part (HRP) for extended private key.
 	XPrivateKeyHRP = "xsecret"
 )
+
+// ToTestnetHRP makes HRPs testnet specified.
+func ToTestnetHRP() {
+	AddressHRP = "tpc"
+	PublicKeyHRP = "tpublic"
+	PrivateKeyHRP = "tsecret"
+	XPublicKeyHRP = "txpublic"
+	XPrivateKeyHRP = "txsecret"
+}


### PR DESCRIPTION
## Description

This PR adds testnet flag for import and export address using private key.

## Related issue(s)

- Fixes https://github.com/pactus-project/pactus/issues/1582