### PR TITLE
fix(gtk): fix panic on Windows 11 when laoding Pactus logo

### DIFF
--- a/cmd/gtk/dialog_about.go
+++ b/cmd/gtk/dialog_about.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gotk3/gotk3/gdk"
 	"github.com/gotk3/gotk3/gtk"
+	"github.com/pactus-project/pactus/cmd"
 	"github.com/pactus-project/pactus/version"
 )
 
@@ -25,9 +26,12 @@ func aboutDialog() *gtk.AboutDialog {
 	dlg := getAboutDialogObj(builder, "id_dialog_about")
 
 	pxLogo, err := gdk.PixbufNewFromBytesOnly(pactusLogo)
-	fatalErrorCheck(err)
+	if err != nil {
+		cmd.PrintErrorMsgf("Failed to load Logo Pixbuf: %v", err)
+	} else {
+		dlg.SetLogo(pxLogo)
+	}
 
-	dlg.SetLogo(pxLogo)
 	dlg.SetVersion(version.NodeVersion.StringWithAlias())
 
 	return dlg

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -34,15 +34,14 @@ func init() {
 	passwordOpt = flag.String("password", "", "wallet password")
 	testnetOpt = flag.Bool("testnet", false, "initializing for the testnet")
 	version.NodeAgent.AppType = "gui"
-	// the gtk on macos should run on main thread.
-	if runtime.GOOS == "darwin" {
-		runtime.UnlockOSThread()
-		runtime.LockOSThread()
-	}
-	gtk.Init(nil)
 }
 
 func main() {
+	// the gtk on macos should run on main thread.
+	runtime.LockOSThread()
+
+	gtk.Init(nil)
+
 	flag.Parse()
 
 	var err error


### PR DESCRIPTION
## Description

This PR fixes a panic on Windows when the node can't start due to issue on loading logo pixbuf.
