### PR TITLE
feat(sync): check expired bundles

### DIFF
--- a/sync/firewall/errors.go
+++ b/sync/firewall/errors.go
@@ -13,6 +13,9 @@ var ErrGossipMessage = errors.New("receive stream message as gossip message")
 // ErrStreamMessage is returned when a gossip message sends as stream message.
 var ErrStreamMessage = errors.New("receive gossip message as stream message")
 
+// ErrExpiredMessage is returned when we receive a expired message from a peer.
+var ErrExpiredMessage = errors.New("received an expired message")
+
 // ErrNetworkMismatch is returned when the bundle doesn't belong to this network.
 var ErrNetworkMismatch = errors.New("bundle is not for this network")
 


### PR DESCRIPTION
## Description

This PR adds a check to determine if a bundle is expired. If it is, the connection to the sender peer will be closed. This helps prevent replay attacks where an attacker attempts to inject expired messages into the network.