### PR TITLE
test(network): added unit test for loadOrCreateKey

### DIFF
--- a/network/network_test.go
+++ b/network/network_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -512,14 +511,13 @@ func TestLoadOrCreateKey(t *testing.T) {
 	})
 
 	t.Run("Should return error when file contains invalid private key", func(t *testing.T) {
-		tempFile, err := os.CreateTemp("", "invalid_key")
-		assert.NoError(t, err)
+		tempFilePath := util.TempFilePath()
 
 		// Writes an invalid private key to the file, decoding key will fail later
-		err = util.WriteFile(tempFile.Name(), []byte("invalid_data"))
+		err := util.WriteFile(tempFilePath, []byte("invalid_data"))
 		assert.NoError(t, err)
 
-		key, err := loadOrCreateKey(tempFile.Name())
+		key, err := loadOrCreateKey(tempFilePath)
 		assert.Error(t, err)
 		assert.Nil(t, key)
 	})


### PR DESCRIPTION
## Description

> Added unit test for loadOrCreateKey, tested with the following cases:

1. Valid Private Key created
2. Invalid Private Key in existing file
3. Input supplied with directory instead of file path
4. Input supplied with invalid file path

## Related Issue

> Nil

Fixes # (issue)

- Increased Unit Test Coverage from 76.6% to 82.1% in `network_test.go`
