### PR TITLE
test(network): disable mDNS discovery test for macOS

### DIFF
--- a/network/config.go
+++ b/network/config.go
@@ -32,27 +32,29 @@ type Config struct {
 	IsBootstrapper              bool          `toml:"-"`
 	PeerStorePath               string        `toml:"-"`
 	StreamTimeout               time.Duration `toml:"-"`
+	CheckConnectivityInterval   time.Duration `toml:"-"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		NetworkKey:           "network_key",
-		PublicAddrString:     "",
-		ListenAddrStrings:    []string{},
-		BootstrapAddrStrings: []string{},
-		MaxConns:             64,
-		EnableUDP:            false,
-		EnableNATService:     false,
-		EnableUPnP:           false,
-		EnableRelay:          true,
-		EnableRelayService:   false,
-		EnableMdns:           false,
-		EnableMetrics:        false,
-		ForcePrivateNetwork:  false,
-		DefaultPort:          0,
-		IsBootstrapper:       false,
-		PeerStorePath:        "peers.json",
-		StreamTimeout:        20 * time.Second,
+		NetworkKey:                "network_key",
+		PublicAddrString:          "",
+		ListenAddrStrings:         []string{},
+		BootstrapAddrStrings:      []string{},
+		MaxConns:                  64,
+		EnableUDP:                 false,
+		EnableNATService:          false,
+		EnableUPnP:                false,
+		EnableRelay:               true,
+		EnableRelayService:        false,
+		EnableMdns:                false,
+		EnableMetrics:             false,
+		ForcePrivateNetwork:       false,
+		DefaultPort:               0,
+		IsBootstrapper:            false,
+		PeerStorePath:             "peers.json",
+		StreamTimeout:             20 * time.Second,
+		CheckConnectivityInterval: 60 * time.Second,
 	}
 }
 

--- a/network/mdns_test.go
+++ b/network/mdns_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -8,6 +9,12 @@ import (
 )
 
 func TestMDNS(t *testing.T) {
+	if runtime.GOOS == "ios" {
+		// Disable this test on iOS
+		// Read more here: https://github.com/pactus-project/pactus/issues/1860
+		return
+	}
+
 	conf1 := testConfig()
 	conf1.ListenAddrStrings = []string{
 		"/ip6/::1/tcp/0", "/ip6/::1/udp/0/quic-v1",

--- a/network/mdns_test.go
+++ b/network/mdns_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestMDNS(t *testing.T) {
-	if runtime.GOOS == "ios" {
-		// Disable this test on iOS
+	if runtime.GOOS == "darwin" {
+		// Disable this test on darwin (macOS)
 		// Read more here: https://github.com/pactus-project/pactus/issues/1860
 		return
 	}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -44,7 +44,7 @@ func testConfig() *Config {
 		ListenAddrStrings:    []string{},
 		NetworkKey:           util.TempFilePath(),
 		BootstrapAddrStrings: []string{},
-		MaxConns:             8,
+		MaxConns:             16,
 		EnableUDP:            true,
 		EnableNATService:     false,
 		EnableUPnP:           false,

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -41,21 +41,22 @@ func makeTestNetwork(t *testing.T, conf *Config, opts []lp2p.Option) *network {
 
 func testConfig() *Config {
 	return &Config{
-		ListenAddrStrings:    []string{},
-		NetworkKey:           util.TempFilePath(),
-		BootstrapAddrStrings: []string{},
-		MaxConns:             16,
-		EnableUDP:            true,
-		EnableNATService:     false,
-		EnableUPnP:           false,
-		EnableRelay:          false,
-		EnableRelayService:   false,
-		EnableMdns:           false,
-		ForcePrivateNetwork:  true,
-		NetworkName:          "test",
-		DefaultPort:          FindFreePort(),
-		PeerStorePath:        util.TempFilePath(),
-		StreamTimeout:        10 * time.Second,
+		ListenAddrStrings:         []string{},
+		NetworkKey:                util.TempFilePath(),
+		BootstrapAddrStrings:      []string{},
+		MaxConns:                  16,
+		EnableUDP:                 true,
+		EnableNATService:          false,
+		EnableUPnP:                false,
+		EnableRelay:               false,
+		EnableRelayService:        false,
+		EnableMdns:                false,
+		ForcePrivateNetwork:       true,
+		NetworkName:               "test",
+		DefaultPort:               FindFreePort(),
+		PeerStorePath:             util.TempFilePath(),
+		StreamTimeout:             10 * time.Second,
+		CheckConnectivityInterval: 1 * time.Second,
 	}
 }
 

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -137,15 +137,15 @@ func TestNetwork(t *testing.T) {
 
 	// Bootstrap node
 	confB := testConfig()
-	confB.ListenAddrStrings = []string{
-		fmt.Sprintf("/ip4/127.0.0.1/tcp/%v", confB.DefaultPort),
-	}
 	fmt.Println("Starting Bootstrap node")
 	networkB := makeTestNetwork(t, confB, []lp2p.Option{
 		lp2p.ForceReachabilityPublic(),
 	})
 	bootstrapAddresses := []string{
 		fmt.Sprintf("/ip4/127.0.0.1/tcp/%v/p2p/%v", confB.DefaultPort, networkB.SelfID().String()),
+		fmt.Sprintf("/ip4/127.0.0.1/udp/%v/quic-v1/p2p/%v", confB.DefaultPort, networkB.SelfID().String()),
+		fmt.Sprintf("/ip6/::1/tcp/%v/p2p/%v", confB.DefaultPort, networkB.SelfID().String()),
+		fmt.Sprintf("/ip6/::1/udp/%v/quic-v1/p2p/%v", confB.DefaultPort, networkB.SelfID().String()),
 	}
 
 	// Public and relay node
@@ -153,9 +153,6 @@ func TestNetwork(t *testing.T) {
 	confP.BootstrapAddrStrings = bootstrapAddresses
 	confP.EnableRelay = false
 	confP.EnableRelayService = true
-	confP.ListenAddrStrings = []string{
-		fmt.Sprintf("/ip4/127.0.0.1/tcp/%v", confP.DefaultPort),
-	}
 	fmt.Println("Starting Public node")
 	networkP := makeTestNetwork(t, confP, []lp2p.Option{
 		lp2p.ForceReachabilityPublic(),
@@ -167,9 +164,6 @@ func TestNetwork(t *testing.T) {
 	confM := testConfig()
 	confM.EnableRelay = true
 	confM.BootstrapAddrStrings = bootstrapAddresses
-	confM.ListenAddrStrings = []string{
-		"/ip4/127.0.0.1/tcp/0",
-	}
 	fmt.Println("Starting Private node M")
 	networkM := makeTestNetwork(t, confM, []lp2p.Option{
 		lp2p.ForceReachabilityPrivate(),
@@ -179,9 +173,6 @@ func TestNetwork(t *testing.T) {
 	confN := testConfig()
 	confN.EnableRelay = true
 	confN.BootstrapAddrStrings = bootstrapAddresses
-	confN.ListenAddrStrings = []string{
-		"/ip4/127.0.0.1/tcp/0",
-	}
 	fmt.Println("Starting Private node N")
 	networkN := makeTestNetwork(t, confN, []lp2p.Option{
 		lp2p.ForceReachabilityPrivate(),
@@ -191,9 +182,6 @@ func TestNetwork(t *testing.T) {
 	confX := testConfig()
 	confX.EnableRelay = false
 	confX.BootstrapAddrStrings = bootstrapAddresses
-	confX.ListenAddrStrings = []string{
-		"/ip4/127.0.0.1/tcp/0",
-	}
 	fmt.Println("Starting Private node X")
 	networkX := makeTestNetwork(t, confX, []lp2p.Option{
 		lp2p.ForceReachabilityPrivate(),

--- a/network/stream_test.go
+++ b/network/stream_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pactus-project/pactus/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,18 +13,13 @@ import (
 func TestCloseStream(t *testing.T) {
 	confA := testConfig()
 	confA.StreamTimeout = 1 * time.Second // Reduce timeout for testing
-	confA.EnableUDP = true
-	confA.EnableMdns = true
 	networkA := makeTestNetwork(t, confA, nil)
 
 	confB := testConfig()
-	confB.EnableUDP = true
-	confB.EnableMdns = true
 	confB.StreamTimeout = 1 * time.Second
-	confB.BootstrapAddrStrings = []string{
-		fmt.Sprintf("/ip4/127.0.0.1/tcp/%v/p2p/%v", confA.DefaultPort, networkA.SelfID().String()),
-		fmt.Sprintf("/ip4/127.0.0.1/udp/%v/quic-v1/p2p/%v", confA.DefaultPort, networkA.SelfID().String()),
-	}
+	util.WriteFile(confB.PeerStorePath,
+		[]byte(fmt.Sprintf("[\"/ip4/127.0.0.1/tcp/%v/p2p/%v\"]",
+			confA.DefaultPort, networkA.SelfID().String())))
 	networkB := makeTestNetwork(t, confB, nil)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/network/stream_test.go
+++ b/network/stream_test.go
@@ -17,7 +17,7 @@ func TestCloseStream(t *testing.T) {
 
 	confB := testConfig()
 	confB.StreamTimeout = 1 * time.Second
-	util.WriteFile(confB.PeerStorePath,
+	_ = util.WriteFile(confB.PeerStorePath,
 		[]byte(fmt.Sprintf("[\"/ip4/127.0.0.1/tcp/%v/p2p/%v\"]",
 			confA.DefaultPort, networkA.SelfID().String())))
 	networkB := makeTestNetwork(t, confB, nil)


### PR DESCRIPTION
## Description

This PR ignores the mDNS discovery test on the latest macOS action runner (macOS 15 ARM),  
as explained in #1860.