### PR TITLE
fix(network): restore default message queue size in PubSub module

### DIFF
--- a/network/gossip.go
+++ b/network/gossip.go
@@ -35,11 +35,10 @@ func newGossipService(ctx context.Context, host lp2phost.Host, conf *Config,
 		lp2pps.WithMessageSignaturePolicy(lp2pps.StrictNoSign),
 		lp2pps.WithNoAuthor(),
 		lp2pps.WithMessageIdFn(MessageIDFunc),
-		lp2pps.WithPeerOutboundQueueSize(600),
 	}
 
 	if conf.IsBootstrapper {
-		// enable Peer eXchange on bootstrappers
+		// enable Peer exchange on bootstrappers
 		opts = append(opts, lp2pps.WithPeerExchange(true))
 	}
 


### PR DESCRIPTION
## Description

Restore default message queue size for pubsub, it was set much higher the default value.