### PR TITLE
fix(consensus): schedule timeout to retry querying for the proposal or votes

### DIFF
--- a/consensus/prepare.go
+++ b/consensus/prepare.go
@@ -68,6 +68,9 @@ func (s *prepareState) onTimeout(ticker *ticker) {
 		if s.isProposer() {
 			s.queryVote()
 		}
+
+		// Schedule another timeout to retry querying for the proposal or votes.
+		// This ensures that delayed or missing data doesn't cause the process to stall.
 		s.scheduleTimeout(ticker.Duration*2, s.height, s.round, tickerTargetQueryProposal)
 	} else if ticker.Target == tickerTargetChangeProposer {
 		s.startChangingProposer()

--- a/consensus/prepare.go
+++ b/consensus/prepare.go
@@ -68,6 +68,7 @@ func (s *prepareState) onTimeout(ticker *ticker) {
 		if s.isProposer() {
 			s.queryVote()
 		}
+		s.scheduleTimeout(ticker.Duration*2, s.height, s.round, tickerTargetQueryProposal)
 	} else if ticker.Target == tickerTargetChangeProposer {
 		s.startChangingProposer()
 	}


### PR DESCRIPTION
## Description

Schedule another timeout to retry querying for the proposal or votes.
This ensures that delayed or missing data doesn't cause the process to stall.

## Related issue(s)

If this Pull Request is related to an issue, mention it here.
- Fixes #1697