### PR TITLE
chore(network): rename SendRequest to SendTo

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -364,7 +364,7 @@ func (n *network) Protect(pid lp2pcore.PeerID, tag string) {
 // It uses a goroutine to ensure that if sending is blocked, receiving messages won't be blocked.
 func (n *network) SendTo(msg []byte, pid lp2pcore.PeerID) {
 	go func() {
-		_, err := n.stream.SendRequest(msg, pid)
+		_, err := n.stream.SendTo(msg, pid)
 		if err != nil {
 			n.logger.Warn("error on sending msg", "pid", pid, "error", err)
 		}

--- a/network/stream.go
+++ b/network/stream.go
@@ -54,13 +54,13 @@ func (s *streamService) handleStream(stream lp2pnetwork.Stream) {
 	s.networkPipe.Send(event)
 }
 
-// SendRequest sends a message to a specific peer, assuming there is already a direct connection.
+// SendTo sends a message to a specific peer, assuming there is already a direct connection.
 //
 // For simplicity, we do not use bi-directional streams.
 // Each time a peer wants to send a message, it creates a new stream.
 //
 // For more details on stream multiplexing, refer to: https://docs.libp2p.io/concepts/multiplex/overview/
-func (s *streamService) SendRequest(msg []byte, pid lp2peer.ID) (lp2pnetwork.Stream, error) {
+func (s *streamService) SendTo(msg []byte, pid lp2peer.ID) (lp2pnetwork.Stream, error) {
 	s.logger.Trace("sending stream", "to", pid)
 	_, err := s.host.Peerstore().SupportsProtocols(pid, s.protocolID)
 	if err != nil {

--- a/network/stream_test.go
+++ b/network/stream_test.go
@@ -29,7 +29,7 @@ func TestCloseStream(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	t.Run("Stream timeout", func(t *testing.T) {
-		stream, err := networkA.stream.SendRequest([]byte("test-1"), networkB.SelfID())
+		stream, err := networkA.stream.SendTo([]byte("test-1"), networkB.SelfID())
 		require.NoError(t, err)
 
 		// NetworkB doesn't close the stream.
@@ -47,7 +47,7 @@ func TestCloseStream(t *testing.T) {
 	})
 
 	t.Run("Stream closed", func(t *testing.T) {
-		stream, err := networkA.stream.SendRequest([]byte("test-2"), networkB.SelfID())
+		stream, err := networkA.stream.SendTo([]byte("test-2"), networkB.SelfID())
 		require.NoError(t, err)
 
 		// NetworkB close the stream.


### PR DESCRIPTION
## Description

Rename `SendRequest` to `SendTo` in Stream, as it may also be used to send response payloads to the peer.