### PR TITLE
fix(release): upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -243,7 +243,7 @@ jobs:
         echo "${{ needs.build-gui-windows.outputs.checksums }}" >> SHA256SUMS
 
     - name: Upload SHA256SUMS as an artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sha256sums
         path: SHA256SUMS


### PR DESCRIPTION
## Description

In this PR the cosign issue in releaser has been fixed. This issued happened because of conflict in upload-artifact and download-artifact versions.

See this doc: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md#which-versions-of-the-artifacts-packages-are-compatible