### PR TITLE
test(consensus): fix data-race issue on consensus tests

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -304,19 +304,19 @@ func (td *testData) addVote(cons *consensus, v *vote.Vote, valID int) *vote.Vote
 
 func (*testData) newHeightTimeout(cons *consensus) {
 	cons.lk.Lock()
-	cons.currentState.onTimeout(&ticker{0, cons.height, cons.round, tickerTargetNewHeight})
+	cons.currentState.onTimeout(&ticker{time.Hour, cons.height, cons.round, tickerTargetNewHeight})
 	cons.lk.Unlock()
 }
 
 func (*testData) queryProposalTimeout(cons *consensus) {
 	cons.lk.Lock()
-	cons.currentState.onTimeout(&ticker{0, cons.height, cons.round, tickerTargetQueryProposal})
+	cons.currentState.onTimeout(&ticker{time.Hour, cons.height, cons.round, tickerTargetQueryProposal})
 	cons.lk.Unlock()
 }
 
 func (*testData) changeProposerTimeout(cons *consensus) {
 	cons.lk.Lock()
-	cons.currentState.onTimeout(&ticker{0, cons.height, cons.round, tickerTargetChangeProposer})
+	cons.currentState.onTimeout(&ticker{time.Hour, cons.height, cons.round, tickerTargetChangeProposer})
 	cons.lk.Unlock()
 }
 


### PR DESCRIPTION
## Description

This PR fixes random failures in consensus tests without adding any complexity to the test code.

In the consensus tests, we have [disabled](https://github.com/pactus-project/pactus/blob/7eb0b0ab436c77dfb8946c4920eaf94801c4b90f/consensus/consensus_test.go#L57) the timer and triggered it manually using functions like [changeProposerTimeout](https://github.com/pactus-project/pactus/blob/7eb0b0ab436c77dfb8946c4920eaf94801c4b90f/consensus/consensus_test.go#L317).

However, in `changeProposerTimeout()`, we set the ticker duration to zero, which causes the timer to be triggered again in a goroutine. See [here](https://github.com/pactus-project/pactus/blob/7eb0b0ab436c77dfb8946c4920eaf94801c4b90f/consensus/prepare.go#L74)

This PR fixes the issue by simply changing the ticker duration to one hour, preventing it from triggering the timer again.

## Related issue(s)

- Fixes #1707 