### PR TITLE
fix(sync): drop messages with mimatched consensus height

### DIFF
--- a/sync/bundle/bundle.go
+++ b/sync/bundle/bundle.go
@@ -23,11 +23,6 @@ const (
 type fixedUint32 uint32
 
 func (u fixedUint32) MarshalCBOR() ([]byte, error) {
-	if u == 0 {
-		// Why can't be empty??
-		return []byte{0}, nil
-	}
-
 	buf := make([]byte, 0, 5)
 
 	// The header for a 4-byte integer is 0x1A followed by the 4 bytes of the uint32.

--- a/sync/bundle/bundle_test.go
+++ b/sync/bundle/bundle_test.go
@@ -83,7 +83,7 @@ func TestDecodeVoteCBOR(t *testing.T) {
 			"" + "f40551e4ff89f3d235e32b4b92055501c0067d277f2dff99943016d6a0f379cf" +
 			"" + "09846c6f06f60758308ab7aecbe03c4ed5b688bcb7e848baffa62bcbf1a40215" +
 			"" + "22c56693f0a7bbcc1fe865277556ee59c1f63ba592acfe1b43" +
-			"041a00001234") // Consensus Height (0x1234)
+			"041a00001234") // Consensus Height (0x00001234)
 	data2, _ := hex.DecodeString(
 		"a4" + // Map(4)
 			"01190100" + // Flags = 0x0100 (compressed)
@@ -94,7 +94,7 @@ func TestDecodeVoteCBOR(t *testing.T) {
 			"" + "067d277f2dff99943016d6a0f379cf09846c6f06f60758308ab7aecbe03c4ed5" +
 			"" + "b688bcb7e848baffa62bcbf1a4021522c56693f0a7bbcc1fe865277556ee59c1" +
 			"" + "f63ba592acfe1b43010000ffff798ce7ec79000000" +
-			"041a00001234") // Consensus Height (0x1234)
+			"041a00001234") // Consensus Height (0x00001234)
 
 	bdl1 := new(Bundle)
 	bdl2 := new(Bundle)
@@ -127,7 +127,7 @@ func TestEncodingData(t *testing.T) {
 			"" + "0100" +
 			"" + "0212" +
 			"" + "0313" +
-			"0400" // Consensus height (0x00)
+			"041a00000000" // Consensus height (0x00000000)
 		assert.Equal(t, expectedData, hex.EncodeToString(data))
 		assert.Equal(t, uint32(0x00), bdl.ConsensusHeight)
 	})
@@ -148,7 +148,7 @@ func TestEncodingData(t *testing.T) {
 			"" + "0112" +
 			"" + "0201" +
 			"" + "0355" + hex.EncodeToString(rndAddr.Bytes()) +
-			"041a00000012" // Consensus height (0x12)
+			"041a00000012" // Consensus height (0x00000012)
 		assert.Equal(t, expectedData, hex.EncodeToString(data))
 		assert.Equal(t, uint32(0x12), bdl.ConsensusHeight)
 	})

--- a/sync/firewall/firewall.go
+++ b/sync/firewall/firewall.go
@@ -78,7 +78,7 @@ func (f *Firewall) OpenGossipBundle(data []byte, from peer.ID) (*bundle.Bundle, 
 			"message_height", bdl.Message.ConsensusHeight(),
 		)
 
-		// Drop the message. n future release we should ban these peers.
+		// Drop the message. In next releases we may ban these peers.
 		return nil, ErrMisMatchConsensusHeight
 	}
 
@@ -230,8 +230,9 @@ func (f *Firewall) isExpiredMessage(msgData []byte) bool {
 		return true
 	}
 
-	consensusHeightRaw := msgData[msgLen-6:]
-	consensusHeight := binary.BigEndian.Uint32(consensusHeightRaw[2:])
+	// Consensus height is the last 4 bytes of the bundle.
+	// Refer to the bundle encoding for more details.
+	consensusHeight := binary.BigEndian.Uint32(msgData[msgLen-4:])
 
 	// The message is expired, or the consensus height is behind the network's current height.
 	if f.state.LastBlockHeight() > 0 && consensusHeight < f.state.LastBlockHeight()-1 {

--- a/sync/firewall/firewall.go
+++ b/sync/firewall/firewall.go
@@ -78,9 +78,8 @@ func (f *Firewall) OpenGossipBundle(data []byte, from peer.ID) (*bundle.Bundle, 
 			"message_height", bdl.Message.ConsensusHeight(),
 		)
 
-		f.peerSet.UpdateStatus(from, status.StatusBanned)
-
-		return bdl, ErrMisMatchConsensusHeight
+		// Drop the message. n future release we should ban these peers.
+		return nil, ErrMisMatchConsensusHeight
 	}
 
 	return bdl, nil

--- a/sync/firewall/firewall_test.go
+++ b/sync/firewall/firewall_test.go
@@ -179,11 +179,12 @@ func TestGossipMismatchBundleHeight(t *testing.T) {
 		"04" + "1a0000029a" // Bundle Consensus Height = 666
 
 	rawMsg := td.DecodingHex(corruptedData)
-	_, err := td.firewall.OpenGossipBundle(rawMsg, td.unknownPeerID)
+	bdl, err := td.firewall.OpenGossipBundle(rawMsg, td.unknownPeerID)
+	assert.Nil(t, bdl)
 	assert.Error(t, err)
 	assert.Equal(t, err, ErrMisMatchConsensusHeight)
 
-	assert.Equal(t, status.StatusBanned, td.firewall.peerSet.GetPeerStatus(td.unknownPeerID))
+	assert.Equal(t, status.StatusUnknown, td.firewall.peerSet.GetPeerStatus(td.unknownPeerID))
 }
 
 func TestGossipMessage(t *testing.T) {


### PR DESCRIPTION
## Description

This PR drops messages with mismatched consensus height instead of banning the peers,
to support nodes running older versions.