### PR TITLE
fix(grpc): update gRPC client to use @grpc/grpc-js

### DIFF
--- a/.github/packager/js/package.json
+++ b/.github/packager/js/package.json
@@ -2,17 +2,11 @@
   "name": "pactus-grpc",
   "version": "{{ VERSION }}",
   "description": "Pactus gRPC client for JavaScript",
+  "author": "Pactus Developers",
+  "license": "MIT",
+  "homepage": "https://github.com/pactus-project/pactus#readme",
   "main": "index.js",
   "types": "index.d.ts",
-  "files": [
-    "**/*.js",
-    "**/*.d.ts",
-    "LICENSE",
-    "README.md"
-  ],
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pactus-project/pactus.git"
@@ -22,14 +16,14 @@
     "grpc",
     "blockchain"
   ],
-  "author": "Pactus Developers",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/pactus-project/pactus/issues"
   },
-  "homepage": "https://github.com/pactus-project/pactus#readme",
   "dependencies": {
-    "@grpc/grpc-js": "^1.8.0",
-    "google-protobuf": "^3.21.0"
+    "@grpc/grpc-js": "^1.9.13",
+    "google-protobuf": "^3.21.2"
+  },
+  "devDependencies": {
+    "grpc-tools": "^1.12.4"
   }
 } 

--- a/www/grpc/buf/buf.gen.yaml
+++ b/www/grpc/buf/buf.gen.yaml
@@ -38,7 +38,9 @@ plugins:
     # https://buf.build/grpc/node
   - remote: buf.build/grpc/node:v1.13.0
     out: ./gen/js
-    opt: import_style=commonjs
+    opt: 
+      - import_style=commonjs
+      - grpc_js
     # https://buf.build/protocolbuffers/dart
   - remote: buf.build/protocolbuffers/dart:v22.0.1
     out: ./gen/dart

--- a/www/grpc/gen/js/blockchain_grpc_pb.js
+++ b/www/grpc/gen/js/blockchain_grpc_pb.js
@@ -1,7 +1,7 @@
 // GENERATED CODE -- DO NOT EDIT!
 
 'use strict';
-var grpc = require('grpc');
+var grpc = require('@grpc/grpc-js');
 var blockchain_pb = require('./blockchain_pb.js');
 var transaction_pb = require('./transaction_pb.js');
 

--- a/www/grpc/gen/js/network_grpc_pb.js
+++ b/www/grpc/gen/js/network_grpc_pb.js
@@ -1,7 +1,7 @@
 // GENERATED CODE -- DO NOT EDIT!
 
 'use strict';
-var grpc = require('grpc');
+var grpc = require('@grpc/grpc-js');
 var network_pb = require('./network_pb.js');
 
 function serialize_pactus_GetNetworkInfoRequest(arg) {

--- a/www/grpc/gen/js/transaction_grpc_pb.js
+++ b/www/grpc/gen/js/transaction_grpc_pb.js
@@ -1,7 +1,7 @@
 // GENERATED CODE -- DO NOT EDIT!
 
 'use strict';
-var grpc = require('grpc');
+var grpc = require('@grpc/grpc-js');
 var transaction_pb = require('./transaction_pb.js');
 
 function serialize_pactus_BroadcastTransactionRequest(arg) {

--- a/www/grpc/gen/js/utils_grpc_pb.js
+++ b/www/grpc/gen/js/utils_grpc_pb.js
@@ -1,7 +1,7 @@
 // GENERATED CODE -- DO NOT EDIT!
 
 'use strict';
-var grpc = require('grpc');
+var grpc = require('@grpc/grpc-js');
 var utils_pb = require('./utils_pb.js');
 
 function serialize_pactus_PublicKeyAggregationRequest(arg) {

--- a/www/grpc/gen/js/wallet_grpc_pb.js
+++ b/www/grpc/gen/js/wallet_grpc_pb.js
@@ -1,7 +1,7 @@
 // GENERATED CODE -- DO NOT EDIT!
 
 'use strict';
-var grpc = require('grpc');
+var grpc = require('@grpc/grpc-js');
 var wallet_pb = require('./wallet_pb.js');
 
 function serialize_pactus_CreateWalletRequest(arg) {


### PR DESCRIPTION
The `grpc` library for Node.js was officially deprecated in April 2021 and is no longer receiving updates [here](https://www.npmjs.com/package/grpc). I advised to migrate to `@grpc/grpc-js`

- add option grpc in yaml file
- remove script and reorder in package json file 

run test in local 

![image](https://github.com/user-attachments/assets/ac1113e2-95d7-4385-af5e-d428009624d3)
