### PR TITLE
fix(cmd): prevent panic on redownloading chunk

### DIFF
--- a/cmd/daemon/import.go
+++ b/cmd/daemon/import.go
@@ -119,8 +119,7 @@ func downloadProgressBar(fileName string) func(stats downloader.Stats) {
 				util.FormatBytesToHumanReadable(uint64(stats.Downloaded)),
 				util.FormatBytesToHumanReadable(uint64(stats.TotalSize)),
 			))
-			err := bar.Add64(stats.Downloaded)
-			cmd.FatalErrorCheck(err)
+			_ = bar.Add64(stats.Downloaded)
 		}
 	}
 }

--- a/cmd/daemon/import.go
+++ b/cmd/daemon/import.go
@@ -119,6 +119,7 @@ func downloadProgressBar(fileName string) func(stats downloader.Stats) {
 				util.FormatBytesToHumanReadable(uint64(stats.Downloaded)),
 				util.FormatBytesToHumanReadable(uint64(stats.TotalSize)),
 			))
+			// Ignore progress bar errors
 			_ = bar.Add64(stats.Downloaded)
 		}
 	}


### PR DESCRIPTION
## Description

Prevent a panic on progress bar when a chunk was re-downloaded.

Fixes #1848 