### PR TITLE
ci(docker): trigger on version tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   push:
-    tags: ["v*.*.*"] # Trigger on version tags (e.g., v1.0.0)
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"] # Trigger on version tags (e.g., v1.0.0)
     branches: ["main"]
 
 env:


### PR DESCRIPTION
## Description

This PR ensures Docker images are published only for version tags (not for tags like release candidates).