### PR TITLE
test(network): fix random failure on network tests for Windows

### DIFF
--- a/util/testsuite/testsuite.go
+++ b/util/testsuite/testsuite.go
@@ -933,7 +933,7 @@ func FindFreePort() int {
 		if err != nil {
 			continue
 		}
-		udpConn.Close()
+		_ = udpConn.Close()
 
 		break
 	}

--- a/util/testsuite/testsuite.go
+++ b/util/testsuite/testsuite.go
@@ -914,10 +914,38 @@ func (*TestSuite) HelperSignTransaction(prv crypto.PrivateKey, trx *tx.Tx) {
 }
 
 func FindFreePort() int {
-	listener, _ := util.NetworkListen(context.Background(), "tcp", "localhost:0")
-	defer func() {
-		_ = listener.Close()
-	}()
+	var freePort int
+	hited := false
+	for {
+		// Find a free TCP port
+		listenerTCP, err := util.NetworkListen(context.Background(), "tcp", "127.0.0.1:0")
+		if err != nil {
+			continue
+		}
 
-	return listener.Addr().(*net.TCPAddr).Port
+		if !hited {
+			freePort = 57621
+			hited = true
+		} else {
+			freePort = listenerTCP.Addr().(*net.TCPAddr).Port
+		}
+
+		_ = listenerTCP.Close()
+
+		udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", freePort))
+		if err != nil {
+			panic("11111111111")
+			continue
+		}
+		udpConn, err := net.ListenUDP("udp", udpAddr)
+		if err != nil {
+			panic("22222222222")
+			continue
+		}
+		udpConn.Close()
+
+		break
+	}
+
+	return freePort
 }

--- a/util/testsuite/testsuite.go
+++ b/util/testsuite/testsuite.go
@@ -915,7 +915,6 @@ func (*TestSuite) HelperSignTransaction(prv crypto.PrivateKey, trx *tx.Tx) {
 
 func FindFreePort() int {
 	var freePort int
-	hited := false
 	for {
 		// Find a free TCP port
 		listenerTCP, err := util.NetworkListen(context.Background(), "tcp", "127.0.0.1:0")
@@ -923,23 +922,15 @@ func FindFreePort() int {
 			continue
 		}
 
-		if !hited {
-			freePort = 57621
-			hited = true
-		} else {
-			freePort = listenerTCP.Addr().(*net.TCPAddr).Port
-		}
-
+		freePort = listenerTCP.Addr().(*net.TCPAddr).Port
 		_ = listenerTCP.Close()
 
 		udpAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", freePort))
 		if err != nil {
-			panic("11111111111")
 			continue
 		}
 		udpConn, err := net.ListenUDP("udp", udpAddr)
 		if err != nil {
-			panic("22222222222")
 			continue
 		}
 		udpConn.Close()


### PR DESCRIPTION
## Description

Try to fix this random test failure in Windows:

```
libp2p error: failed to listen on any addresses: [listen udp4 127.0.0.1:57621: bind: An attempt was made to access a socket in a way forbidden by its access permissions.]
```