### PR TITLE
test(types): refactor account and validator tests

### DIFF
--- a/committee/committee_test.go
+++ b/committee/committee_test.go
@@ -36,11 +36,11 @@ func TestProposer(t *testing.T) {
 func TestInvalidProposerJoinAndLeave(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val1, _ := ts.GenerateTestValidator(0)
-	val2, _ := ts.GenerateTestValidator(1)
-	val3, _ := ts.GenerateTestValidator(2)
-	val4, _ := ts.GenerateTestValidator(3)
-	val5, _ := ts.GenerateTestValidator(4)
+	val1 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(0))
+	val2 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(1))
+	val3 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(2))
+	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(3))
+	val5 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(4))
 
 	cmt, err := committee.NewCommittee([]*validator.Validator{val1, val2, val3, val4}, 4, val5.Address())
 	assert.Error(t, err)
@@ -50,13 +50,13 @@ func TestInvalidProposerJoinAndLeave(t *testing.T) {
 func TestProposerMove(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val1, _ := ts.GenerateTestValidator(1)
-	val2, _ := ts.GenerateTestValidator(2)
-	val3, _ := ts.GenerateTestValidator(3)
-	val4, _ := ts.GenerateTestValidator(4)
-	val5, _ := ts.GenerateTestValidator(5)
-	val6, _ := ts.GenerateTestValidator(6)
-	val7, _ := ts.GenerateTestValidator(7)
+	val1 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(1))
+	val2 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(2))
+	val3 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(3))
+	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(4))
+	val5 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(5))
+	val6 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(6))
+	val7 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(7))
 
 	cmt, err := committee.NewCommittee(
 		[]*validator.Validator{val1, val2, val3, val4, val5, val6, val7}, 7, val1.Address())
@@ -97,10 +97,10 @@ func TestProposerMove(t *testing.T) {
 func TestValidatorConsistency(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val1, _ := ts.GenerateTestValidator(1)
-	val2, _ := ts.GenerateTestValidator(2)
-	val3, _ := ts.GenerateTestValidator(3)
-	val4, _ := ts.GenerateTestValidator(4)
+	val1 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(1))
+	val2 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(2))
+	val3 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(3))
+	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(4))
 
 	cmt, _ := committee.NewCommittee([]*validator.Validator{val1, val2, val3, val4}, 4, val1.Address())
 
@@ -115,13 +115,13 @@ func TestValidatorConsistency(t *testing.T) {
 func TestProposerJoin(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val1, _ := ts.GenerateTestValidator(1)
-	val2, _ := ts.GenerateTestValidator(2)
-	val3, _ := ts.GenerateTestValidator(3)
-	val4, _ := ts.GenerateTestValidator(4)
-	val5, _ := ts.GenerateTestValidator(5)
-	val6, _ := ts.GenerateTestValidator(6)
-	val7, _ := ts.GenerateTestValidator(7)
+	val1 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(1))
+	val2 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(2))
+	val3 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(3))
+	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(4))
+	val5 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(5))
+	val6 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(6))
+	val7 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(7))
 
 	cmt, err := committee.NewCommittee([]*validator.Validator{val1, val2, val3, val4}, 7, val1.Address())
 	assert.NoError(t, err)
@@ -315,10 +315,10 @@ func TestProposerJoinAndLeave(t *testing.T) {
 func TestIsProposer(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val1, _ := ts.GenerateTestValidator(0)
-	val2, _ := ts.GenerateTestValidator(1)
-	val3, _ := ts.GenerateTestValidator(2)
-	val4, _ := ts.GenerateTestValidator(3)
+	val1 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(0))
+	val2 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(1))
+	val3 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(2))
+	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(3))
 
 	cmt, err := committee.NewCommittee([]*validator.Validator{val1, val2, val3, val4}, 4, val1.Address())
 	assert.NoError(t, err)
