### PR TITLE
fix(consensus): prevent moving to next round on decided vote

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -310,13 +310,13 @@ func (cs *consensus) AddVote(vte *vote.Vote) {
 	if added {
 		cs.logger.Info("new vote added", "vote", vte)
 
-		cs.currentState.onAddVote(vte)
-
 		if vte.Type() == vote.VoteTypeCPDecided {
 			if vte.Round() > cs.round {
 				cs.changeProposer.cpDecide(vte.Round(), vte.CPValue())
 			}
 		}
+
+		cs.currentState.onAddVote(vte)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes a potential bug in the consensus. 
When the consensus lags and receives a decided vote after a majority of precommits, it moves to the next height but erroneously increments the round by one. To address this, we first check the decided vote and then call the `onAddVote` method.