### PR TITLE
refactor(other): use slices.Contains to simplify code

### DIFF
--- a/consensus/cp.go
+++ b/consensus/cp.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/types/proposal"
@@ -24,10 +25,8 @@ func (cp *changeProposer) onTimeout(t *ticker) {
 }
 
 func (*changeProposer) checkCPValue(vote *vote.Vote, allowedValues ...vote.CPValue) error {
-	for _, v := range allowedValues {
-		if vote.CPValue() == v {
-			return nil
-		}
+	if slices.Contains(allowedValues, vote.CPValue()) {
+		return nil
 	}
 
 	return InvalidJustificationError{

--- a/util/slice.go
+++ b/util/slice.go
@@ -6,6 +6,7 @@ import (
 	"crypto/subtle"
 	"encoding/binary"
 	"math/rand"
+	"slices"
 )
 
 func Uint16ToSlice(n uint16) []byte {
@@ -116,14 +117,7 @@ func Subtracts(slice1, slice2 []int32) []int32 {
 	}
 
 	for _, num1 := range slice1 {
-		found := false
-		for _, num2 := range slice2 {
-			if num1 == num2 {
-				found = true
-
-				break
-			}
-		}
+		found := slices.Contains(slice2, num1)
 		if !found {
 			sub = append(sub, num1)
 		}
@@ -134,13 +128,7 @@ func Subtracts(slice1, slice2 []int32) []int32 {
 
 // Contains checks whether the given slice has a specific item.
 func Contains[T comparable](slice []T, item T) bool {
-	for _, i := range slice {
-		if i == item {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(slice, item)
 }
 
 // Equal tells whether a and b contain the same elements.


### PR DESCRIPTION
## Description

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.


