### PR TITLE
feat(network): evaluate propagate policy for gossip messages

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -638,11 +638,11 @@ func TestHandleQueryVote(t *testing.T) {
 	td.enterNextRound(td.consP)
 	td.addPrepareVote(td.consP, td.RandHash(), height, 2, tIndexY)
 
-	t.Run("Query vote for round 0: should send the decided vote for the round 1", func(t *testing.T) {
+	t.Run("Query vote for round 0: should send the decided vote for the round 0", func(t *testing.T) {
 		rndVote := td.consP.HandleQueryVote(height, 0)
 		assert.Equal(t, vote.VoteTypeCPDecided, rndVote.Type())
 		assert.Equal(t, height, rndVote.Height())
-		assert.Equal(t, int16(1), rndVote.Round())
+		assert.Equal(t, int16(0), rndVote.Round())
 	})
 
 	t.Run("Query vote for round 1: should send the decided vote for the round 1", func(t *testing.T) {
@@ -652,7 +652,7 @@ func TestHandleQueryVote(t *testing.T) {
 		assert.Equal(t, int16(1), rndVote.Round())
 	})
 
-	t.Run("Query vote for round 2: should send the prepare vote for the current round", func(t *testing.T) {
+	t.Run("Query vote for round 2: should send the prepare vote for the round 2", func(t *testing.T) {
 		rndVote := td.consP.HandleQueryVote(height, 2)
 		assert.Equal(t, vote.VoteTypePrepare, rndVote.Type())
 		assert.Equal(t, height, rndVote.Height())

--- a/consensus/cp.go
+++ b/consensus/cp.go
@@ -321,7 +321,7 @@ func (cp *changeProposer) cpStrongTermination() {
 		}
 		cp.enterNewState(cp.prepareState)
 	} else if cpDecided.HasAnyVoteFor(cp.cpRound, vote.CPValueYes) {
-		cp.round += 1
+		cp.round++
 		cp.cpDecided = 1
 		cp.enterNewState(cp.proposeState)
 

--- a/network/dht.go
+++ b/network/dht.go
@@ -6,6 +6,7 @@ import (
 	lp2pdht "github.com/libp2p/go-libp2p-kad-dht"
 	lp2pcore "github.com/libp2p/go-libp2p/core"
 	lp2phost "github.com/libp2p/go-libp2p/core/host"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/pactus-project/pactus/util/logger"
 )
 
@@ -19,6 +20,9 @@ type dhtService struct {
 func newDHTService(ctx context.Context, host lp2phost.Host, protocolID lp2pcore.ProtocolID,
 	conf *Config, log *logger.SubLogger,
 ) *dhtService {
+	// A dirty code in LibP2P!!!
+	lp2pdht.DefaultBootstrapPeers = []multiaddr.Multiaddr{}
+
 	mode := lp2pdht.ModeAuto
 	if conf.IsBootstrapper {
 		mode = lp2pdht.ModeServer

--- a/network/gossip.go
+++ b/network/gossip.go
@@ -35,6 +35,7 @@ func newGossipService(ctx context.Context, host lp2phost.Host, conf *Config,
 		lp2pps.WithMessageSignaturePolicy(lp2pps.StrictNoSign),
 		lp2pps.WithNoAuthor(),
 		lp2pps.WithMessageIdFn(MessageIDFunc),
+		lp2pps.WithSeenMessagesTTL(60 * time.Second),
 	}
 
 	if conf.IsBootstrapper {
@@ -114,19 +115,13 @@ func (g *gossipService) publish(msg []byte, topic *lp2pps.Topic) error {
 }
 
 // JoinTopic joins to the topic with the given name and subscribes to receive topic messages.
-func (g *gossipService) JoinTopic(topicID TopicID, shouldPropagate ShouldPropagate) error {
+func (g *gossipService) JoinTopic(topicID TopicID, evaluator PropagationEvaluator) error {
 	switch topicID {
 	case TopicIDUnspecified:
 		return InvalidTopicError{TopicID: topicID}
 
 	case TopicIDBlock:
-		if g.topicBlock != nil {
-			g.logger.Warn("already subscribed to block topic")
-
-			return nil
-		}
-
-		topic, err := g.joinTopic(topicID, shouldPropagate)
+		topic, err := g.joinTopic(topicID, evaluator)
 		if err != nil {
 			return err
 		}
@@ -135,13 +130,7 @@ func (g *gossipService) JoinTopic(topicID TopicID, shouldPropagate ShouldPropaga
 		return nil
 
 	case TopicIDTransaction:
-		if g.topicTransaction != nil {
-			g.logger.Warn("already subscribed to transaction topic")
-
-			return nil
-		}
-
-		topic, err := g.joinTopic(topicID, shouldPropagate)
+		topic, err := g.joinTopic(topicID, evaluator)
 		if err != nil {
 			return err
 		}
@@ -150,13 +139,7 @@ func (g *gossipService) JoinTopic(topicID TopicID, shouldPropagate ShouldPropaga
 		return nil
 
 	case TopicIDConsensus:
-		if g.topicConsensus != nil {
-			g.logger.Warn("already subscribed to consensus topic")
-
-			return nil
-		}
-
-		topic, err := g.joinTopic(topicID, shouldPropagate)
+		topic, err := g.joinTopic(topicID, evaluator)
 		if err != nil {
 			return err
 		}
@@ -175,7 +158,7 @@ func (g *gossipService) TopicName(topicID TopicID) string {
 
 // joinTopic joins a given topic and registers a validator for it.
 // If successful, it returns the topic and subscribes to it.
-func (g *gossipService) joinTopic(topicID TopicID, shouldPropagate ShouldPropagate) (*lp2pps.Topic, error) {
+func (g *gossipService) joinTopic(topicID TopicID, evaluator PropagationEvaluator) (*lp2pps.Topic, error) {
 	topicName := g.TopicName(topicID)
 	topic, err := g.pubsub.Join(topicName)
 	if err != nil {
@@ -188,7 +171,7 @@ func (g *gossipService) joinTopic(topicID TopicID, shouldPropagate ShouldPropaga
 	}
 
 	err = g.pubsub.RegisterTopicValidator(
-		topicName, g.createValidator(topicID, shouldPropagate))
+		topicName, g.createValidator(topicID, evaluator))
 	if err != nil {
 		return nil, LibP2PError{Err: err}
 	}
@@ -221,7 +204,7 @@ func (g *gossipService) joinTopic(topicID TopicID, shouldPropagate ShouldPropaga
 	return topic, nil
 }
 
-func (g *gossipService) createValidator(topicID TopicID, shouldPropagate ShouldPropagate,
+func (g *gossipService) createValidator(topicID TopicID, evaluator PropagationEvaluator,
 ) func(context.Context, lp2pcore.PeerID, *lp2pps.Message) lp2pps.ValidationResult {
 	return func(_ context.Context, peerId lp2pcore.PeerID, lp2pMsg *lp2pps.Message) lp2pps.ValidationResult {
 		msg := &GossipMessage{
@@ -235,16 +218,26 @@ func (g *gossipService) createValidator(topicID TopicID, shouldPropagate ShouldP
 			return lp2pps.ValidationAccept
 		}
 
-		if !shouldPropagate(msg) {
-			g.logger.Debug("message ignored", "from", peerId, "topic", topicID)
+		switch evaluator(msg) {
+		case Drop:
+			g.logger.Debug("message dropped", "from", peerId, "topic", topicID)
+
+			return lp2pps.ValidationIgnore
+
+		case DropButConsume:
+			g.logger.Debug("message dropped but consumed", "from", peerId, "topic", topicID)
 
 			// Consume the message first
 			g.onReceiveMessage(msg)
 
 			return lp2pps.ValidationIgnore
-		}
 
-		return lp2pps.ValidationAccept
+		case Propagate:
+			return lp2pps.ValidationAccept
+
+		default:
+			panic("unreachable")
+		}
 	}
 }
 

--- a/network/interface.go
+++ b/network/interface.go
@@ -121,9 +121,22 @@ func (*ProtocolsEvents) Type() EventType {
 	return EventTypeProtocols
 }
 
-// ShouldPropagate determines whether a message should be disregarded:
-// it will be neither delivered to the application nor forwarded to the network.
-type ShouldPropagate func(*GossipMessage) bool
+// PropagationPolicy defines the possible actions for how a gossip message should propagate.
+type PropagationPolicy int
+
+const (
+	// Propagate means the message should be forwarded to other peers in the network.
+	Propagate = PropagationPolicy(0)
+
+	// DropButConsume means the message should not be forwarded but should be processed locally.
+	DropButConsume = PropagationPolicy(1)
+
+	// Drop means the message should be discarded without any further processing.
+	Drop = PropagationPolicy(2)
+)
+
+// PropagationEvaluator is a function that evaluates how a gossip message should propagate.
+type PropagationEvaluator func(*GossipMessage) PropagationPolicy
 
 type Network interface {
 	Start() error
@@ -132,7 +145,7 @@ type Network interface {
 	EventChannel() <-chan Event
 	Broadcast([]byte, TopicID)
 	SendTo([]byte, lp2pcore.PeerID)
-	JoinTopic(TopicID, ShouldPropagate) error
+	JoinTopic(TopicID, PropagationEvaluator) error
 	CloseConnection(lp2pcore.PeerID)
 	SelfID() lp2pcore.PeerID
 	NumConnectedPeers() int

--- a/network/mock.go
+++ b/network/mock.go
@@ -47,7 +47,7 @@ func (mock *MockNetwork) EventChannel() <-chan Event {
 	return mock.EventCh
 }
 
-func (*MockNetwork) JoinTopic(_ TopicID, _ ShouldPropagate) error {
+func (*MockNetwork) JoinTopic(_ TopicID, _ PropagationEvaluator) error {
 	return nil
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -390,8 +390,8 @@ func (n *network) Broadcast(msg []byte, topicID TopicID) {
 	}()
 }
 
-func (n *network) JoinTopic(topicID TopicID, sp ShouldPropagate) error {
-	return n.gossip.JoinTopic(topicID, sp)
+func (n *network) JoinTopic(topicID TopicID, evaluator PropagationEvaluator) error {
+	return n.gossip.JoinTopic(topicID, evaluator)
 }
 
 func (n *network) CloseConnection(pid lp2ppeer.ID) {

--- a/sync/bundle/bundle.go
+++ b/sync/bundle/bundle.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -18,10 +19,29 @@ const (
 	BundleFlagHandshaking    = 0x0400
 )
 
+// Custom type to enforce uint32 encoding as 4 bytes, ignoring zeros.
+type fixedUint32 uint32
+
+func (u fixedUint32) MarshalCBOR() ([]byte, error) {
+	if u == 0 {
+		// Why can't be empty??
+		return []byte{0}, nil
+	}
+
+	buf := make([]byte, 0, 5)
+
+	// The header for a 4-byte integer is 0x1A followed by the 4 bytes of the uint32.
+	buf = append(buf, 0x1A)
+
+	// Append the uint32 in big-endian format
+	buf = binary.BigEndian.AppendUint32(buf, uint32(u))
+
+	return buf, nil
+}
+
 type Bundle struct {
-	Flags      int
-	SequenceNo int
-	Message    message.Message
+	Flags   int
+	Message message.Message
 }
 
 func NewBundle(msg message.Message) *Bundle {
@@ -43,15 +63,11 @@ func (b *Bundle) CompressIt() {
 	b.Flags = util.SetFlag(b.Flags, BundleFlagCompressed)
 }
 
-func (b *Bundle) SetSequenceNo(seqNo int) {
-	b.SequenceNo = seqNo
-}
-
 type _Bundle struct {
-	Flags       int          `cbor:"1,keyasint"`
-	MessageType message.Type `cbor:"2,keyasint"`
-	MessageData []byte       `cbor:"3,keyasint"`
-	SequenceNo  int          `cbor:"4,keyasint"`
+	Flags           int          `cbor:"1,keyasint"`
+	MessageType     message.Type `cbor:"2,keyasint"`
+	MessageData     []byte       `cbor:"3,keyasint"`
+	ConsensusHeight fixedUint32  `cbor:"4,keyasint,omitempty"`
 }
 
 func (b *Bundle) Encode() ([]byte, error) {
@@ -69,10 +85,10 @@ func (b *Bundle) Encode() ([]byte, error) {
 	}
 
 	msg := &_Bundle{
-		Flags:       b.Flags,
-		MessageType: b.Message.Type(),
-		MessageData: data,
-		SequenceNo:  b.SequenceNo,
+		Flags:           b.Flags,
+		MessageType:     b.Message.Type(),
+		MessageData:     data,
+		ConsensusHeight: fixedUint32(b.Message.ConsensusHeight()),
 	}
 
 	return cbor.Marshal(msg)
@@ -102,7 +118,6 @@ func (b *Bundle) Decode(r io.Reader) (int, error) {
 	}
 
 	b.Flags = bdl.Flags
-	b.SequenceNo = bdl.SequenceNo
 	b.Message = msg
 
 	return bytesRead, cbor.Unmarshal(data, msg)

--- a/sync/bundle/bundle_test.go
+++ b/sync/bundle/bundle_test.go
@@ -75,23 +75,26 @@ func TestDecodeVoteMessage(t *testing.T) {
 
 func TestDecodeVoteCBOR(t *testing.T) {
 	dat1, _ := hex.DecodeString(
-		"a3" +
-			"0100" + // flags: 0
-			"0207" + // Type (vote)
-			"035879a101a70101" +
-			"02186403010458200264572d4d6bfcd2140d4f885fd5a32fe42fdbf40551e4ff89f3d235e32b4b92055501c0067d277f2dff" +
-			"99943016d6a0f379cf09846c6f06f60758308ab7aecbe03c4ed5b688bcb7e848baffa62bcbf1a4021522c56693f0a7bbcc1f" +
-			"e865277556ee59c1f63ba592acfe1b43" +
-			"0401") // SequenceNo
+		"a4" + // Map(4)
+			"0100" + // Flags = 0
+			"0207" + // Message Type = 7 (TypeVote)
+			"035879" + // Message + Len
+			"a101a7010102186403010458200264572d4d6bfcd2140d4f885fd5a32fe42fdb" + // Vote Message Uncompressed
+			"f40551e4ff89f3d235e32b4b92055501c0067d277f2dff99943016d6a0f379cf" +
+			"09846c6f06f60758308ab7aecbe03c4ed5b688bcb7e848baffa62bcbf1a40215" +
+			"22c56693f0a7bbcc1fe865277556ee59c1f63ba592acfe1b43" +
+			"041a00001234") // Consensus Height
 	data2, _ := hex.DecodeString(
-		"a3" +
-			"01190100" + // flags: 0x0100 (compressed)
-			"0207" + // Type (vote)
-			"0358951f8b08" +
-			"000000000000ff00790086ffa101a7010102186403010458200264572d4d6bfcd2140d4f885fd5a32fe42fdbf40551e4ff89" +
-			"f3d235e32b4b92055501c0067d277f2dff99943016d6a0f379cf09846c6f06f60758308ab7aecbe03c4ed5b688bcb7e848ba" +
-			"ffa62bcbf1a4021522c56693f0a7bbcc1fe865277556ee59c1f63ba592acfe1b43010000ffff798ce7ec79000000" +
-			"0401") // SequenceNo
+		"a4" + // Map(4)
+			"01190100" + // Flags = 0x0100 (compressed)
+			"0207" + // Message Type = 7 (TypeVote)
+			"035895" + // Message + Len
+			"1f8b08000000000000ff00790086ffa101a7010102186403010458200264572d" + // Vote Uncompressed
+			"4d6bfcd2140d4f885fd5a32fe42fdbf40551e4ff89f3d235e32b4b92055501c0" +
+			"067d277f2dff99943016d6a0f379cf09846c6f06f60758308ab7aecbe03c4ed5" +
+			"b688bcb7e848baffa62bcbf1a4021522c56693f0a7bbcc1fe865277556ee59c1" +
+			"f63ba592acfe1b43010000ffff798ce7ec79000000" +
+			"041a00001234") // Consensus Height
 
 	bdl1 := new(Bundle)
 	bdl2 := new(Bundle)
@@ -102,12 +105,46 @@ func TestDecodeVoteCBOR(t *testing.T) {
 	assert.NoError(t, bdl2.BasicCheck())
 
 	assert.Equal(t, bdl1.Message, bdl2.Message)
+	assert.Equal(t, 0x0000, bdl1.Flags)
+	assert.Equal(t, 0x0100, bdl2.Flags)
 	assert.Contains(t, bdl1.String(), "vote")
 }
 
-func TestSetSequenceNo(t *testing.T) {
-	bdl := new(Bundle)
-	bdl.SetSequenceNo(1001)
+func TestEncodingData(t *testing.T) {
+	t.Run("Encoding non-consensus message", func(t *testing.T) {
+		msg := message.NewBlocksRequestMessage(0x11, 0x12, 0x13)
+		bdl := NewBundle(msg)
+		data, _ := bdl.Encode()
 
-	assert.Equal(t, 1001, bdl.SequenceNo)
+		expectedData := "a4" + // Map(3)
+			"0100" + // Flags = 0
+			"0209" + // Message Type = 9 (TypeBlocksRequest)
+			"0347" + // Message + Len
+			"a3" +
+			"0111" +
+			"0212" +
+			"0313" +
+			"0400"
+		assert.Equal(t, expectedData, hex.EncodeToString(data))
+	})
+
+	t.Run("Encoding consensus message", func(t *testing.T) {
+		ts := testsuite.NewTestSuite(t)
+
+		rndAddr := ts.RandValAddress()
+		msg := message.NewQueryVoteMessage(0x11, 0x12, rndAddr)
+		bdl := NewBundle(msg)
+		data, _ := bdl.Encode()
+
+		expectedData := "a4" + // Map(3)
+			"0100" + // Flags = 0
+			"0206" + // Message Type = 6 (TypeQueryVote)
+			"03581c" + // Message + Len
+			"a3" +
+			"0111" +
+			"0212" +
+			"0355" + hex.EncodeToString(rndAddr.Bytes()) +
+			"041a00000011" // Consensus height
+		assert.Equal(t, expectedData, hex.EncodeToString(data))
+	})
 }

--- a/sync/bundle/message/block_announce.go
+++ b/sync/bundle/message/block_announce.go
@@ -44,6 +44,10 @@ func (*BlockAnnounceMessage) ShouldBroadcast() bool {
 	return true
 }
 
+func (m *BlockAnnounceMessage) ConsensusHeight() uint32 {
+	return m.Certificate.Height()
+}
+
 func (m *BlockAnnounceMessage) String() string {
 	return fmt.Sprintf("{⌘ %d %v}",
 		m.Certificate.Height(),

--- a/sync/bundle/message/block_announce_test.go
+++ b/sync/bundle/message/block_announce_test.go
@@ -34,7 +34,7 @@ func TestBlockAnnounceMessage(t *testing.T) {
 		msg := NewBlockAnnounceMessage(blk, cert)
 
 		assert.NoError(t, msg.BasicCheck())
-		assert.Equal(t, height, msg.Height())
+		assert.Equal(t, height, msg.ConsensusHeight())
 		assert.Contains(t, msg.String(), fmt.Sprintf("%d", height))
 	})
 }

--- a/sync/bundle/message/blocks_request.go
+++ b/sync/bundle/message/blocks_request.go
@@ -47,6 +47,10 @@ func (*BlocksRequestMessage) ShouldBroadcast() bool {
 	return false
 }
 
+func (*BlocksRequestMessage) ConsensusHeight() uint32 {
+	return 0
+}
+
 func (m *BlocksRequestMessage) String() string {
 	return fmt.Sprintf("{⚓ %d %v:%v}", m.SessionID, m.From, m.To())
 }

--- a/sync/bundle/message/blocks_response.go
+++ b/sync/bundle/message/blocks_response.go
@@ -51,6 +51,10 @@ func (*BlocksResponseMessage) ShouldBroadcast() bool {
 	return false
 }
 
+func (*BlocksResponseMessage) ConsensusHeight() uint32 {
+	return 0
+}
+
 func (m *BlocksResponseMessage) Count() uint32 {
 	return uint32(len(m.BlocksData))
 }

--- a/sync/bundle/message/hello.go
+++ b/sync/bundle/message/hello.go
@@ -72,6 +72,10 @@ func (*HelloMessage) ShouldBroadcast() bool {
 	return false
 }
 
+func (*HelloMessage) ConsensusHeight() uint32 {
+	return 0
+}
+
 func (m *HelloMessage) String() string {
 	return fmt.Sprintf("{%s %d %s}", m.Moniker, m.Height, m.Services)
 }

--- a/sync/bundle/message/hello_ack.go
+++ b/sync/bundle/message/hello_ack.go
@@ -36,6 +36,10 @@ func (*HelloAckMessage) ShouldBroadcast() bool {
 	return false
 }
 
+func (*HelloAckMessage) ConsensusHeight() uint32 {
+	return 0
+}
+
 func (m *HelloAckMessage) String() string {
 	return fmt.Sprintf("{%s: %s %v}", m.ResponseCode, m.Reason, m.Height)
 }

--- a/sync/bundle/message/message.go
+++ b/sync/bundle/message/message.go
@@ -135,5 +135,9 @@ type Message interface {
 	Type() Type
 	TopicID() network.TopicID
 	ShouldBroadcast() bool
+	// ConsensusHeight indicates the consensus height at which the message is broadcast.
+	// This is applicable for consensus messages, including BlockAnnounce.
+	// For non-consensus messages, this height is set to zero.
+	ConsensusHeight() uint32
 	String() string
 }

--- a/sync/bundle/message/proposal.go
+++ b/sync/bundle/message/proposal.go
@@ -33,6 +33,14 @@ func (*ProposalMessage) ShouldBroadcast() bool {
 	return true
 }
 
+func (m *ProposalMessage) ConsensusHeight() uint32 {
+	return m.Height()
+}
+
+func (m *ProposalMessage) Height() uint32 {
+	return m.Proposal.Height()
+}
+
 func (m *ProposalMessage) String() string {
 	return m.Proposal.String()
 }

--- a/sync/bundle/message/query_proposal.go
+++ b/sync/bundle/message/query_proposal.go
@@ -41,6 +41,10 @@ func (*QueryProposalMessage) ShouldBroadcast() bool {
 	return true
 }
 
+func (m *QueryProposalMessage) ConsensusHeight() uint32 {
+	return m.Height
+}
+
 func (m *QueryProposalMessage) String() string {
 	return fmt.Sprintf("{%v %s}", m.Height, m.Querier.ShortString())
 }

--- a/sync/bundle/message/query_votes.go
+++ b/sync/bundle/message/query_votes.go
@@ -41,6 +41,10 @@ func (*QueryVoteMessage) ShouldBroadcast() bool {
 	return true
 }
 
+func (m *QueryVoteMessage) ConsensusHeight() uint32 {
+	return m.Height
+}
+
 func (m *QueryVoteMessage) String() string {
 	return fmt.Sprintf("{%d/%d %s}", m.Height, m.Round, m.Querier.ShortString())
 }

--- a/sync/bundle/message/transactions.go
+++ b/sync/bundle/message/transactions.go
@@ -43,6 +43,10 @@ func (*TransactionsMessage) ShouldBroadcast() bool {
 	return true
 }
 
+func (*TransactionsMessage) ConsensusHeight() uint32 {
+	return 0
+}
+
 func (m *TransactionsMessage) String() string {
 	var builder strings.Builder
 

--- a/sync/bundle/message/vote.go
+++ b/sync/bundle/message/vote.go
@@ -31,6 +31,10 @@ func (*VoteMessage) ShouldBroadcast() bool {
 	return true
 }
 
+func (m *VoteMessage) ConsensusHeight() uint32 {
+	return m.Vote.Height()
+}
+
 func (m *VoteMessage) String() string {
 	return m.Vote.String()
 }

--- a/sync/firewall/errors.go
+++ b/sync/firewall/errors.go
@@ -13,9 +13,6 @@ var ErrGossipMessage = errors.New("receive stream message as gossip message")
 // ErrStreamMessage is returned when a gossip message sends as stream message.
 var ErrStreamMessage = errors.New("receive gossip message as stream message")
 
-// ErrExpiredMessage is returned when we receive a expired message from a peer.
-var ErrExpiredMessage = errors.New("received an expired message")
-
 // ErrNetworkMismatch is returned when the bundle doesn't belong to this network.
 var ErrNetworkMismatch = errors.New("bundle is not for this network")
 

--- a/sync/firewall/firewall_test.go
+++ b/sync/firewall/firewall_test.go
@@ -2,6 +2,7 @@ package firewall
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 	"time"
 
@@ -118,7 +119,7 @@ func TestDecodeBundles(t *testing.T) {
 				"" + "01" + "1864" + // Key 1 (Height), Value: 100
 				"" + "02" + "20" + // Key 2 (Round), Value: -1
 				"" + "03" + "5501aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" + // Key 3 (Querier), Value: 21 Bytes
-				"04" + "05", // Key 4 (Sequence number), Value: 5
+				"04" + "1a00001234", // Key 4 (Consensus Height), Value: 0x1234
 			wantErr: true,
 		},
 
@@ -132,7 +133,7 @@ func TestDecodeBundles(t *testing.T) {
 				"" + "01" + "1864" + // Key 1 (Height), Value: 100
 				"" + "02" + "00" + // Key 2 (Round), Value: 0
 				"" + "03" + "5501aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" + // Key 3 (Querier), Value: 21 Bytes
-				"04" + "05", // Key 4 (Sequence number), Value: 5
+				"04" + "1a00001234", // Key 4 (Consensus Height), Value: 0x1234
 			wantErr: true,
 		},
 		{
@@ -145,7 +146,7 @@ func TestDecodeBundles(t *testing.T) {
 				"" + "01" + "1864" + // Key 1 (Height), Value: 100
 				"" + "02" + "00" + // Key 2 (Round), Value: 0
 				"" + "03" + "5501aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" + // Key 3 (Querier), Value: 21 Bytes
-				"04" + "05", // Key 4 (Sequence number), Value: 5
+				"04" + "1a00001234", // Key 4 (Consensus Height), Value: 0x1234
 			wantErr: false,
 		},
 	}
@@ -421,14 +422,42 @@ func TestParseP2PAddr(t *testing.T) {
 	}
 }
 
+func makeTestGossipMessage(consensusHeight uint32) *network.GossipMessage {
+	data := make([]byte, 0, 6)
+	data = append(data, 0x04, 0x1a)
+	data = binary.BigEndian.AppendUint32(data, consensusHeight)
+
+	return &network.GossipMessage{
+		Data: data,
+	}
+}
+
 func TestAllowBlockRequest(t *testing.T) {
 	conf := DefaultConfig()
 	conf.RateLimit.BlockTopic = 1
 
 	td := setup(t, conf)
 
-	assert.True(t, td.firewall.AllowBlockRequest())
-	assert.False(t, td.firewall.AllowBlockRequest())
+	td.state.CommitTestBlocks(10)
+
+	t.Run("expired message", func(t *testing.T) {
+		msg := makeTestGossipMessage(td.state.LastBlockHeight() - 2)
+
+		assert.Equal(t, network.Drop, td.firewall.AllowBlockRequest(msg))
+	})
+
+	t.Run("expired message", func(t *testing.T) {
+		msg := makeTestGossipMessage(td.state.LastBlockHeight() + 2)
+
+		assert.Equal(t, network.Drop, td.firewall.AllowBlockRequest(msg))
+	})
+
+	t.Run("rate limit exceeded", func(t *testing.T) {
+		msg := makeTestGossipMessage(td.state.LastBlockHeight())
+
+		assert.Equal(t, network.Propagate, td.firewall.AllowBlockRequest(msg))
+		assert.Equal(t, network.DropButConsume, td.firewall.AllowBlockRequest(msg))
+	})
 }
 
 func TestAllowTransactionRequest(t *testing.T) {
@@ -437,8 +466,12 @@ func TestAllowTransactionRequest(t *testing.T) {
 
 	td := setup(t, conf)
 
-	assert.True(t, td.firewall.AllowTransactionRequest())
-	assert.False(t, td.firewall.AllowTransactionRequest())
+	t.Run("rate limit exceeded", func(t *testing.T) {
+		msg := makeTestGossipMessage(td.state.LastBlockHeight())
+
+		assert.Equal(t, network.Propagate, td.firewall.AllowTransactionRequest(msg))
+		assert.Equal(t, network.DropButConsume, td.firewall.AllowTransactionRequest(msg))
+	})
 }
 
 func TestAllowConsensusRequest(t *testing.T) {
@@ -447,6 +480,24 @@ func TestAllowConsensusRequest(t *testing.T) {
 
 	td := setup(t, conf)
 
-	assert.True(t, td.firewall.AllowConsensusRequest())
-	assert.False(t, td.firewall.AllowConsensusRequest())
+	td.state.CommitTestBlocks(10)
+
+	t.Run("expired message", func(t *testing.T) {
+		msg := makeTestGossipMessage(td.state.LastBlockHeight() - 2)
+
+		assert.Equal(t, network.Drop, td.firewall.AllowConsensusRequest(msg))
+	})
+
+	t.Run("expired message", func(t *testing.T) {
+		msg := makeTestGossipMessage(td.state.LastBlockHeight() + 2)
+
+		assert.Equal(t, network.Drop, td.firewall.AllowConsensusRequest(msg))
+	})
+
+	t.Run("rate limit exceeded", func(t *testing.T) {
+		msg := makeTestGossipMessage(td.state.LastBlockHeight())
+
+		assert.Equal(t, network.Propagate, td.firewall.AllowConsensusRequest(msg))
+		assert.Equal(t, network.DropButConsume, td.firewall.AllowConsensusRequest(msg))
+	})
 }

--- a/sync/peerset/peer_set.go
+++ b/sync/peerset/peer_set.go
@@ -284,13 +284,6 @@ func (ps *PeerSet) UpdateSentMetric(pid *peer.ID, msgType message.Type, bytes in
 	}
 }
 
-func (ps *PeerSet) TotalSentBundles() int {
-	ps.lk.RLock()
-	defer ps.lk.RUnlock()
-
-	return int(ps.metric.TotalSent.Bundles)
-}
-
 func (ps *PeerSet) StartedAt() time.Time {
 	ps.lk.RLock()
 	defer ps.lk.RUnlock()

--- a/sync/peerset/peer_set_test.go
+++ b/sync/peerset/peer_set_test.go
@@ -102,7 +102,6 @@ func TestPeerSet(t *testing.T) {
 		assert.Equal(t, int64(150), peerSetMetric.MessageReceived[message.TypeTransaction].Bytes)
 		assert.Equal(t, int64(450), peerSetMetric.TotalSent.Bytes)
 		assert.Equal(t, int64(450), peerSetMetric.MessageSent[message.TypeBlocksRequest].Bytes)
-		assert.Equal(t, 2, peerSet.TotalSentBundles())
 	})
 
 	t.Run("Testing UpdateHeight", func(t *testing.T) {

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -377,21 +377,6 @@ func TestBroadcastBlockAnnounce(t *testing.T) {
 	})
 }
 
-func TestBundleSequenceNo(t *testing.T) {
-	td := setup(t, nil)
-
-	msg := message.NewQueryProposalMessage(td.RandHeight(), td.RandRound(), td.RandValAddress())
-
-	td.sync.broadcast(msg)
-	bdl1 := td.shouldPublishMessageWithThisType(t, message.TypeQueryProposal)
-	assert.Equal(t, 0, bdl1.SequenceNo)
-
-	// Sending the same message again
-	td.sync.broadcast(msg)
-	bdl2 := td.shouldPublishMessageWithThisType(t, message.TypeQueryProposal)
-	assert.Equal(t, 1, bdl2.SequenceNo)
-}
-
 func TestAllBlocksInCache(t *testing.T) {
 	td := setup(t, nil)
 


### PR DESCRIPTION
## Description

This PR evaluates the Propagate Policy for Gossip messages.
We use sequence as the consensus height. The sequence number is no more valid.
Each gossip message now carries the consensus height, and each node drops messages if they are expired.
To ensure compatibility with previous versions, we parse the message if the consensus height can't be read from the message data.