### PR TITLE
fix(wallet): set Argon2 derived bytes for AES IV

### DIFF
--- a/crypto/bls/bls_test.go
+++ b/crypto/bls/bls_test.go
@@ -2,7 +2,6 @@ package bls_test
 
 import (
 	"encoding/hex"
-	"fmt"
 	"testing"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
@@ -41,11 +40,6 @@ func TestSignatureAggregate(t *testing.T) {
 		"ad747172697127cb08dda29a386e106eb24ab0edfbc044014c3bd7a5f583cc38b3a223ff2c1df9c0b4df110630e6946b")
 	sig1 := prv1.Sign(msg).(*bls.Signature)
 	sig2 := prv2.Sign(msg).(*bls.Signature)
-
-	fmt.Println(prv1.PublicKey().String())
-	fmt.Println(prv2.PublicKey().String())
-	agPub := bls.PublicKeyAggregate(prv1.PublicKeyNative(), prv2.PublicKeyNative())
-	fmt.Println(agPub.String())
 
 	assert.True(t, bls.SignatureAggregate(sig1, sig2).EqualsTo(agg))
 	assert.False(t, prv1.EqualsTo(prv2))

--- a/crypto/bls/bls_test.go
+++ b/crypto/bls/bls_test.go
@@ -2,6 +2,7 @@ package bls_test
 
 import (
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
@@ -40,6 +41,11 @@ func TestSignatureAggregate(t *testing.T) {
 		"ad747172697127cb08dda29a386e106eb24ab0edfbc044014c3bd7a5f583cc38b3a223ff2c1df9c0b4df110630e6946b")
 	sig1 := prv1.Sign(msg).(*bls.Signature)
 	sig2 := prv2.Sign(msg).(*bls.Signature)
+
+	fmt.Println(prv1.PublicKey().String())
+	fmt.Println(prv2.PublicKey().String())
+	agPub := bls.PublicKeyAggregate(prv1.PublicKeyNative(), prv2.PublicKeyNative())
+	fmt.Println(agPub.String())
 
 	assert.True(t, bls.SignatureAggregate(sig1, sig2).EqualsTo(agg))
 	assert.False(t, prv1.EqualsTo(prv2))

--- a/wallet/encrypter/encrypter.go
+++ b/wallet/encrypter/encrypter.go
@@ -88,7 +88,7 @@ func NopeEncrypter() Encrypter {
 // DefaultEncrypter creates a new encrypter instance.
 // If no option sets it uses the default parameters.
 //
-// The default encrypter uses Argon2ID as password hasher and AES_256_CBC as
+// The default encrypter uses Argon2ID as password hasher and AES_256_CTR as
 // encryption algorithm.
 func DefaultEncrypter(opts ...Option) Encrypter {
 	argon2dParameters := &argon2dParameters{

--- a/wallet/encrypter/encrypter.go
+++ b/wallet/encrypter/encrypter.go
@@ -21,6 +21,7 @@ type argon2dParameters struct {
 	iterations  uint32
 	memory      uint32
 	parallelism uint8
+	keyLen      uint32
 }
 
 type Option func(p *argon2dParameters)
@@ -47,11 +48,20 @@ const (
 	nameParamIterations  = "iterations"
 	nameParamMemory      = "memory"
 	nameParamParallelism = "parallelism"
+	nameParamKeyLen      = "keylen"
 
 	nameFuncNope      = ""
 	nameFuncArgon2ID  = "ARGON2ID"
 	nameFuncAES256CTR = "AES_256_CTR"
+	nameFuncAES256CBC = "AES_256_CBC"
 	nameFuncMACv1     = "MACV1"
+
+	// Parameter Choice
+	// https://www.rfc-editor.org/rfc/rfc9106.html#section-4
+	defaultIterations  = 3
+	defaultMemory      = 65536 // 2 ^ 16
+	defaultParallelism = 4
+	defaultKeyLen      = 48
 )
 
 // ErrNotSupported describes an error in which the encrypted method is no
@@ -75,17 +85,18 @@ func NopeEncrypter() Encrypter {
 	}
 }
 
-// DefaultEncrypter creates a default encrypter instance.
+// DefaultEncrypter creates a new encrypter instance.
+// If no option sets it uses the default parameters.
 //
-// The default encrypter uses Argon2ID as password hasher and AES_256_CTR as
+// The default encrypter uses Argon2ID as password hasher and AES_256_CBC as
 // encryption algorithm.
 func DefaultEncrypter(opts ...Option) Encrypter {
-	// Parameter Choice
-	// https://www.rfc-editor.org/rfc/rfc9106.html#section-4
+
 	argon2dParameters := &argon2dParameters{
-		iterations:  uint32(3),
-		memory:      uint32(65536), // 2 ^ 16
-		parallelism: uint8(4),
+		iterations:  defaultIterations,
+		memory:      defaultMemory,
+		parallelism: defaultParallelism,
+		keyLen:      defaultKeyLen,
 	}
 	for _, opt := range opts {
 		opt(argon2dParameters)
@@ -98,6 +109,7 @@ func DefaultEncrypter(opts ...Option) Encrypter {
 	encParams.SetUint32(nameParamIterations, argon2dParameters.iterations)
 	encParams.SetUint32(nameParamMemory, argon2dParameters.memory)
 	encParams.SetUint8(nameParamParallelism, argon2dParameters.parallelism)
+	encParams.SetUint32(nameParamKeyLen, argon2dParameters.keyLen)
 
 	return Encrypter{
 		Method: method,
@@ -140,22 +152,23 @@ func (e *Encrypter) Encrypt(message, password string) (string, error) {
 			return "", err
 		}
 
-		iterations := e.Params.GetUint32(nameParamIterations)
-		memory := e.Params.GetUint32(nameParamMemory)
-		parallelism := e.Params.GetUint8(nameParamParallelism)
+		iterations := e.Params.GetUint32(nameParamIterations, defaultIterations)
+		memory := e.Params.GetUint32(nameParamMemory, defaultMemory)
+		parallelism := e.Params.GetUint8(nameParamParallelism, defaultParallelism)
+		keyLen := e.Params.GetUint32(nameParamKeyLen, defaultKeyLen)
 
 		// Argon2 currently has three modes:
 		// - data-dependent Argon2d,
 		// - data-independent Argon2i,
 		// - a mix of the two, Argon2id.
-		cipherKey := argon2.IDKey([]byte(password), salt, iterations, memory, parallelism, 32)
+		derivedBytes := argon2.IDKey([]byte(password), salt, iterations, memory, parallelism, keyLen)
 
 		// Encrypter method
 		switch funcs[1] {
 		case nameFuncAES256CTR:
-			// Using salt for Initialization Vector (IV)
-			iv := salt
-			cipher := aesCrypt([]byte(message), iv, cipherKey)
+			cipherKey := derivedBytes[:32]
+			iv := derivedBytes[32:]
+			cipher := aesCTRCrypt([]byte(message), iv, cipherKey)
 
 			// MAC method
 			switch funcs[2] {
@@ -215,18 +228,35 @@ func (e *Encrypter) Decrypt(cipherText, password string) (string, error) {
 	case nameFuncArgon2ID:
 		salt := data[0:16]
 
-		iterations := e.Params.GetUint32(nameParamIterations)
-		memory := e.Params.GetUint32(nameParamMemory)
-		parallelism := e.Params.GetUint8(nameParamParallelism)
+		iterations := e.Params.GetUint32(nameParamIterations, defaultIterations)
+		memory := e.Params.GetUint32(nameParamMemory, defaultMemory)
+		parallelism := e.Params.GetUint8(nameParamParallelism, defaultParallelism)
+		keyLen := e.Params.GetUint32(nameParamKeyLen, defaultKeyLen)
 
-		cipherKey := argon2.IDKey([]byte(password), salt, iterations, memory, parallelism, 32)
+		derivedByte := argon2.IDKey([]byte(password), salt, iterations, memory, parallelism, keyLen)
 
 		// Encrypter method
 		switch funcs[1] {
 		case nameFuncAES256CTR:
-			iv := salt
+			var iv, cipherKey []byte
+
+			switch keyLen {
+			case 0:
+				// This case supports legacy encryption methods where the same salt is reused as the IV.
+				cipherKey = derivedByte
+				iv = salt
+
+			case 48:
+				// The first 32 bytes are used as the encryption key, and the last 16 bytes are used as the IV.
+				cipherKey = derivedByte[:32]
+				iv = derivedByte[32:]
+
+			default:
+				return "", ErrInvalidParam
+			}
+
 			enc := data[16 : len(data)-4]
-			text = string(aesCrypt(enc, iv, cipherKey))
+			text = string(aesCTRCrypt(enc, iv, cipherKey))
 
 			// MAC method
 			switch funcs[2] {
@@ -249,9 +279,9 @@ func (e *Encrypter) Decrypt(cipherText, password string) (string, error) {
 	return text, nil
 }
 
-// aesCrypt encrypts/decrypts a message using AES-256-CTR and
+// aesCTRCrypt encrypts/decrypts a message using AES-256-CTR and
 // returns the encoded/decoded bytes.
-func aesCrypt(message, initVec, cipherKey []byte) []byte {
+func aesCTRCrypt(message, initVec, cipherKey []byte) []byte {
 	// Generate the cipher message
 	cipherMsg := make([]byte, len(message))
 	aesCipher, err := aes.NewCipher(cipherKey)
@@ -259,6 +289,34 @@ func aesCrypt(message, initVec, cipherKey []byte) []byte {
 
 	stream := cipher.NewCTR(aesCipher, initVec)
 	stream.XORKeyStream(cipherMsg, message)
+
+	return cipherMsg
+}
+
+// aesCBCEncrypt encrypts/decrypts a message using AES-256-CBC and
+// returns the encoded/decoded bytes.
+func aesCBCEncrypt(message, initVec, cipherKey []byte) []byte {
+	// Generate the cipher message
+	cipherMsg := make([]byte, len(message))
+	aesCipher, err := aes.NewCipher(cipherKey)
+	exitOnErr(err)
+
+	stream := cipher.NewCBCEncrypter(aesCipher, initVec)
+	stream.CryptBlocks(cipherMsg, message)
+
+	return cipherMsg
+}
+
+// aesCBCDecrypt encrypts/decrypts a message using AES-256-CBC and
+// returns the encoded/decoded bytes.
+func aesCBCDecrypt(message, initVec, cipherKey []byte) []byte {
+	// Generate the cipher message
+	cipherMsg := make([]byte, len(message))
+	aesCipher, err := aes.NewCipher(cipherKey)
+	exitOnErr(err)
+
+	stream := cipher.NewCBCDecrypter(aesCipher, initVec)
+	stream.CryptBlocks(cipherMsg, message)
 
 	return cipherMsg
 }

--- a/wallet/encrypter/encrypter_test.go
+++ b/wallet/encrypter/encrypter_test.go
@@ -37,16 +37,45 @@ func TestDefaultEncrypter(t *testing.T) {
 	assert.Equal(t, "3", enc.Params["iterations"])
 	assert.Equal(t, "4", enc.Params["memory"])
 	assert.Equal(t, "5", enc.Params["parallelism"])
+	assert.Equal(t, "48", enc.Params["keylen"])
 	assert.True(t, enc.IsEncrypted())
 }
 
-func TestEncrypter(t *testing.T) {
+func TestEncrypterV2(t *testing.T) {
 	enc := &Encrypter{
 		Method: "ARGON2ID-AES_256_CTR-MACV1",
 		Params: params{
 			nameParamIterations:  "1",
 			nameParamMemory:      "1",
 			nameParamParallelism: "1",
+		},
+	}
+
+	msg := "foo"
+
+	_, err := enc.Encrypt(msg, "")
+	assert.ErrorIs(t, err, ErrInvalidPassword)
+
+	password := "cowboy"
+	cipher, err := enc.Encrypt(msg, password)
+	assert.NoError(t, err)
+
+	dec, err := enc.Decrypt(cipher, password)
+	assert.NoError(t, err)
+	assert.Equal(t, msg, dec)
+
+	_, err = enc.Decrypt(cipher, "invalid-password")
+	assert.ErrorIs(t, err, ErrInvalidPassword)
+}
+
+func TestEncrypterV3(t *testing.T) {
+	enc := &Encrypter{
+		Method: "ARGON2ID-AES_256_CTR-MACV1",
+		Params: params{
+			nameParamIterations:  "1",
+			nameParamMemory:      "1",
+			nameParamParallelism: "1",
+			nameParamKeyLen:      "48",
 		},
 	}
 

--- a/wallet/encrypter/error.go
+++ b/wallet/encrypter/error.go
@@ -7,6 +7,9 @@ import (
 // ErrInvalidPassword describes an error in which the password is invalid.
 var ErrInvalidPassword = errors.New("invalid password")
 
+// ErrInvalidParam describes an error in which the encryption parameter is invalid.
+var ErrInvalidParam = errors.New("invalid param")
+
 // ErrInvalidCipher describes an error in which the cipher message is invalid.
 var ErrInvalidCipher = errors.New("invalid cipher message")
 

--- a/wallet/encrypter/params.go
+++ b/wallet/encrypter/params.go
@@ -31,17 +31,19 @@ func (p params) SetString(key, val string) {
 	p[key] = val
 }
 
-func (p params) GetUint8(key string) uint8 {
-	return uint8(p.GetUint64(key))
+func (p params) GetUint8(key string, defaultValue uint64) uint8 {
+	return uint8(p.GetUint64(key, defaultValue))
 }
 
-func (p params) GetUint32(key string) uint32 {
-	return uint32(p.GetUint64(key))
+func (p params) GetUint32(key string, defaultValue uint64) uint32 {
+	return uint32(p.GetUint64(key, defaultValue))
 }
 
-func (p params) GetUint64(key string) uint64 {
+func (p params) GetUint64(key string, defaultValue uint64) uint64 {
 	val, err := strconv.ParseUint(p[key], 10, 64)
-	exitOnErr(err)
+	if err != nil {
+		return defaultValue
+	}
 
 	return val
 }

--- a/wallet/encrypter/params_test.go
+++ b/wallet/encrypter/params_test.go
@@ -18,7 +18,7 @@ func TestParamsUint8(t *testing.T) {
 	p := params{}
 	for _, tt := range tests {
 		p.SetUint8(tt.key, tt.val)
-		assert.Equal(t, tt.val, p.GetUint8(tt.key))
+		assert.Equal(t, tt.val, p.GetUint8(tt.key, 0))
 	}
 }
 
@@ -34,7 +34,7 @@ func TestParamsUint32(t *testing.T) {
 	p := params{}
 	for _, tt := range tests {
 		p.SetUint32(tt.key, tt.val)
-		assert.Equal(t, tt.val, p.GetUint32(tt.key))
+		assert.Equal(t, tt.val, p.GetUint32(tt.key, 0))
 	}
 }
 
@@ -50,24 +50,34 @@ func TestParamsUint64(t *testing.T) {
 	p := params{}
 	for _, tt := range tests {
 		p.SetUint64(tt.key, tt.val)
-		assert.Equal(t, tt.val, p.GetUint64(tt.key))
+		assert.Equal(t, tt.val, p.GetUint64(tt.key, 0))
 	}
+}
+
+func TestParamsDefaultValue(t *testing.T) {
+	p := params{}
+	assert.Equal(t, uint64(24), p.GetUint64("not-exist", 24))
+	assert.Equal(t, uint32(24), p.GetUint32("not-exist", 24))
+	assert.Equal(t, uint8(24), p.GetUint8("not-exist", 24))
+
 }
 
 func TestParamsBytes(t *testing.T) {
 	tests := []struct {
-		key string
-		val []byte
+		key    string
+		val    []byte
+		base64 string
 	}{
-		{"k1", []byte{0, 0}},
-		{"k2", []byte{0xff, 0xff}},
-		{"k2", []byte{}},
+		{"k1", []byte{0, 0}, "AAA="},
+		{"k2", []byte{0xff, 0xff}, "//8="},
+		{"k2", []byte{}, ""},
 	}
 
 	p := params{}
 	for _, tt := range tests {
 		p.SetBytes(tt.key, tt.val)
 		assert.Equal(t, tt.val, p.GetBytes(tt.key))
+		assert.Equal(t, tt.base64, p.GetString(tt.key))
 	}
 }
 

--- a/wallet/encrypter/params_test.go
+++ b/wallet/encrypter/params_test.go
@@ -59,7 +59,6 @@ func TestParamsDefaultValue(t *testing.T) {
 	assert.Equal(t, uint64(24), p.GetUint64("not-exist", 24))
 	assert.Equal(t, uint32(24), p.GetUint32("not-exist", 24))
 	assert.Equal(t, uint8(24), p.GetUint8("not-exist", 24))
-
 }
 
 func TestParamsBytes(t *testing.T) {
@@ -88,7 +87,7 @@ func TestParamsString(t *testing.T) {
 	}{
 		{"k1", "foo"},
 		{"k2", "bar"},
-		{"k3", "bar"},
+		{"k3", ""},
 	}
 
 	p := params{}

--- a/wallet/store.go
+++ b/wallet/store.go
@@ -85,8 +85,7 @@ func (s *Store) UpgradeWallet(walletPath string) error {
 			return err
 		}
 
-	case Version2,
-		Version3:
+	case Version2, Version3:
 		return nil
 
 	default:

--- a/wallet/store.go
+++ b/wallet/store.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	Version1 = 1 // initial version
-	Version2 = 2 // supporting Ed25519
+	Version1 = 1 // Initial version
+	Version2 = 2 // Supporting Ed25519
+	Version3 = 3 // USe AEC-256-CBC for default encryption
 
-	VersionLatest = Version2
+	VersionLatest = Version3
 )
 
 type Store struct {
@@ -84,8 +85,8 @@ func (s *Store) UpgradeWallet(walletPath string) error {
 			return err
 		}
 
-	case Version2:
-		// Current version
+	case Version2,
+		Version3:
 		return nil
 
 	default:

--- a/wallet/store_test.go
+++ b/wallet/store_test.go
@@ -10,29 +10,40 @@ import (
 
 func TestUpgradeWallet(t *testing.T) {
 	// password is: "password"
-	data, err := util.ReadFile("./testdata/wallet_version_1")
-	require.NoError(t, err)
+	tests := []struct {
+		walletPath      string
+		upgradedVersion int
+	}{
+		{"./testdata/wallet_version_1", 2},
+		{"./testdata/wallet_version_2", 2},
+		{"./testdata/wallet_version_3", 3},
+	}
 
-	tempPath := util.TempFilePath()
-	err = util.WriteFile(tempPath, data)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		data, err := util.ReadFile(tt.walletPath)
+		require.NoError(t, err)
 
-	wlt, err := Open(tempPath, true)
-	require.NoError(t, err)
+		tempPath := util.TempFilePath()
+		err = util.WriteFile(tempPath, data)
+		require.NoError(t, err)
 
-	assert.Equal(t, 4, wlt.AddressCount())
-	assert.Equal(t, VersionLatest, wlt.store.Version)
+		wlt, err := Open(tempPath, true)
+		require.NoError(t, err)
 
-	infos := wlt.AddressInfos()
-	for _, info := range infos {
-		assert.NotEmpty(t, info.PublicKey)
+		assert.Equal(t, 4, wlt.AddressCount())
+		assert.Equal(t, tt.upgradedVersion, wlt.store.Version)
+
+		infos := wlt.AddressInfos()
+		for _, info := range infos {
+			assert.NotEmpty(t, info.PublicKey)
+		}
 	}
 }
 
 func TestUnsupportedWallet(t *testing.T) {
 	_, err := Open("./testdata/unsupported_wallet", true)
 	require.ErrorIs(t, err, UnsupportedVersionError{
-		WalletVersion:    3,
+		WalletVersion:    4,
 		SupportedVersion: VersionLatest,
 	})
 }

--- a/wallet/testdata/unsupported_wallet
+++ b/wallet/testdata/unsupported_wallet
@@ -1,3 +1,3 @@
 {
-  "version": 3
+  "version": 4
 }

--- a/wallet/testdata/wallet_version_2
+++ b/wallet/testdata/wallet_version_2
@@ -1,0 +1,62 @@
+{
+  "version": 2,
+  "uuid": "44156117-268a-49f0-a906-400659b7a051",
+  "created_at": "2024-08-27T16:45:08Z",
+  "network": 0,
+  "crc": 3868496370,
+  "vault": {
+    "type": 1,
+    "coin_type": 21888,
+    "addresses": {
+      "pc1p4xuja689hg2434yhr32clhn97x6afw58qlrcyd": {
+        "address": "pc1p4xuja689hg2434yhr32clhn97x6afw58qlrcyd",
+        "public_key": "public1p3wmdecume03kehtcaks95jjyem2m7pev0da2yx7t0gws66nkgp7vaah5sdd5gv0s4d34y0nqxch0cqq7fnsy9v46kum7e46gx9dua4sss7ne57m5c776h0e9dt0dw8hv24uushps9arv0zk8dc2xe0k7pgk588tf",
+        "label": "Imported Validator Address 1",
+        "path": "m/65535'/21888'/1'/0'"
+      },
+      "pc1pjneygutecly9gtandrdt8j36v8g4fl42k4y5xp": {
+        "address": "pc1pjneygutecly9gtandrdt8j36v8g4fl42k4y5xp",
+        "public_key": "public1p3mzchmke52mghze9mlsnszvj8jueggxxa9n3va8zhpjzgys82zje93ajrhaye7flzv54g4ydhlauupr5zh4ffsem80xyflzyzkeh79prnkx9jtyxe24kvpkrtfg0f6a6rma8v6x4nsc786s4f35a8ankcueym98h",
+        "label": "test-2",
+        "path": "m/12381'/21888'/1'/0"
+      },
+      "pc1z0m0vw8sjfgv7f2zgq2hfxutg8rwn7gpffhe8tf": {
+        "address": "pc1z0m0vw8sjfgv7f2zgq2hfxutg8rwn7gpffhe8tf",
+        "public_key": "public1p5dwsgfwmacjpuhaxhy0522j87qc5390v56ndh92f7flxge7vt3zfuxlvuwpnk7tdeed4s4l2r5nj5zuyjfh0uzjmvrauf4t5xfvff5cpljvpqqpk7pzhv0hxfhf9gt5896vnllsf89ux8kc7anqlu7nxvvxcclw7",
+        "label": "test-1",
+        "path": "m/12381'/21888'/2'/0"
+      },
+      "pc1z4xuja689hg2434yhr32clhn97x6afw58a5n9ns": {
+        "address": "pc1z4xuja689hg2434yhr32clhn97x6afw58a5n9ns",
+        "public_key": "public1p3wmdecume03kehtcaks95jjyem2m7pev0da2yx7t0gws66nkgp7vaah5sdd5gv0s4d34y0nqxch0cqq7fnsy9v46kum7e46gx9dua4sss7ne57m5c776h0e9dt0dw8hv24uushps9arv0zk8dc2xe0k7pgk588tf",
+        "label": "Imported Reward Address 1",
+        "path": "m/65535'/21888'/2'/0'"
+      }
+    },
+    "encrypter": {
+      "method": "ARGON2ID-AES_256_CTR-MACV1",
+      "params": {
+        "iterations": "3",
+        "memory": "65536",
+        "parallelism": "4"
+      }
+    },
+    "key_store": "hlkOogftrz0kU1xqwIF4Vgj5/fuo+6FNSUWK+cVD20Fvrp1KUUNQTDex9F5SC/EMJfoJhwH5ofMek+j9bDYJL53BX5wO3w/ASqm/+j23cm6VJ40IMh+q74OX3pNOTMvSd9ZDYO0aPEA4rnKLyBMHX2L82r0DaAfLQ8zNV+ngx+SUCBPy+cpvzyoHdvYDlwf1YdSjjrbBfLaXa53Odg38Zgp9eieJb3gcq51jtM5GOOpXb1YR9jByYBb/7cn75/1WoEkojRCcylK/+/SYdCnGhsXbpVPu4/70LaPKDa+JNBytq1Kg",
+    "purposes": {
+      "purpose_bls": {
+        "xpub_account": "xpublic1pqdwnqqyqsp2spqqpqqqgqgxj6mlduay8ase6hkefwa2lk2esz0gn2yu59tnk3w2tgnlfk5hleuqxpqdlt5q2f207qrwq9gasqscpckjv8hggc57n044gvml7u05cpzu8ra0zq2s3x3mak6xhtzga27tdx5pypnqxhlkf9aedptzcsd8l3q6m7ch6g4lphzsdv20fvc3dsu7mlj8kdy3n5fyllg07wecmpr8y6nsr95zlz",
+        "xpub_validator": "xpublic1pqdwnqqyqsp2spqqzqqqgqgx4n38q9n6qtvgrnx5r8atntrfnj4thwj6my5tx8tfe6ex6p89y7qqxptrfzgmnu62rut65lddgxl5nujdn82tusz5w2wqpjqpdpgplj0zx3gaaz9wv93yqcls6clepehlvhsvdp2ndwphhmag3j3hgsfxxz434hduxvqq4n8njxh4x9mnal2wma4sw5kp6y680tkut62gk6trfjscmsdumc",
+        "next_account_index": 1,
+        "next_validator_index": 1
+      },
+      "purpose_bip44": {
+        "next_ed25519_index": 0
+      }
+    }
+  },
+  "history": {
+    "transactions": null,
+    "activities": null,
+    "pendings": null
+  }
+}

--- a/wallet/testdata/wallet_version_3
+++ b/wallet/testdata/wallet_version_3
@@ -1,0 +1,62 @@
+{
+  "version": 3,
+  "uuid": "44156117-268a-49f0-a906-400659b7a051",
+  "created_at": "2024-08-27T16:45:08Z",
+  "network": 0,
+  "crc": 3868496370,
+  "vault": {
+    "type": 1,
+    "coin_type": 21888,
+    "addresses": {
+      "pc1p4xuja689hg2434yhr32clhn97x6afw58qlrcyd": {
+        "address": "pc1p4xuja689hg2434yhr32clhn97x6afw58qlrcyd",
+        "public_key": "public1p3wmdecume03kehtcaks95jjyem2m7pev0da2yx7t0gws66nkgp7vaah5sdd5gv0s4d34y0nqxch0cqq7fnsy9v46kum7e46gx9dua4sss7ne57m5c776h0e9dt0dw8hv24uushps9arv0zk8dc2xe0k7pgk588tf",
+        "label": "Imported Validator Address 1",
+        "path": "m/65535'/21888'/1'/0'"
+      },
+      "pc1pjneygutecly9gtandrdt8j36v8g4fl42k4y5xp": {
+        "address": "pc1pjneygutecly9gtandrdt8j36v8g4fl42k4y5xp",
+        "public_key": "public1p3mzchmke52mghze9mlsnszvj8jueggxxa9n3va8zhpjzgys82zje93ajrhaye7flzv54g4ydhlauupr5zh4ffsem80xyflzyzkeh79prnkx9jtyxe24kvpkrtfg0f6a6rma8v6x4nsc786s4f35a8ankcueym98h",
+        "label": "test-2",
+        "path": "m/12381'/21888'/1'/0"
+      },
+      "pc1z0m0vw8sjfgv7f2zgq2hfxutg8rwn7gpffhe8tf": {
+        "address": "pc1z0m0vw8sjfgv7f2zgq2hfxutg8rwn7gpffhe8tf",
+        "public_key": "public1p5dwsgfwmacjpuhaxhy0522j87qc5390v56ndh92f7flxge7vt3zfuxlvuwpnk7tdeed4s4l2r5nj5zuyjfh0uzjmvrauf4t5xfvff5cpljvpqqpk7pzhv0hxfhf9gt5896vnllsf89ux8kc7anqlu7nxvvxcclw7",
+        "label": "test-1",
+        "path": "m/12381'/21888'/2'/0"
+      },
+      "pc1z4xuja689hg2434yhr32clhn97x6afw58a5n9ns": {
+        "address": "pc1z4xuja689hg2434yhr32clhn97x6afw58a5n9ns",
+        "public_key": "public1p3wmdecume03kehtcaks95jjyem2m7pev0da2yx7t0gws66nkgp7vaah5sdd5gv0s4d34y0nqxch0cqq7fnsy9v46kum7e46gx9dua4sss7ne57m5c776h0e9dt0dw8hv24uushps9arv0zk8dc2xe0k7pgk588tf",
+        "label": "Imported Reward Address 1",
+        "path": "m/65535'/21888'/2'/0'"
+      }
+    },
+    "encrypter": {
+      "method": "ARGON2ID-AES_256_CTR-MACV1",
+      "params": {
+        "iterations": "3",
+        "memory": "65536",
+        "parallelism": "4"
+      }
+    },
+    "key_store": "hlkOogftrz0kU1xqwIF4Vgj5/fuo+6FNSUWK+cVD20Fvrp1KUUNQTDex9F5SC/EMJfoJhwH5ofMek+j9bDYJL53BX5wO3w/ASqm/+j23cm6VJ40IMh+q74OX3pNOTMvSd9ZDYO0aPEA4rnKLyBMHX2L82r0DaAfLQ8zNV+ngx+SUCBPy+cpvzyoHdvYDlwf1YdSjjrbBfLaXa53Odg38Zgp9eieJb3gcq51jtM5GOOpXb1YR9jByYBb/7cn75/1WoEkojRCcylK/+/SYdCnGhsXbpVPu4/70LaPKDa+JNBytq1Kg",
+    "purposes": {
+      "purpose_bls": {
+        "xpub_account": "xpublic1pqdwnqqyqsp2spqqpqqqgqgxj6mlduay8ase6hkefwa2lk2esz0gn2yu59tnk3w2tgnlfk5hleuqxpqdlt5q2f207qrwq9gasqscpckjv8hggc57n044gvml7u05cpzu8ra0zq2s3x3mak6xhtzga27tdx5pypnqxhlkf9aedptzcsd8l3q6m7ch6g4lphzsdv20fvc3dsu7mlj8kdy3n5fyllg07wecmpr8y6nsr95zlz",
+        "xpub_validator": "xpublic1pqdwnqqyqsp2spqqzqqqgqgx4n38q9n6qtvgrnx5r8atntrfnj4thwj6my5tx8tfe6ex6p89y7qqxptrfzgmnu62rut65lddgxl5nujdn82tusz5w2wqpjqpdpgplj0zx3gaaz9wv93yqcls6clepehlvhsvdp2ndwphhmag3j3hgsfxxz434hduxvqq4n8njxh4x9mnal2wma4sw5kp6y680tkut62gk6trfjscmsdumc",
+        "next_account_index": 1,
+        "next_validator_index": 1
+      },
+      "purpose_bip44": {
+        "next_ed25519_index": 0
+      }
+    }
+  },
+  "history": {
+    "transactions": null,
+    "activities": null,
+    "pendings": null
+  }
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -109,7 +109,7 @@ func Create(walletPath, mnemonic, password string, chain genesis.ChainType,
 	}
 
 	store := &Store{
-		Version:   Version2,
+		Version:   VersionLatest,
 		UUID:      uuid.New(),
 		CreatedAt: time.Now().Round(time.Second).UTC(),
 		Network:   chain,

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -97,7 +97,7 @@ func TestOpenWallet(t *testing.T) {
 		_, err := wallet.Open(td.wallet.Path(), true)
 		assert.ErrorIs(t, err, wallet.UnsupportedVersionError{
 			WalletVersion:    0,
-			SupportedVersion: 2,
+			SupportedVersion: wallet.VersionLatest,
 		})
 	})
 


### PR DESCRIPTION
## Description

This PR updates the encryption logic to use Argon2-derived bytes for the Initialization Vector (IV) in AES, replacing the legacy approach of reusing the salt as the IV. 

### Explanation:

In the legacy or previous approach, we used the same salt in the Password Hasher (Argon2 in this case) as the Initialization Vector (IV) for the AES encryption algorithm. The seed is random and should not be an issue, but some documentation recommends never reusing a seed, even for different purposes.  

To address this, we propose extending the key length from 32 bytes to 48 bytes, using the first 32 bytes as the encryption key and the remaining 16 bytes as the IV.  

In OpenSSL, the salt is public. I found [this code](https://github.com/openssl/openssl/blob/91c6e157c696e8fee7320408ddb959ecf233fbaf/apps/enc.c#L546).
The encrypted files usually start with `Salted__`. 

Based on [this](https://docs.openssl.org/3.3/man1/openssl-enc/#options) documentation, the IV is derived from the password in OpenSSL.  Check the `-iv` section:

> The actual IV to use: this must be represented as a string comprised only of hex digits. When only the key is specified using the -K option, the IV must explicitly be defined. When a password is being specified using one of the other options, the IV is generated from this password.

We follow the same approach in this PR. [Here](https://github.com/openssl/openssl/blob/91c6e157c696e8fee7320408ddb959ecf233fbaf/apps/enc.c#L585) I found the code that generates IV in OpenSSL.  
