### PR TITLE
fix(consensus): ensure slow consensus terminates on cp-round > 0

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -839,8 +839,8 @@ func TestCases(t *testing.T) {
 		{1697898884837384019, 2, "1/3+ cp:PRE-VOTE in prepare step"},
 		{1694848907840926239, 0, "1/3+ cp:PRE-VOTE in precommit step"},
 		{1694849103290580532, 1, "Conflicting votes, cp-round=0"},
-		{1697900665869342730, 1, "Conflicting votes, cp-round=1"},
-		{1697887970998950590, 1, "consP & consB: Change Proposer, consX & consY: Commit (2 block announces)"},
+		{1733141709511627892, 0, "Conflicting votes, cp-round=1"},
+		{1733142353680459225, 1, "consP & consB: Change Proposer, consX & consY: Commit (2 block announces)"},
 	}
 
 	for no, tt := range tests {

--- a/consensus/cp.go
+++ b/consensus/cp.go
@@ -310,22 +310,21 @@ func (cp *changeProposer) checkJust(vte *vote.Vote) error {
 	}
 }
 
-func (cp *changeProposer) cpStrongTermination() {
-	cpDecided := cp.log.CPDecidedVoteSet(cp.round)
-	if cpDecided.HasAnyVoteFor(cp.cpRound, vote.CPValueNo) {
+func (cp *changeProposer) cpStrongTermination(round, cpRound int16) {
+	cpDecided := cp.log.CPDecidedVoteSet(round)
+	if cpDecided.HasAnyVoteFor(cpRound, vote.CPValueNo) {
+		cp.round = round
 		cp.cpDecided = 0
 
-		roundProposal := cp.log.RoundProposal(cp.round)
+		roundProposal := cp.log.RoundProposal(round)
 		if roundProposal == nil {
 			cp.queryProposal()
 		}
 		cp.enterNewState(cp.prepareState)
-	} else if cpDecided.HasAnyVoteFor(cp.cpRound, vote.CPValueYes) {
-		cp.round++
+	} else if cpDecided.HasAnyVoteFor(cpRound, vote.CPValueYes) {
+		cp.round = round + 1
 		cp.cpDecided = 1
-		cp.enterNewState(cp.proposeState)
 
-		// Check if there is any decided vote for the next round.
-		cp.cpStrongTermination()
+		cp.enterNewState(cp.proposeState)
 	}
 }

--- a/consensus/cp_decide.go
+++ b/consensus/cp_decide.go
@@ -26,6 +26,7 @@ func (s *cpDecideState) decide() {
 				QCert: cert,
 			}
 			s.signAddCPDecidedVote(hash.UndefHash, s.cpRound, vote.CPValueYes, just)
+			s.cpStrongTermination(s.round, s.cpRound)
 		} else if cpMainVotes.HasQuorumVotesFor(s.cpRound, vote.CPValueNo) {
 			// decided for no and proceeds to the next round
 			s.logger.Info("binary agreement decided", "value", 0, "round", s.cpRound)
@@ -36,6 +37,7 @@ func (s *cpDecideState) decide() {
 				QCert: cert,
 			}
 			s.signAddCPDecidedVote(*s.cpWeakValidity, s.cpRound, vote.CPValueNo, just)
+			s.cpStrongTermination(s.round, s.cpRound)
 		} else {
 			// conflicting votes
 			s.logger.Debug("conflicting main votes", "round", s.cpRound)
@@ -50,7 +52,9 @@ func (s *cpDecideState) onAddVote(v *vote.Vote) {
 		s.decide()
 	}
 
-	s.cpStrongTermination()
+	if v.IsCPVote() {
+		s.cpStrongTermination(v.Round(), v.CPRound())
+	}
 }
 
 func (*cpDecideState) name() string {

--- a/consensus/cp_mainvote.go
+++ b/consensus/cp_mainvote.go
@@ -91,7 +91,9 @@ func (s *cpMainVoteState) onAddVote(v *vote.Vote) {
 		s.decide()
 	}
 
-	s.cpStrongTermination()
+	if v.IsCPVote() {
+		s.cpStrongTermination(v.Round(), v.CPRound())
+	}
 }
 
 func (*cpMainVoteState) name() string {


### PR DESCRIPTION
## Description

This PR ensures that a slow consensus can terminate and move forward if the decision occurs in a cp-round greater than 0.