### PR TITLE
fix(util): ignore filtered levels

### DIFF
--- a/util/logger/logger.go
+++ b/util/logger/logger.go
@@ -113,6 +113,10 @@ func InitGlobalLogger(conf *Config) {
 }
 
 func addFields(event *zerolog.Event, keyvals ...any) *zerolog.Event {
+	if event == nil {
+		return nil
+	}
+
 	if len(keyvals)%2 != 0 {
 		keyvals = append(keyvals, "!MISSING-VALUE!")
 	}
@@ -173,6 +177,10 @@ func NewSubLogger(name string, obj fmt.Stringer) *SubLogger {
 }
 
 func (sl *SubLogger) logObj(event *zerolog.Event, msg string, keyvals ...any) {
+	if event == nil {
+		return
+	}
+
 	if sl.obj != nil {
 		event = event.Str(sl.name, sl.obj.String())
 	}

--- a/util/logger/logger_test.go
+++ b/util/logger/logger_test.go
@@ -32,7 +32,7 @@ func TestNilObjLogger(t *testing.T) {
 	assert.Contains(t, buf.String(), "error")
 }
 
-func TestObjLogger(t *testing.T) {
+func TestSubLogger(t *testing.T) {
 	globalInst = nil
 	c := DefaultConfig()
 	c.Colorful = false


### PR DESCRIPTION
## Description

Check if the log is filtered and ignore the log to improve the performance.
