### PR TITLE
refactor(util): use slices.Equal to simplify code

### DIFF
--- a/util/bip39/bip39.go
+++ b/util/bip39/bip39.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 
 	"github.com/pactus-project/pactus/util/bip39/wordlists"
@@ -341,16 +342,7 @@ func padByteSlice(slice []byte, length int) []byte {
 // compareByteSlices returns true of the byte slices have equal contents and
 // returns false otherwise.
 func compareByteSlices(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
+	return slices.Equal(a, b)
 }
 
 func splitMnemonicWords(mnemonic string) ([]string, bool) {


### PR DESCRIPTION
## Description

In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).

## Related Issue

Fixes # (issue)
