### PR TITLE
feat(network): set limit for network message size

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -158,6 +158,7 @@ linters:
         - ip
         - "no"
         - tt
+        - n
         - i
         - j
         - l

--- a/network/config.go
+++ b/network/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	PeerStorePath               string        `toml:"-"`
 	StreamTimeout               time.Duration `toml:"-"`
 	CheckConnectivityInterval   time.Duration `toml:"-"`
+	MaxGossipMessageSize        int           `toml:"-"`
+	MaxStreamMessageSize        int           `toml:"-"`
 }
 
 func DefaultConfig() *Config {
@@ -55,6 +57,8 @@ func DefaultConfig() *Config {
 		PeerStorePath:             "peers.json",
 		StreamTimeout:             20 * time.Second,
 		CheckConnectivityInterval: 60 * time.Second,
+		MaxGossipMessageSize:      1 * 1024 * 1024, // 1 MB
+		MaxStreamMessageSize:      8 * 1024 * 1024, // 8 MB
 	}
 }
 

--- a/network/dht.go
+++ b/network/dht.go
@@ -17,8 +17,8 @@ type dhtService struct {
 	logger   *logger.SubLogger
 }
 
-func newDHTService(ctx context.Context, host lp2phost.Host, protocolID lp2pcore.ProtocolID,
-	conf *Config, log *logger.SubLogger,
+func newDHTService(ctx context.Context, host lp2phost.Host, conf *Config,
+	protocolID lp2pcore.ProtocolID, log *logger.SubLogger,
 ) *dhtService {
 	// A dirty code in LibP2P!!!
 	// prevent apply default bootstrap node of libp2p

--- a/network/gossip.go
+++ b/network/gossip.go
@@ -37,6 +37,7 @@ func newGossipService(ctx context.Context, host lp2phost.Host, conf *Config,
 		lp2pps.WithNoAuthor(),
 		lp2pps.WithMessageIdFn(MessageIDFunc),
 		lp2pps.WithSeenMessagesTTL(60 * time.Second),
+		lp2pps.WithMaxMessageSize(conf.MaxGossipMessageSize),
 	}
 
 	if conf.IsBootstrapper {

--- a/network/network.go
+++ b/network/network.go
@@ -260,7 +260,7 @@ func makeNetwork(ctx context.Context, conf *Config,
 	}
 
 	self.peerMgr = newPeerMgr(ctx, host, conf, self.logger)
-	self.dht = newDHTService(ctx, host, kadProtocolID, conf, self.logger)
+	self.dht = newDHTService(ctx, host, conf, kadProtocolID, self.logger)
 	self.stream = newStreamService(ctx, host, conf, streamProtocolID, self.networkPipe, self.logger)
 	self.gossip = newGossipService(ctx, host, conf, self.networkPipe, self.logger)
 	self.notifee = newNotifeeService(ctx, host, self.networkPipe, self.peerMgr, streamProtocolID, self.logger)


### PR DESCRIPTION
## Description

This PR sets limits for network message sizes. Currently, Gossip messages cannot exceed 1 MB (libP2P default), and stream messages are limited to 8 MB.