### PR TITLE
fix(consensus): ignore vote verification of existing votes

### DIFF
--- a/consensus/log/log_test.go
+++ b/consensus/log/log_test.go
@@ -64,14 +64,14 @@ func TestAddInvalidVoteType(t *testing.T) {
 	log := NewLog()
 	log.MoveToNewHeight(cmt.Validators())
 
-	data, _ := hex.DecodeString("A701050218320301045820BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+	data, _ := hex.DecodeString("A7010F0218320301045820BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
 		"055501AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA06f607f6")
 	invVote := new(vote.Vote)
 	err := invVote.UnmarshalCBOR(data)
 	assert.NoError(t, err)
 
 	added, err := log.AddVote(invVote)
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected vote type: 15")
 	assert.False(t, added)
 	assert.False(t, log.HasVote(invVote.Hash()))
 }

--- a/types/vote/vote_type.go
+++ b/types/vote/vote_type.go
@@ -1,5 +1,9 @@
 package vote
 
+import (
+	"fmt"
+)
+
 type Type int
 
 const (
@@ -33,6 +37,6 @@ func (t Type) String() string {
 	case VoteTypeCPDecided:
 		return "DECIDED"
 	default:
-		return ("invalid vote type")
+		return fmt.Sprintf("%d", t)
 	}
 }


### PR DESCRIPTION
## Description

This PR checks the vote signature and verifies the vote only if it has not been verified before and does not already exist. This approach prevents redundant verification of existing votes.