### PR TITLE
refactor(cmd): get first account address from wallet as reward address

### DIFF
--- a/wallet/vault/vault.go
+++ b/wallet/vault/vault.go
@@ -239,7 +239,6 @@ func (v *Vault) AddressInfos() []AddressInfo {
 
 	v.sortAddressesByAddressIndex(addrs...)
 	v.sortAddressesByAddressType(addrs...)
-	v.sortAddressesByPurpose(addrs...)
 
 	return addrs
 }

--- a/wallet/vault/vault.go
+++ b/wallet/vault/vault.go
@@ -239,6 +239,7 @@ func (v *Vault) AddressInfos() []AddressInfo {
 
 	v.sortAddressesByAddressIndex(addrs...)
 	v.sortAddressesByAddressType(addrs...)
+	v.sortAddressesByPurpose(addrs...)
 
 	return addrs
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -181,6 +181,10 @@ func (w *Wallet) Name() string {
 	return path.Base(w.path)
 }
 
+func (w *Wallet) CoinType() uint32 {
+	return w.store.Vault.CoinType
+}
+
 func (w *Wallet) IsOffline() bool {
 	return len(w.grpcClient.servers) == 0
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -646,3 +646,10 @@ func TestTotalStake(t *testing.T) {
 
 	require.Equal(t, stake, val1.Stake()+val2.Stake())
 }
+
+func TestCoinType(t *testing.T) {
+	td := setup(t)
+	defer td.Close()
+
+	assert.Equal(t, td.wallet.CoinType(), uint32(21888))
+}


### PR DESCRIPTION
## Description

This PR introduces a change in behavior for obtaining the reward address.
If the reward address is not specified in the config, it attempts to retrieve it from the wallet.
The first Ed25519 account address is considered as the reward address, and if not available, the first BLS account address is used.