### PR TITLE
refactor(shell): rename shell command to interactive

### DIFF
--- a/cmd/shell/main.go
+++ b/cmd/shell/main.go
@@ -24,7 +24,7 @@ const (
 var _prefix string
 
 // createRootCommand creates and configures the root command with all subcommands
-// This function contains all the logic from main() but is testable
+// This function contains all the logic from main() but is testable.
 func createRootCommand() *cobra.Command {
 	var (
 		serverAddr string

--- a/cmd/shell/main.go
+++ b/cmd/shell/main.go
@@ -31,13 +31,13 @@ func main() {
 	)
 
 	rootCmd := &cobra.Command{
-		Use:          "shell",
+		Use:          "interactive",
 		Short:        "Pactus Shell",
 		SilenceUsage: true,
 		Long:         `pactus-shell is a command line tool for interacting with the Pactus blockchain using gRPC`,
 	}
 
-	shell := shell.New(rootCmd, nil,
+	interactive := shell.New(rootCmd, nil,
 		prompt.OptionSuggestionBGColor(prompt.Black),
 		prompt.OptionSuggestionTextColor(prompt.Green),
 		prompt.OptionDescriptionBGColor(prompt.Black),
@@ -50,22 +50,21 @@ func main() {
 		fs.StringVar(&password, namer("auth-password"), "", "password for gRPC basic authentication")
 	})
 
-	shell.Flags().StringVar(&serverAddr, "server-addr", defaultServerAddr, "gRPC server address")
-	shell.Flags().StringVar(&username, "auth-username", "",
+	interactive.Flags().StringVar(&serverAddr, "server-addr", defaultServerAddr, "gRPC server address")
+	interactive.Flags().StringVar(&username, "auth-username", "",
+		"username for gRPC basic authentication")
+	interactive.Flags().StringVar(&password, "auth-password", "",
 		"username for gRPC basic authentication")
 
-	shell.Flags().StringVar(&password, "auth-password", "",
-		"username for gRPC basic authentication")
-
-	shell.PreRun = func(_ *cobra.Command, _ []string) {
+	interactive.PreRun = func(_ *cobra.Command, _ []string) {
 		cls()
-		cmd.PrintInfoMsgf("Welcome to PactusBlockchain shell\n\n- Home: https://pactus.org\n- " +
+		cmd.PrintInfoMsgf("Welcome to PactusBlockchain interactive mode\n\n- Home: https://pactus.org\n- " +
 			"Docs: https://docs.pactus.org")
 		cmd.PrintLine()
 		_prefix = fmt.Sprintf("pactus@%s > ", serverAddr)
 	}
 
-	shell.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
+	interactive.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
 		setAuthContext(cmd, username, password)
 	}
 
@@ -76,10 +75,8 @@ func main() {
 	changeDefaultParameters := func(cobra *cobra.Command) *cobra.Command {
 		_ = cobra.PersistentFlags().Lookup("server-addr").Value.Set(defaultServerAddr)
 		cobra.PersistentFlags().Lookup("server-addr").DefValue = defaultServerAddr
-
 		_ = cobra.PersistentFlags().Lookup("response-format").Value.Set(defaultResponseFormat)
 		cobra.PersistentFlags().Lookup("response-format").DefValue = defaultResponseFormat
-
 		return cobra
 	}
 
@@ -88,7 +85,11 @@ func main() {
 	rootCmd.AddCommand(changeDefaultParameters(pb.TransactionClientCommand()))
 	rootCmd.AddCommand(changeDefaultParameters(pb.WalletClientCommand()))
 	rootCmd.AddCommand(clearScreen())
-	rootCmd.AddCommand(shell)
+
+	interactive.Use = "interactive"
+	interactive.Short = "Start pactus-shell in interactive mode"
+
+	rootCmd.AddCommand(interactive)
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/cmd/shell/main.go
+++ b/cmd/shell/main.go
@@ -23,7 +23,9 @@ const (
 
 var _prefix string
 
-func main() {
+// createRootCommand creates and configures the root command with all subcommands
+// This function contains all the logic from main() but is testable
+func createRootCommand() *cobra.Command {
 	var (
 		serverAddr string
 		username   string
@@ -53,6 +55,7 @@ func main() {
 	interactive.Flags().StringVar(&serverAddr, "server-addr", defaultServerAddr, "gRPC server address")
 	interactive.Flags().StringVar(&username, "auth-username", "",
 		"username for gRPC basic authentication")
+
 	interactive.Flags().StringVar(&password, "auth-password", "",
 		"username for gRPC basic authentication")
 
@@ -77,6 +80,7 @@ func main() {
 		cobra.PersistentFlags().Lookup("server-addr").DefValue = defaultServerAddr
 		_ = cobra.PersistentFlags().Lookup("response-format").Value.Set(defaultResponseFormat)
 		cobra.PersistentFlags().Lookup("response-format").DefValue = defaultResponseFormat
+
 		return cobra
 	}
 
@@ -90,6 +94,12 @@ func main() {
 	interactive.Short = "Start pactus-shell in interactive mode"
 
 	rootCmd.AddCommand(interactive)
+
+	return rootCmd
+}
+
+func main() {
+	rootCmd := createRootCommand()
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/cmd/shell/main_test.go
+++ b/cmd/shell/main_test.go
@@ -12,7 +12,7 @@ func TestCreateRootCommand(t *testing.T) {
 	// This executes the ENTIRE main() logic including all changed lines
 	rootCmd := createRootCommand()
 
-	// Verify the root command properties 
+	// Verify the root command properties
 	require.Equal(t, "interactive", rootCmd.Use)
 	require.Equal(t, "Pactus Shell", rootCmd.Short)
 	require.Contains(t, rootCmd.Long, "pactus-shell is a command line tool")
@@ -89,7 +89,7 @@ func TestLivePrefix(t *testing.T) {
 	require.Equal(t, "test@localhost > ", prefix)
 }
 
-// TestClearScreenCommand tests the clearScreen function
+// TestClearScreenCommand tests the clearScreen function.
 func TestClearScreenCommand(t *testing.T) {
 	clearCmd := clearScreen()
 
@@ -118,13 +118,13 @@ func TestSetAuthContext(t *testing.T) {
 	require.NotEqual(t, originalCtx, rootCmd.Context())
 }
 
-// TestConstants tests the defined constants
+// TestConstants tests the defined constants.
 func TestConstants(t *testing.T) {
 	require.Equal(t, "localhost:50051", defaultServerAddr)
 	require.Equal(t, "prettyjson", defaultResponseFormat)
 }
 
-// TestClsFunction tests the cls function doesn't panic
+// TestClsFunction tests the cls function doesn't panic.
 func TestClsFunction(t *testing.T) {
 	require.NotPanics(t, func() {
 		cls()

--- a/cmd/shell/main_test.go
+++ b/cmd/shell/main_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+func TestCreateRootCommand(t *testing.T) {
+	// This executes the ENTIRE main() logic including all changed lines
+	rootCmd := createRootCommand()
+
+	// Verify the root command properties 
+	require.Equal(t, "interactive", rootCmd.Use)
+	require.Equal(t, "Pactus Shell", rootCmd.Short)
+	require.Contains(t, rootCmd.Long, "pactus-shell is a command line tool")
+	require.True(t, rootCmd.SilenceUsage)
+
+	// Verify interactive command was added
+	var interactiveCmd *cobra.Command
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "interactive" {
+			interactiveCmd = cmd
+			break
+		}
+	}
+
+	require.NotNil(t, interactiveCmd, "interactive command should be added")
+	require.Equal(t, "interactive", interactiveCmd.Use)
+	require.Equal(t, "Start pactus-shell in interactive mode", interactiveCmd.Short)
+
+	// Verify flags were set up 
+	serverAddrFlag := interactiveCmd.Flags().Lookup("server-addr")
+	require.NotNil(t, serverAddrFlag)
+	require.Equal(t, defaultServerAddr, serverAddrFlag.DefValue)
+
+	usernameFlag := interactiveCmd.Flags().Lookup("auth-username")
+	require.NotNil(t, usernameFlag)
+
+	passwordFlag := interactiveCmd.Flags().Lookup("auth-password")
+	require.NotNil(t, passwordFlag)
+
+	// Verify PreRun and PersistentPreRun are set 
+	require.NotNil(t, interactiveCmd.PreRun)
+	require.NotNil(t, interactiveCmd.PersistentPreRun)
+
+	// Execute PreRun to hit
+	interactiveCmd.PreRun(nil, nil)
+
+	// Execute PersistentPreRun
+	testCmd := &cobra.Command{}
+	testCmd.SetContext(context.Background())
+	interactiveCmd.PersistentPreRun(testCmd, nil)
+
+	// Verify other commands were added
+	var clearCmd *cobra.Command
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "clear" {
+			clearCmd = cmd
+			break
+		}
+	}
+	require.NotNil(t, clearCmd)
+
+
+	rootCmd.SetArgs([]string{"--help"})
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	rootCmd.SetArgs([]string{"interactive", "--help"})
+	err = rootCmd.Execute()
+	require.NoError(t, err)
+
+	// Test that main function would work
+	require.NotNil(t, rootCmd)
+	require.Equal(t, "interactive", rootCmd.Use)
+}
+
+// TestLivePrefix tests the livePrefix function
+func TestLivePrefix(t *testing.T) {
+	_prefix = "test@localhost > "
+
+	prefix, ok := livePrefix()
+	require.True(t, ok)
+	require.Equal(t, "test@localhost > ", prefix)
+}
+
+// TestClearScreenCommand tests the clearScreen function
+func TestClearScreenCommand(t *testing.T) {
+	clearCmd := clearScreen()
+
+	require.NotNil(t, clearCmd)
+	require.Equal(t, "clear", clearCmd.Use)
+	require.Equal(t, "clear screen", clearCmd.Short)
+	require.NotNil(t, clearCmd.Run)
+
+	// Test that the Run function works without error
+	clearCmd.Run(nil, nil)
+}
+
+// TestSetAuthContext tests the setAuthContext function
+func TestSetAuthContext(t *testing.T) {
+	rootCmd := &cobra.Command{}
+	rootCmd.SetContext(context.Background())
+
+	// Test with empty credentials (should not modify context)
+	originalCtx := rootCmd.Context()
+	setAuthContext(rootCmd, "", "")
+	require.Equal(t, originalCtx, rootCmd.Context())
+
+	// Test with valid credentials (should set auth context)
+	setAuthContext(rootCmd, "testuser", "testpass")
+	require.NotNil(t, rootCmd.Context())
+	require.NotEqual(t, originalCtx, rootCmd.Context())
+}
+
+// TestConstants tests the defined constants
+func TestConstants(t *testing.T) {
+	require.Equal(t, "localhost:50051", defaultServerAddr)
+	require.Equal(t, "prettyjson", defaultResponseFormat)
+}
+
+// TestClsFunction tests the cls function doesn't panic
+func TestClsFunction(t *testing.T) {
+	// Test that cls() doesn't panic
+	cls()
+}

--- a/cmd/shell/main_test.go
+++ b/cmd/shell/main_test.go
@@ -59,6 +59,7 @@ func TestCreateRootCommand(t *testing.T) {
 	for _, cmd := range rootCmd.Commands() {
 		if cmd.Use == "clear" {
 			clearCmd = cmd
+
 			break
 		}
 	}
@@ -78,7 +79,7 @@ func TestCreateRootCommand(t *testing.T) {
 	require.Equal(t, "interactive", rootCmd.Use)
 }
 
-// TestLivePrefix tests the livePrefix function
+// TestLivePrefix tests the livePrefix function.
 func TestLivePrefix(t *testing.T) {
 	_prefix = "test@localhost > "
 
@@ -100,7 +101,7 @@ func TestClearScreenCommand(t *testing.T) {
 	clearCmd.Run(nil, nil)
 }
 
-// TestSetAuthContext tests the setAuthContext function
+// TestSetAuthContext tests the setAuthContext function.
 func TestSetAuthContext(t *testing.T) {
 	rootCmd := &cobra.Command{}
 	rootCmd.SetContext(context.Background())

--- a/cmd/shell/main_test.go
+++ b/cmd/shell/main_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
+
 func TestCreateRootCommand(t *testing.T) {
 	// This executes the ENTIRE main() logic including all changed lines
 	rootCmd := createRootCommand()

--- a/cmd/shell/main_test.go
+++ b/cmd/shell/main_test.go
@@ -23,6 +23,7 @@ func TestCreateRootCommand(t *testing.T) {
 	for _, cmd := range rootCmd.Commands() {
 		if cmd.Use == "interactive" {
 			interactiveCmd = cmd
+
 			break
 		}
 	}
@@ -125,6 +126,7 @@ func TestConstants(t *testing.T) {
 
 // TestClsFunction tests the cls function doesn't panic
 func TestClsFunction(t *testing.T) {
-	// Test that cls() doesn't panic
-	cls()
+	assert.NotPanics(t, func() {
+		cls()
+	}, "calling cls() shoul not panic")
 }

--- a/cmd/shell/main_test.go
+++ b/cmd/shell/main_test.go
@@ -126,7 +126,7 @@ func TestConstants(t *testing.T) {
 
 // TestClsFunction tests the cls function doesn't panic
 func TestClsFunction(t *testing.T) {
-	assert.NotPanics(t, func() {
+	require.NotPanics(t, func() {
 		cls()
 	}, "calling cls() shoul not panic")
 }

--- a/cmd/shell/main_test.go
+++ b/cmd/shell/main_test.go
@@ -32,7 +32,7 @@ func TestCreateRootCommand(t *testing.T) {
 	require.Equal(t, "interactive", interactiveCmd.Use)
 	require.Equal(t, "Start pactus-shell in interactive mode", interactiveCmd.Short)
 
-	// Verify flags were set up 
+	// Verify flags were set up
 	serverAddrFlag := interactiveCmd.Flags().Lookup("server-addr")
 	require.NotNil(t, serverAddrFlag)
 	require.Equal(t, defaultServerAddr, serverAddrFlag.DefValue)
@@ -43,7 +43,7 @@ func TestCreateRootCommand(t *testing.T) {
 	passwordFlag := interactiveCmd.Flags().Lookup("auth-password")
 	require.NotNil(t, passwordFlag)
 
-	// Verify PreRun and PersistentPreRun are set 
+	// Verify PreRun and PersistentPreRun are set
 	require.NotNil(t, interactiveCmd.PreRun)
 	require.NotNil(t, interactiveCmd.PersistentPreRun)
 
@@ -65,7 +65,6 @@ func TestCreateRootCommand(t *testing.T) {
 		}
 	}
 	require.NotNil(t, clearCmd)
-
 
 	rootCmd.SetArgs([]string{"--help"})
 	err := rootCmd.Execute()

--- a/util/shell/shell.go
+++ b/util/shell/shell.go
@@ -21,7 +21,7 @@ type lexer struct {
 	stdin   *term.State
 }
 
-// New creates a Cobra CLI command named "shell" which runs an interactive shell prompt for the root command.
+// New creates a Cobra CLI command named "interactive" which runs an interactive shell prompt for the root command.
 func New(root *cobra.Command, refresh func() *cobra.Command, opts ...prompt.Option) *cobra.Command {
 	lexer := &lexer{
 		root:    root,
@@ -33,8 +33,8 @@ func New(root *cobra.Command, refresh func() *cobra.Command, opts ...prompt.Opti
 	opts = append(opts, prompt.OptionPrefix(prefix), prompt.OptionShowCompletionAtStart())
 
 	return &cobra.Command{
-		Use:   "shell",
-		Short: "Start an interactive shell.",
+		Use:   "interactive",
+		Short: "Start pactus-shell in interactive mode.",
 		Run: func(cmd *cobra.Command, _ []string) {
 			lexer.saveStdin()
 

--- a/util/shell/shell_test.go
+++ b/util/shell/shell_test.go
@@ -148,6 +148,7 @@ func hasSubcommand(cmd *cobra.Command, name string) bool {
 
 	return false
 }
+
 func TestNew_CommandProperties(t *testing.T) {
 	// Test that the New function creates a command with correct properties
 	root := &cobra.Command{}
@@ -232,8 +233,8 @@ func TestChangedLinesExecution(t *testing.T) {
 	cmd := New(root, nil)
 
 	// Verify the exact changes
-	require.Equal(t, "interactive", cmd.Use)                               // Line 36
-	require.Equal(t, "Start pactus-shell in interactive mode.", cmd.Short) // Line 37
+	require.Equal(t, "interactive", cmd.Use)
+	require.Equal(t, "Start pactus-shell in interactive mode.", cmd.Short)
 
 	require.NotEqual(t, "shell", cmd.Use)
 	require.NotEqual(t, "Start an interactive shell.", cmd.Short)

--- a/util/shell/shell_test.go
+++ b/util/shell/shell_test.go
@@ -148,3 +148,93 @@ func hasSubcommand(cmd *cobra.Command, name string) bool {
 
 	return false
 }
+func TestNew_CommandProperties(t *testing.T) {
+	// Test that the New function creates a command with correct properties
+	root := &cobra.Command{}
+
+	interactiveCmd := New(root, nil)
+
+	require.Equal(t, "interactive", interactiveCmd.Use)
+	require.Equal(t, "Start pactus-shell in interactive mode.", interactiveCmd.Short)
+	require.NotNil(t, interactiveCmd.Run)
+}
+
+func TestNew_CommandName(t *testing.T) {
+	// Test that the command is named "interactive" not "shell"
+	root := &cobra.Command{}
+
+	interactiveCmd := New(root, nil)
+
+	require.Equal(t, "interactive", interactiveCmd.Name())
+	require.NotEqual(t, "shell", interactiveCmd.Name())
+}
+
+func TestNew_WithOptions(t *testing.T) {
+	// Test that New function accepts prompt options
+	root := &cobra.Command{}
+
+	// Test with some dummy options
+	interactiveCmd := New(root, nil,
+		prompt.OptionPrefix("test> "),
+		prompt.OptionShowCompletionAtStart(),
+	)
+
+	require.Equal(t, "interactive", interactiveCmd.Use)
+	require.NotNil(t, interactiveCmd.Run)
+}
+func TestNew_InteractiveCommandCreation(t *testing.T) {
+	// Test that the New function creates a command with the exact changed properties
+	root := &cobra.Command{}
+
+	interactiveCmd := New(root, nil)
+
+	// Verify the specific changed lines
+	require.Equal(t, "interactive", interactiveCmd.Use)
+	require.Equal(t, "Start pactus-shell in interactive mode.", interactiveCmd.Short)
+	require.NotNil(t, interactiveCmd.Run)
+
+	// Test that it's not the old values
+	require.NotEqual(t, "shell", interactiveCmd.Use)
+	require.NotEqual(t, "Start an interactive shell.", interactiveCmd.Short)
+}
+
+func TestNew_WithAllOptions(t *testing.T) {
+	root := &cobra.Command{}
+	refresh := func() *cobra.Command { return root }
+
+	interactiveCmd := New(root, refresh,
+		prompt.OptionPrefix("test> "),
+		prompt.OptionShowCompletionAtStart(),
+		prompt.OptionSuggestionBGColor(prompt.Black),
+		prompt.OptionSuggestionTextColor(prompt.Green),
+	)
+
+	// Verify the changed properties are correct
+	require.Equal(t, "interactive", interactiveCmd.Use)
+	require.Equal(t, "Start pactus-shell in interactive mode.", interactiveCmd.Short)
+	require.NotNil(t, interactiveCmd.Run)
+}
+
+func TestNew_CommandNameNotShell(t *testing.T) {
+	// Explicitly test that the command is NOT named "shell" anymore
+	root := &cobra.Command{}
+
+	interactiveCmd := New(root, nil)
+
+	// This ensures we're testing the actual change
+	require.NotEqual(t, "shell", interactiveCmd.Name())
+	require.Equal(t, "interactive", interactiveCmd.Name())
+}
+
+func TestChangedLinesExecution(t *testing.T) {
+	root := &cobra.Command{}
+
+	cmd := New(root, nil)
+
+	// Verify the exact changes
+	require.Equal(t, "interactive", cmd.Use)                               // Line 36
+	require.Equal(t, "Start pactus-shell in interactive mode.", cmd.Short) // Line 37
+
+	require.NotEqual(t, "shell", cmd.Use)
+	require.NotEqual(t, "Start an interactive shell.", cmd.Short)
+}

--- a/util/shell/shell_test.go
+++ b/util/shell/shell_test.go
@@ -183,6 +183,7 @@ func TestNew_WithOptions(t *testing.T) {
 	require.Equal(t, "interactive", interactiveCmd.Use)
 	require.NotNil(t, interactiveCmd.Run)
 }
+
 func TestNew_InteractiveCommandCreation(t *testing.T) {
 	// Test that the New function creates a command with the exact changed properties
 	root := &cobra.Command{}


### PR DESCRIPTION
# Rename Shell Command to Interactive

## Overview
This PR changes the command name from "shell" to "interactive" (issue #1717)for a more accurate representation of the functionality. The command provides an interactive CLI for interacting with the Pactus blockchain.

## Changes
- Renamed the shell command to "interactive" throughout the codebase
- Updated welcome message to "Welcome to PactusBlockchain interactive mode"
- Modified unit tests to reflect the new command name
- Maintained all existing functionality while using the new name

## Testing
- Verified basic interactive mode functionality
- Checked command completion works correctly
- Tested all blockchain/network/transaction/wallet service commands
- Ran all unit tests to ensure they pass with new naming
