### PR TITLE
refactor(other): use maps.Copy for cleaner map handling

### DIFF
--- a/consensus/voteset/binary_voteset.go
+++ b/consensus/voteset/binary_voteset.go
@@ -1,6 +1,8 @@
 package voteset
 
 import (
+	"maps"
+
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/types/validator"
 	"github.com/pactus-project/pactus/types/vote"
@@ -149,9 +151,7 @@ func (vs *BinaryVoteSet) BinaryVotes(cpRound int16, cpValue vote.CPValue) map[cr
 	votes := map[crypto.Address]*vote.Vote{}
 	roundVotes := vs.mustGetRoundVotes(cpRound)
 	voteBox := roundVotes.voteBoxes[cpValue]
-	for a, v := range voteBox.votes {
-		votes[a] = v
-	}
+	maps.Copy(votes, voteBox.votes)
 
 	return votes
 }

--- a/consensus/voteset/block_voteset.go
+++ b/consensus/voteset/block_voteset.go
@@ -1,6 +1,8 @@
 package voteset
 
 import (
+	"maps"
+
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/types/validator"
@@ -41,9 +43,7 @@ func newBlockVoteSet(voteSet *voteSet) *BlockVoteSet {
 func (vs *BlockVoteSet) BlockVotes(blockHash hash.Hash) map[crypto.Address]*vote.Vote {
 	votes := map[crypto.Address]*vote.Vote{}
 	blockVotes := vs.mustGetBlockVotes(blockHash)
-	for a, v := range blockVotes.votes {
-		votes[a] = v
-	}
+	maps.Copy(votes, blockVotes.votes)
 
 	return votes
 }

--- a/consensusv2/voteset/binary_voteset.go
+++ b/consensusv2/voteset/binary_voteset.go
@@ -1,6 +1,8 @@
 package voteset
 
 import (
+	"maps"
+
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/types/validator"
 	"github.com/pactus-project/pactus/types/vote"
@@ -155,9 +157,7 @@ func (vs *BinaryVoteSet) BinaryVotes(cpRound int16, cpValue vote.CPValue) map[cr
 	votes := map[crypto.Address]*vote.Vote{}
 	roundVotes := vs.mustGetRoundVotes(cpRound)
 	voteBox := roundVotes.voteBoxes[cpValue]
-	for a, v := range voteBox.votes {
-		votes[a] = v
-	}
+	maps.Copy(votes, voteBox.votes)
 
 	return votes
 }

--- a/consensusv2/voteset/block_voteset.go
+++ b/consensusv2/voteset/block_voteset.go
@@ -1,6 +1,8 @@
 package voteset
 
 import (
+	"maps"
+
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/types/validator"
@@ -34,9 +36,7 @@ func newBlockVoteSet(voteSet *voteSet) *BlockVoteSet {
 func (vs *BlockVoteSet) BlockVotes(blockHash hash.Hash) map[crypto.Address]*vote.Vote {
 	votes := map[crypto.Address]*vote.Vote{}
 	blockVotes := vs.mustGetBlockVotes(blockHash)
-	for a, v := range blockVotes.votes {
-		votes[a] = v
-	}
+	maps.Copy(votes, blockVotes.votes)
 
 	return votes
 }

--- a/wallet/vault/vault.go
+++ b/wallet/vault/vault.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"cmp"
 	"encoding/json"
+	"maps"
 
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/bls"
@@ -176,9 +177,7 @@ func (v *Vault) Neuter() *Vault {
 		Purposes:  v.Purposes,
 	}
 
-	for addr, info := range v.Addresses {
-		neutered.Addresses[addr] = info
-	}
+	maps.Copy(neutered.Addresses, v.Addresses)
 
 	return neutered
 }


### PR DESCRIPTION
## Description

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

