### PR TITLE
refactor(util): use the built-in max/min to simplify the code

### DIFF
--- a/util/bech32m/bech32m.go
+++ b/util/bech32m/bech32m.go
@@ -315,10 +315,7 @@ func ConvertBits(data []byte, fromBits, toBits uint8, pad bool) ([]byte, error) 
 
 			// The number of bytes to next extract is the minimum of
 			// remFromBits and remToBits.
-			toExtract := remFromBits
-			if remToBits < toExtract {
-				toExtract = remToBits
-			}
+			toExtract := min(remToBits, remFromBits)
 
 			// Add the next bits to nextByte, shifting the already
 			// added bits to the left.


### PR DESCRIPTION
## Description

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