@@ -334,10 +334,10 @@ func TestIsProposer(t *testing.T) {
 func TestCommitters(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val1, _ := ts.GenerateTestValidator(0)
-	val2, _ := ts.GenerateTestValidator(1)
-	val3, _ := ts.GenerateTestValidator(2)
-	val4, _ := ts.GenerateTestValidator(3)
+	val1 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(0))
+	val2 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(1))
+	val3 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(2))
+	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(3))
 
 	cmt, err := committee.NewCommittee([]*validator.Validator{val1, val2, val3, val4}, 4, val1.Address())
 	assert.NoError(t, err)
@@ -347,13 +347,13 @@ func TestCommitters(t *testing.T) {
 func TestSortJoined(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val1, _ := ts.GenerateTestValidator(0)
-	val2, _ := ts.GenerateTestValidator(1)
-	val3, _ := ts.GenerateTestValidator(2)
-	val4, _ := ts.GenerateTestValidator(3)
-	val5, _ := ts.GenerateTestValidator(4)
-	val6, _ := ts.GenerateTestValidator(5)
-	val7, _ := ts.GenerateTestValidator(6)
+	val1 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(0))
+	val2 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(1))
+	val3 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(2))
+	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(3))
+	val5 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(4))
+	val6 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(5))
+	val7 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(6))
 
 	cmt, err := committee.NewCommittee([]*validator.Validator{val1, val2, val3, val4}, 17, val1.Address())
 	assert.NoError(t, err)
