### PR TITLE
fix(gtk): panic on windows 11 and mac

### DIFF
--- a/cmd/gtk/assets/ui/widget_node.ui
+++ b/cmd/gtk/assets/ui/widget_node.ui
@@ -304,7 +304,7 @@
                         <property name="valign">start</property>
                         <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
-                        <property name="label" translatable="yes">📡 Connections</property>
+                        <property name="label" translatable="yes">📡 Connections:</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>

--- a/cmd/gtk/dialog_about.go
+++ b/cmd/gtk/dialog_about.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gotk3/gotk3/gdk"
 	"github.com/gotk3/gotk3/gtk"
+	"github.com/pactus-project/pactus/cmd"
 	"github.com/pactus-project/pactus/version"
 )
 
@@ -25,9 +26,12 @@ func aboutDialog() *gtk.AboutDialog {
 	dlg := getAboutDialogObj(builder, "id_dialog_about")
 
 	pxLogo, err := gdk.PixbufNewFromBytesOnly(pactusLogo)
-	fatalErrorCheck(err)
+	if err != nil {
+		cmd.PrintErrorMsgf("Failed to load Logo Pixbuf: %v", err)
+	} else {
+		dlg.SetLogo(pxLogo)
+	}
 
-	dlg.SetLogo(pxLogo)
 	dlg.SetVersion(version.NodeVersion.StringWithAlias())
 
 	return dlg

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -4,6 +4,11 @@ package main
 
 import (
 	"flag"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+
 	"github.com/gofrs/flock"
 	"github.com/gotk3/gotk3/gdk"
 	"github.com/gotk3/gotk3/glib"
@@ -14,10 +19,6 @@ import (
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/version"
 	"github.com/pactus-project/pactus/wallet"
-	"log"
-	"os"
-	"path/filepath"
-	"runtime"
 )
 
 const appID = "com.github.pactus-project.pactus.pactus-gui"

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -34,15 +34,14 @@ func init() {
 	passwordOpt = flag.String("password", "", "wallet password")
 	testnetOpt = flag.Bool("testnet", false, "initializing for the testnet")
 	version.NodeAgent.AppType = "gui"
-	// the gtk on macos should run on main thread.
-	if runtime.GOOS == "darwin" {
-		runtime.UnlockOSThread()
-		runtime.LockOSThread()
-	}
-	gtk.Init(nil)
 }
 
 func main() {
+	// the gtk on macos should run on main thread.
+	runtime.LockOSThread()
+
+	gtk.Init(nil)
+
 	flag.Parse()
 
 	var err error

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -4,11 +4,6 @@ package main
 
 import (
 	"flag"
-	"log"
-	"os"
-	"path/filepath"
-	"runtime"
-
 	"github.com/gofrs/flock"
 	"github.com/gotk3/gotk3/gdk"
 	"github.com/gotk3/gotk3/glib"
@@ -19,6 +14,10 @@ import (
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/version"
 	"github.com/pactus-project/pactus/wallet"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
 )
 
 const appID = "com.github.pactus-project.pactus.pactus-gui"
@@ -34,14 +33,15 @@ func init() {
 	passwordOpt = flag.String("password", "", "wallet password")
 	testnetOpt = flag.Bool("testnet", false, "initializing for the testnet")
 	version.NodeAgent.AppType = "gui"
-}
 
-func main() {
 	// the gtk on macos should run on main thread.
+	runtime.UnlockOSThread()
 	runtime.LockOSThread()
 
 	gtk.Init(nil)
+}
 
+func main() {
 	flag.Parse()
 
 	var err error


### PR DESCRIPTION
Some users are reported they GUI panics while loading the Pactus logo (SVG)