### PR TITLE
fix(sync): ignore hello message from outdated nodes

### DIFF
--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -201,8 +201,8 @@ func makeAliceAndBobNetworks(t *testing.T) *networkAliceBob {
 	assert.NoError(t, syncBob.Start())
 
 	// Connect the networks of Alice and Bob to each other (Alice is outbound, Bob is inbound)
-	networkAlice.AddAnotherNetwork(networkBob, lp2pnetwork.DirOutbound)
 	networkBob.AddAnotherNetwork(networkAlice, lp2pnetwork.DirInbound)
+	networkAlice.AddAnotherNetwork(networkBob, lp2pnetwork.DirOutbound)
 
 	// Verify that Hello messages are exchanged between Alice and Bob
 	// Alice sends hello to Bob

--- a/sync/handler_hello.go
+++ b/sync/handler_hello.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pactus-project/pactus/sync/bundle/message"
 	"github.com/pactus-project/pactus/sync/peerset/peer"
 	"github.com/pactus-project/pactus/sync/peerset/peer/status"
+	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/version"
 )
@@ -106,6 +107,11 @@ func (handler *helloHandler) ParseMessage(m message.Message, pid peer.ID) {
 
 	for _, pub := range msg.PublicKeys {
 		handler.state.UpdateValidatorProtocolVersion(pub.ValidatorAddress(), agent.ProtocolVersion)
+	}
+
+	if agent.ProtocolVersion < protocol.ProtocolVersionLatest {
+		// Keep outdated peer connected for gossiping but don't mark as known.
+		return
 	}
 
 	peer := handler.peerSet.GetPeer(pid)


### PR DESCRIPTION
## Description

This PR adds protocol version compatibility checking in the Hello message handler. When a peer with an outdated protocol version sends a Hello message:

- The peer remains in `Connected` status (not rejected)
- The peer is not marked as `Known` (prevents full sync)
- The peer can still participate in basic gossiping

This provides graceful degradation, outdated peers can gossip but won't be used for block synchronization, preventing compatibility issues.