### PR TITLE
fix(state): update protocol version for own validators

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pactus-project/pactus/util/persistentmerkle"
 	"github.com/pactus-project/pactus/util/pipeline"
 	"github.com/pactus-project/pactus/util/simplemerkle"
+	"github.com/pactus-project/pactus/version"
 )
 
 type state struct {
@@ -124,6 +125,16 @@ func LoadOrNewState(
 
 	for _, num := range state.committee.Committers() {
 		state.logger.Debug("availability score", "val", num, "score", state.scoreMgr.AvailabilityScore(num))
+	}
+
+	// Set ProtocolVersion for own validators.
+	for _, key := range valKeys {
+		val, _ := store.Validator(key.Address())
+		if val == nil {
+			continue
+		}
+
+		store.UpdateValidatorProtocolVersion(val.Address(), version.NodeAgent.ProtocolVersion)
 	}
 
 	state.logger.Debug("last info", "committers", state.committee.Committers(), "state_root", state.stateRoot())

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pactus-project/pactus/types/account"
 	"github.com/pactus-project/pactus/types/block"
 	"github.com/pactus-project/pactus/types/certificate"
+	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 	"github.com/pactus-project/pactus/types/validator"
@@ -547,7 +548,6 @@ func TestLoadState(t *testing.T) {
 
 	assert.Equal(t, td.state.TotalAccounts(), newState.TotalAccounts())
 	assert.Equal(t, td.state.TotalValidators(), newState.TotalValidators())
-	assert.Equal(t, td.state.CommitteeValidators(), newState.CommitteeValidators())
 	assert.Equal(t, td.state.CommitteePower(), newState.CommitteePower())
 	assert.Equal(t, td.state.TotalPower(), newState.TotalPower())
 	assert.Equal(t, td.state.Params(), newState.Params())
@@ -627,4 +627,11 @@ func TestCommittedBlock(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, blkLast.Hash(), td.state.LastBlockHash())
 	})
+}
+
+func TestUpdateProptocolVersion(t *testing.T) {
+	td := setup(t)
+
+	val := td.state.ValidatorByAddress(td.state.valKeys[0].Address())
+	assert.Equal(t, protocol.ProtocolVersionLatest, val.ProtocolVersion())
 }

--- a/sync/handler_proposal.go
+++ b/sync/handler_proposal.go
@@ -24,7 +24,7 @@ func (handler *proposalHandler) ParseMessage(m message.Message, _ peer.ID) {
 	handler.consMgr.SetProposal(msg.Proposal)
 
 	// TODO: This condition can be removed in future releases.
-	// This helps to support old nodes that don't specify their protocol version.
+	// This helps to support old nodes that don't specify their protocol version in proposal.
 	if msg.ProtocolVersion != protocol.ProtocolVersionUnknown {
 		handler.state.UpdateValidatorProtocolVersion(
 			msg.Proposal.Block().Header().ProposerAddress(),

--- a/sync/handler_proposal_test.go
+++ b/sync/handler_proposal_test.go
@@ -4,13 +4,15 @@ import (
 	"testing"
 
 	"github.com/pactus-project/pactus/sync/bundle/message"
+	"github.com/pactus-project/pactus/types/protocol"
+	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestParsingProposalMessages(t *testing.T) {
 	td := setup(t, nil)
 
-	t.Run("Parsing proposal message", func(t *testing.T) {
+	t.Run("Set proposal for consensus", func(t *testing.T) {
 		consensusHeight := td.state.LastBlockHeight() + 1
 		prop := td.GenerateTestProposal(consensusHeight, 0)
 		msg := message.NewProposalMessage(prop)
@@ -18,5 +20,20 @@ func TestParsingProposalMessages(t *testing.T) {
 
 		td.receivingNewMessage(td.sync, msg, pid)
 		assert.Equal(t, prop, td.consMgr.Proposal())
+	})
+
+	t.Run("Update protocol version of the proposer", func(t *testing.T) {
+		consensusHeight := td.state.LastBlockHeight() + 1
+		valKey := td.RandValKey()
+		val := td.GenerateTestValidator(testsuite.ValidatorWithPublicKey(valKey.PublicKey()))
+		td.state.TestStore.UpdateValidator(val)
+		prop := td.GenerateTestProposal(consensusHeight, 0, testsuite.ProposalWithKey(valKey))
+		msg := message.NewProposalMessage(prop)
+		pid := td.RandPeerID()
+
+		td.receivingNewMessage(td.sync, msg, pid)
+
+		assert.Equal(t, protocol.ProtocolVersionLatest,
+			td.state.ValidatorByAddress(valKey.Address()).ProtocolVersion())
 	})
 }


### PR DESCRIPTION
## Description

When a node starts up, its own validators were not being assigned the correct protocol version. 
This PR ensures that when a node initializes its state, all validators owned by the node are automatically assigned the latest protocol version

## Related Issue

Fixes #1870 
