### PR TITLE
fix(gtk): fix missing colon on connection label

### DIFF
--- a/cmd/gtk/assets/ui/widget_node.ui
+++ b/cmd/gtk/assets/ui/widget_node.ui
@@ -304,7 +304,7 @@
                         <property name="valign">start</property>
                         <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
-                        <property name="label" translatable="yes">📡 Connections</property>
+                        <property name="label" translatable="yes">📡 Connections:</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>


### PR DESCRIPTION
## Description

This PR fixes a missing colon on connection label.