### PR TITLE
fix(sandbox): remove check height for banned address

### DIFF
--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -318,9 +318,5 @@ func (sb *sandbox) IsBanned(addr crypto.Address) bool {
 	sb.lk.RLock()
 	defer sb.lk.RUnlock()
 
-	if sb.height > 820_000 {
-		return sb.store.IsBanned(addr)
-	}
-
-	return false
+	return sb.store.IsBanned(addr)
 }


### PR DESCRIPTION
## Description

This PR removes the check height for the banned addresses.