@@ -369,10 +369,10 @@ func TestTotalPower(t *testing.T) {
 
 	pub, _ := ts.RandBLSKeyPair()
 	val0 := validator.NewValidator(pub, 0) // Bootstrap validator
-	val1, _ := ts.GenerateTestValidator(0)
-	val2, _ := ts.GenerateTestValidator(1)
-	val3, _ := ts.GenerateTestValidator(2)
-	val4, _ := ts.GenerateTestValidator(3)
+	val1 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(0))
+	val2 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(1))
+	val3 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(2))
+	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithNumber(3))
 
 	cmt, err := committee.NewCommittee([]*validator.Validator{val0, val1, val2, val3, val4}, 4, val1.Address())
 	assert.NoError(t, err)

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -836,11 +836,11 @@ func TestCases(t *testing.T) {
 		round       int16
 		description string
 	}{
-		{1697898884837384019, 2, "1/3+ cp:PRE-VOTE in prepare step"},
-		{1694848907840926239, 0, "1/3+ cp:PRE-VOTE in precommit step"},
-		{1694849103290580532, 1, "Conflicting votes, cp-round=0"},
-		{1697900665869342730, 1, "Conflicting votes, cp-round=1"},
-		{1697887970998950590, 1, "consP & consB: Change Proposer, consX & consY: Commit (2 block announces)"},
+		{1697898884837384019, 2, "1/3+ cp:PRE-VOTE in Prepare step"},
+		{1694848907840926239, 2, "1/3+ cp:PRE-VOTE in Precommit step"},
+		{1732698646319341342, 1, "Conflicting cp:PRE-VOTE in cp_round 0"},
+		{1732698786369716238, 1, "Conflicting cp:PRE-VOTE in cp_round 1"},
+		{1732702222972506364, 1, "consX & consY: Change Proposer, consB & consP: Committed block"},
 	}
 
 	for no, tt := range tests {

--- a/consensus/voteset/voteset_test.go
+++ b/consensus/voteset/voteset_test.go
@@ -21,8 +21,11 @@ func setupCommittee(ts *testsuite.TestSuite, stakes ...amount.Amount) (
 	totalPower := int64(0)
 	for i, s := range stakes {
 		pub, prv := ts.RandBLSKeyPair()
-		val := validator.NewValidator(pub, int32(i))
-		val.AddToStake(s)
+		val := ts.GenerateTestValidator(
+			testsuite.ValidatorWithNumber(int32(i)),
+			testsuite.ValidatorWithPublicKey(pub),
+			testsuite.ValidatorWithStake(s),
+		)
 		valsMap[val.Address()] = val
 		totalPower += val.Power()
 		valKeys = append(valKeys, bls.NewValidatorKey(prv))

--- a/genesis/genesis_test.go
+++ b/genesis/genesis_test.go
@@ -20,11 +20,14 @@ import (
 func TestMarshaling(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	acc, prv := ts.GenerateTestAccount(0)
-	acc.AddToBalance(100000)
-	val, _ := ts.GenerateTestValidator(0)
+	acc, addr := ts.GenerateTestAccount(
+		testsuite.AccountWithNumber(0),
+		testsuite.AccountWithBalance(100000))
+	val := ts.GenerateTestValidator(
+		testsuite.ValidatorWithNumber(0),
+	)
 	gen1 := genesis.MakeGenesis(util.RoundNow(10),
-		map[crypto.Address]*account.Account{prv: acc},
+		map[crypto.Address]*account.Account{addr: acc},
 		[]*validator.Validator{val}, genesis.DefaultGenesisParams())
 	gen2 := new(genesis.Genesis)
 

--- a/sandbox/sandbox_test.go
+++ b/sandbox/sandbox_test.go
@@ -80,7 +80,7 @@ func TestAccountChange(t *testing.T) {
 	})
 
 	t.Run("Retrieve an account from store and update it", func(t *testing.T) {
-		acc, addr := td.GenerateTestAccount(td.RandInt32(10000))
+		acc, addr := td.GenerateTestAccount()
 		bal := acc.Balance()
 		td.store.UpdateAccount(addr, acc)
 
@@ -164,7 +164,7 @@ func TestValidatorChange(t *testing.T) {
 	})
 
 	t.Run("Retrieve an validator from store and update it", func(t *testing.T) {
-		val, _ := td.GenerateTestValidator(td.RandInt32(10000))
+		val := td.GenerateTestValidator()
 		addr := val.Address()
 		stk := val.Stake()
 		td.store.UpdateValidator(val)
@@ -278,14 +278,14 @@ func TestUpdateFromOutsideTheSandbox(t *testing.T) {
 
 	t.Run("Try update an account from outside the sandbox, Should panic", func(t *testing.T) {
 		assert.Panics(t, func() {
-			acc, addr := td.GenerateTestAccount(td.RandInt32(10000))
+			acc, addr := td.GenerateTestAccount()
 			td.sbx.UpdateAccount(addr, acc)
 		})
 	})
 
 	t.Run("Try update a validator from outside the sandbox, Should panic", func(t *testing.T) {
 		assert.Panics(t, func() {
-			val, _ := td.GenerateTestValidator(td.RandInt32(10000))
+			val := td.GenerateTestValidator()
 			td.sbx.UpdateValidator(val)
 		})
 	})

--- a/state/lastinfo/last_info_test.go
+++ b/state/lastinfo/last_info_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/pactus-project/pactus/crypto"
-	"github.com/pactus-project/pactus/crypto/bls"
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/store"
 	"github.com/pactus-project/pactus/types/block"
@@ -41,7 +40,6 @@ func setup(t *testing.T) *testData {
 	pub2, _ := ts.RandBLSKeyPair()
 	pub3, _ := ts.RandBLSKeyPair()
 	pub4, prv4 := ts.RandBLSKeyPair()
-	valKey := bls.NewValidatorKey(prv4)
 
 	val0 := validator.NewValidator(pub0, 0)
 	val1 := validator.NewValidator(pub1, 1)
@@ -80,7 +78,7 @@ func setup(t *testing.T) *testData {
 		ts.RandHash(),
 		prevCert, lastSeed, val2.Address())
 
-	sig := valKey.Sign([]byte("fatdog"))
+	sig := ts.RandBLSSignature()
 	lastCert := certificate.NewBlockCertificate(lastHeight, 0)
 	lastCert.SetSignature(committers, []int32{}, sig)
 	mockStore.SaveBlock(lastBlock, lastCert)

--- a/store/account_test.go
+++ b/store/account_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/types/account"
+	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,8 +14,7 @@ import (
 func TestAccountCounter(t *testing.T) {
 	td := setup(t, nil)
 
-	num := td.RandInt32(1000)
-	acc, addr := td.GenerateTestAccount(num)
+	acc, addr := td.GenerateTestAccount()
 
 	t.Run("Add new account, should increase the total accounts number", func(t *testing.T) {
 		assert.Zero(t, td.store.TotalAccounts())
@@ -48,7 +48,7 @@ func TestAccountBatchSaving(t *testing.T) {
 	total := td.RandInt32NonZero(100)
 	t.Run("Add some accounts", func(t *testing.T) {
 		for i := int32(0); i < total; i++ {
-			acc, addr := td.GenerateTestAccount(i)
+			acc, addr := td.GenerateTestAccount(testsuite.AccountWithNumber(i))
 			td.store.UpdateAccount(addr, acc)
 		}
 		assert.NoError(t, td.store.WriteBatch())
@@ -69,7 +69,7 @@ func TestAccountByAddress(t *testing.T) {
 	var lastAddr crypto.Address
 	t.Run("Add some accounts", func(t *testing.T) {
 		for i := int32(0); i < total; i++ {
-			acc, addr := td.GenerateTestAccount(i)
+			acc, addr := td.GenerateTestAccount(testsuite.AccountWithNumber(i))
 			td.store.UpdateAccount(addr, acc)
 
 			lastAddr = addr
@@ -105,7 +105,7 @@ func TestIterateAccounts(t *testing.T) {
 	total := td.RandInt32NonZero(100)
 	hashes1 := []hash.Hash{}
 	for i := int32(0); i < total; i++ {
-		acc, addr := td.GenerateTestAccount(i)
+		acc, addr := td.GenerateTestAccount(testsuite.AccountWithNumber(i))
 		td.store.UpdateAccount(addr, acc)
 		hashes1 = append(hashes1, acc.Hash())
 	}
@@ -133,8 +133,7 @@ func TestIterateAccounts(t *testing.T) {
 func TestAccountDeepCopy(t *testing.T) {
 	td := setup(t, nil)
 
-	num := td.RandInt32(1000)
-	acc1, addr := td.GenerateTestAccount(num)
+	acc1, addr := td.GenerateTestAccount()
 	td.store.UpdateAccount(addr, acc1)
 
 	acc2, _ := td.store.Account(addr)

--- a/store/mock.go
+++ b/store/mock.go
@@ -251,14 +251,14 @@ func (*MockStore) WriteBatch() error {
 }
 
 func (m *MockStore) AddTestValidator() *validator.Validator {
-	val, _ := m.ts.GenerateTestValidator(m.ts.RandInt32(10000))
+	val := m.ts.GenerateTestValidator()
 	m.UpdateValidator(val)
 
 	return val
 }
 
 func (m *MockStore) AddTestAccount() (*account.Account, crypto.Address) {
-	acc, addr := m.ts.GenerateTestAccount(m.ts.RandInt32(10000))
+	acc, addr := m.ts.GenerateTestAccount()
 	m.UpdateAccount(addr, acc)
 
 	return acc, addr

--- a/store/validator_test.go
+++ b/store/validator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/types/validator"
+	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,8 +14,7 @@ import (
 func TestValidatorCounter(t *testing.T) {
 	td := setup(t, nil)
 
-	num := td.RandInt32(1000)
-	val, _ := td.GenerateTestValidator(num)
+	val := td.GenerateTestValidator()
 
 	t.Run("Add new validator, should increase the total validators number", func(t *testing.T) {
 		assert.Zero(t, td.store.TotalValidators())
@@ -36,7 +36,7 @@ func TestValidatorCounter(t *testing.T) {
 		val1, err := td.store.Validator(val.Address())
 		assert.NoError(t, err)
 
-		val2, err := td.store.ValidatorByNumber(num)
+		val2, err := td.store.ValidatorByNumber(val.Number())
 		assert.NoError(t, err)
 
 		assert.Equal(t, val1.Hash(), val2.Hash())
@@ -51,7 +51,7 @@ func TestValidatorBatchSaving(t *testing.T) {
 	total := td.RandInt32NonZero(100)
 	t.Run("Add some validators", func(t *testing.T) {
 		for i := int32(0); i < total; i++ {
-			val, _ := td.GenerateTestValidator(i)
+			val := td.GenerateTestValidator(testsuite.ValidatorWithNumber(i))
 			td.store.UpdateValidator(val)
 		}
 		assert.NoError(t, td.store.WriteBatch())
@@ -72,7 +72,7 @@ func TestValidatorAddresses(t *testing.T) {
 	addrs1 := make([]crypto.Address, 0, total)
 
 	for i := int32(0); i < total; i++ {
-		val, _ := td.GenerateTestValidator(i)
+		val := td.GenerateTestValidator(testsuite.ValidatorWithNumber(i))
 		td.store.UpdateValidator(val)
 		addrs1 = append(addrs1, val.Address())
 	}
@@ -87,7 +87,7 @@ func TestValidatorByNumber(t *testing.T) {
 	total := td.RandInt32NonZero(100)
 	t.Run("Add some validators", func(t *testing.T) {
 		for i := int32(0); i < total; i++ {
-			val, _ := td.GenerateTestValidator(i)
+			val := td.GenerateTestValidator(testsuite.ValidatorWithNumber(i))
 			td.store.UpdateValidator(val)
 		}
 		assert.NoError(t, td.store.WriteBatch())
@@ -140,7 +140,7 @@ func TestValidatorByAddress(t *testing.T) {
 	total := td.RandInt32NonZero(100)
 	t.Run("Add some validators", func(t *testing.T) {
 		for i := int32(0); i < total; i++ {
-			val, _ := td.GenerateTestValidator(i)
+			val := td.GenerateTestValidator(testsuite.ValidatorWithNumber(i))
 			td.store.UpdateValidator(val)
 		}
 		assert.NoError(t, td.store.WriteBatch())
@@ -181,7 +181,7 @@ func TestIterateValidators(t *testing.T) {
 	total := td.RandInt32NonZero(100)
 	hashes1 := []hash.Hash{}
 	for i := int32(0); i < total; i++ {
-		val, _ := td.GenerateTestValidator(i)
+		val := td.GenerateTestValidator(testsuite.ValidatorWithNumber(i))
 		td.store.UpdateValidator(val)
 		hashes1 = append(hashes1, val.Hash())
 	}
@@ -210,7 +210,7 @@ func TestValidatorDeepCopy(t *testing.T) {
 	td := setup(t, nil)
 
 	num := td.RandInt32NonZero(1000)
-	val1, _ := td.GenerateTestValidator(num)
+	val1 := td.GenerateTestValidator(testsuite.ValidatorWithNumber(num))
 	td.store.UpdateValidator(val1)
 
 	val2, _ := td.store.ValidatorByNumber(num)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/pactus-project/pactus/consensus"
-	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/bls"
 	"github.com/pactus-project/pactus/genesis"
 	"github.com/pactus-project/pactus/network"
@@ -201,18 +200,18 @@ func (td *testData) addPeer(t *testing.T, status status.Status, services service
 	return pid
 }
 
-func (td *testData) addValidatorToCommittee(t *testing.T, pub crypto.PublicKey) {
+func (td *testData) addValidatorToCommittee(t *testing.T, pub *bls.PublicKey) {
 	t.Helper()
 
 	if pub == nil {
 		pub, _ = td.RandBLSKeyPair()
 	}
-	val := validator.NewValidator(pub.(*bls.PublicKey), td.RandInt32(1000))
+	val := td.GenerateTestValidator(testsuite.ValidatorWithPublicKey(pub))
 	// Note: This may not be completely accurate, but it has no harm for testing purposes.
 	val.UpdateLastSortitionHeight(td.state.TestCommittee.Proposer(0).LastSortitionHeight() + 1)
 	td.state.TestStore.UpdateValidator(val)
 	td.state.TestCommittee.Update(0, []*validator.Validator{val})
-	require.True(t, td.state.TestCommittee.Contains(pub.(*bls.PublicKey).ValidatorAddress()))
+	require.True(t, td.state.TestCommittee.Contains(pub.ValidatorAddress()))
 
 	for _, cons := range td.consMocks {
 		cons.SetActive(cons.ValKey.PublicKey().EqualsTo(pub))

--- a/types/account/account_test.go
+++ b/types/account/account_test.go
@@ -15,7 +15,7 @@ import (
 func TestFromBytes(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	acc, _ := ts.GenerateTestAccount(ts.RandInt32(10000))
+	acc, _ := ts.GenerateTestAccount()
 	bs, err := acc.Bytes()
 	require.NoError(t, err)
 	require.Equal(t, len(bs), acc.SerializeSize())
@@ -47,7 +47,7 @@ func TestDecoding(t *testing.T) {
 func TestAddToBalance(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	acc, _ := ts.GenerateTestAccount(100)
+	acc, _ := ts.GenerateTestAccount()
 	bal := acc.Balance()
 	acc.AddToBalance(1)
 	assert.Equal(t, bal+1, acc.Balance())
@@ -56,7 +56,7 @@ func TestAddToBalance(t *testing.T) {
 func TestSubtractFromBalance(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	acc, _ := ts.GenerateTestAccount(100)
+	acc, _ := ts.GenerateTestAccount()
 	bal := acc.Balance()
 	acc.SubtractFromBalance(1)
 	assert.Equal(t, bal-1, acc.Balance())
@@ -65,9 +65,10 @@ func TestSubtractFromBalance(t *testing.T) {
 func TestClone(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	acc, _ := ts.GenerateTestAccount(100)
+	acc, _ := ts.GenerateTestAccount()
 	cloned := acc.Clone()
 	cloned.AddToBalance(1)
 
+	assert.Equal(t, acc.Number(), cloned.Number())
 	assert.NotEqual(t, acc.Balance(), cloned.Balance())
 }

--- a/types/certificate/block_certificate_test.go
+++ b/types/certificate/block_certificate_test.go
@@ -102,7 +102,7 @@ func TestBlockCertificateValidation(t *testing.T) {
 		cert.SetSignature(committers, absentees, aggSig)
 
 		invValidators := slices.Clone(validators)
-		invValidators[0], _ = ts.GenerateTestValidator(0)
+		invValidators[0] = ts.GenerateTestValidator()
 		err := cert.Validate(invValidators, blockHash)
 		assert.ErrorIs(t, err, certificate.UnexpectedCommittersError{
 			Committers: committers,

--- a/types/proposal/proposal_test.go
+++ b/types/proposal/proposal_test.go
@@ -47,7 +47,7 @@ func TestProposalSignature(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	proposerKey := ts.RandValKey()
-	prop := ts.GenerateTestProposal(ts.RandHeight(), ts.RandRound(), testsuite.WithProposerKey(proposerKey))
+	prop := ts.GenerateTestProposal(ts.RandHeight(), ts.RandRound(), testsuite.ProposalWithKey(proposerKey))
 
 	err := prop.Verify(proposerKey.PublicKey())
 	assert.NoError(t, err)

--- a/types/validator/validator_test.go
+++ b/types/validator/validator_test.go
@@ -16,7 +16,7 @@ import (
 func TestFromBytes(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val, _ := ts.GenerateTestValidator(ts.RandInt32(1000000))
+	val := ts.GenerateTestValidator()
 	val.UpdateLastBondingHeight(ts.RandHeight())
 	val.UpdateLastSortitionHeight(ts.RandHeight())
 	val.UpdateUnbondingHeight(ts.RandHeight())
@@ -70,7 +70,7 @@ func TestDecoding(t *testing.T) {
 func TestPower(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val, _ := ts.GenerateTestValidator(ts.RandInt32(1000))
+	val := ts.GenerateTestValidator()
 	val.SubtractFromStake(val.Stake())
 	assert.Equal(t, amount.Amount(0), val.Stake())
 	assert.Equal(t, int64(1), val.Power())
@@ -85,7 +85,7 @@ func TestPower(t *testing.T) {
 func TestAddToStake(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val, _ := ts.GenerateTestValidator(100)
+	val := ts.GenerateTestValidator()
 	stake := val.Stake()
 	val.AddToStake(1)
 	assert.Equal(t, stake+1, val.Stake())
@@ -94,7 +94,7 @@ func TestAddToStake(t *testing.T) {
 func TestSubtractFromStake(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val, _ := ts.GenerateTestValidator(100)
+	val := ts.GenerateTestValidator()
 	stake := val.Stake()
 	val.SubtractFromStake(1)
 	assert.Equal(t, stake-1, val.Stake())
@@ -103,9 +103,11 @@ func TestSubtractFromStake(t *testing.T) {
 func TestClone(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	val, _ := ts.GenerateTestValidator(100)
+	val := ts.GenerateTestValidator()
 	cloned := val.Clone()
 	cloned.AddToStake(1)
 
+	assert.Equal(t, val.Number(), cloned.Number())
+	assert.Equal(t, val.PublicKey(), cloned.PublicKey())
 	assert.NotEqual(t, val.Stake(), cloned.Stake())
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -8,9 +8,7 @@ import (
 	"github.com/pactus-project/pactus/crypto/bls"
 	"github.com/pactus-project/pactus/genesis"
 	"github.com/pactus-project/pactus/state"
-	"github.com/pactus-project/pactus/types/account"
 	"github.com/pactus-project/pactus/types/tx/payload"
-	"github.com/pactus-project/pactus/types/validator"
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/pactus-project/pactus/wallet"
@@ -605,11 +603,8 @@ func TestTotalBalance(t *testing.T) {
 	addr1, _ := crypto.AddressFromString(addrInfo1.Address)
 	addr3, _ := crypto.AddressFromString(addrInfo3.Address)
 
-	acc1 := account.NewAccount(td.RandInt32(1000))
-	acc3 := account.NewAccount(td.RandInt32(1000))
-
-	acc1.AddToBalance(td.RandAmount())
-	acc3.AddToBalance(td.RandAmount())
+	acc1, _ := td.GenerateTestAccount()
+	acc3, _ := td.GenerateTestAccount()
 
 	td.mockState.TestStore.Accounts[addr1] = acc1
 	td.mockState.TestStore.Accounts[addr3] = acc3
@@ -629,17 +624,11 @@ func TestTotalStake(t *testing.T) {
 	addr1, _ := crypto.AddressFromString(addrInfo1.Address)
 	addr3, _ := crypto.AddressFromString(addrInfo2.Address)
 
-	pub1, _ := bls.PublicKeyFromString(addrInfo1.PublicKey)
-	pub2, _ := bls.PublicKeyFromString(addrInfo2.PublicKey)
-
-	val1 := validator.NewValidator(pub1, 1)
-	val2 := validator.NewValidator(pub2, 2)
+	val1 := td.GenerateTestValidator()
+	val2 := td.GenerateTestValidator()
 
 	td.mockState.TestStore.Validators[addr1] = val1
 	td.mockState.TestStore.Validators[addr3] = val2
-
-	val1.AddToStake(td.RandAmount())
-	val2.AddToStake(td.RandAmount())
 
 	stake, err := td.wallet.TotalStake()
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

This PR aims to simplify and improve tests by refactoring the `GenerateTestAccount` and `GenerateTestValidator` methods. These methods now accept options to construct test accounts and validators with optional parameters.

## Related issue(s)

- Fixes #1606