### PR TITLE
fix(encoding): prevent data-length attack

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -30,6 +30,7 @@ jobs:
             packager
             other
             daemon
+            cbor
             cmd
             firewall
             gtk
@@ -41,6 +42,7 @@ jobs:
             crypto
             docs
             docker
+            encoding
             execution
             genesis
             network

--- a/types/block/block.go
+++ b/types/block/block.go
@@ -208,6 +208,13 @@ func (b *Block) Decode(r io.Reader) error {
 	if err != nil {
 		return err
 	}
+
+	// We set 1000 as a hardcoded value,
+	// matching the maximum number of transactions allowed in a block.
+	if length > 1000 {
+		return ErrTooManyTransactions
+	}
+
 	b.data.Txs = make([]*tx.Tx, length)
 	for i := 0; i < int(length); i++ {
 		trx := new(tx.Tx)

--- a/types/block/block_test.go
+++ b/types/block/block_test.go
@@ -42,6 +42,27 @@ func TestBasicCheck(t *testing.T) {
 		})
 	})
 
+	t.Run("Too many transactions", func(t *testing.T) {
+		data := ts.DecodingHex(
+			"02" + // Version
+				"00000000" + // UnixTime
+				"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" + // PrevBlockHash
+				"DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD" + // StateRoot
+				"333333333333333333333333333333333333333333333333" + // SortitionSeed
+				"333333333333333333333333333333333333333333333333" +
+				"01AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" + // ProposerAddress
+				"04030201" + // PrevCert: Height
+				"0100" + // PrevCert: Round
+				"0401020304" + // PrevCert: Committers
+				"0102" + // PrevCert: Absentees
+				"b53d79e156e9417e010fa21f2b2a96bee6be46fcd233295d" +
+				"2f697cdb9e782b6112ac01c80d0d9d64c2320664c77fa2a6" + // PrevCert: Signature
+				"e907") // Txs: Len (1001)
+
+		_, err := block.FromBytes(data)
+		assert.ErrorIs(t, err, block.ErrTooManyTransactions)
+	})
+
 	t.Run("Without the previous certificate", func(t *testing.T) {
 		blk, _ := ts.GenerateTestBlock(ts.RandHeight(), testsuite.BlockWithPrevCert(nil))
 

--- a/types/block/errors.go
+++ b/types/block/errors.go
@@ -1,5 +1,9 @@
 package block
 
+import "errors"
+
+var ErrTooManyTransactions = errors.New("too many transactions in block")
+
 // BasicCheckError is returned when the basic check on the certificate fails.
 type BasicCheckError struct {
 	Reason string

--- a/types/certificate/certificate.go
+++ b/types/certificate/certificate.go
@@ -175,6 +175,13 @@ func (cert *Certificate) Decode(r io.Reader) error {
 	if err != nil {
 		return err
 	}
+
+	// We set 51 as a hardcoded value,
+	// matching the maximum number of committers allowed in a block.
+	if lenCommitters > 51 {
+		return ErrTooManyCommitters
+	}
+
 	committers := make([]int32, lenCommitters)
 	for i := 0; i < int(lenCommitters); i++ {
 		n, err := encoding.ReadVarInt(r)
@@ -188,6 +195,12 @@ func (cert *Certificate) Decode(r io.Reader) error {
 	if err != nil {
 		return err
 	}
+	// We set 51 as a hardcoded value,
+	// matching the maximum number of committers allowed in a block.
+	if lenAbsentees > 51 {
+		return ErrTooManyAbsentees
+	}
+
 	absentees := make([]int32, lenAbsentees)
 	for i := 0; i < int(lenAbsentees); i++ {
 		n, err := encoding.ReadVarInt(r)

--- a/types/certificate/errors.go
+++ b/types/certificate/errors.go
@@ -1,8 +1,14 @@
 package certificate
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
+)
+
+var (
+	ErrTooManyCommitters = errors.New("too many committers in certificate")
+	ErrTooManyAbsentees  = errors.New("too many absentees in certificate")
 )
 
 // BasicCheckError is returned when the basic check on the certificate fails.

--- a/types/tx/payload/batch_transfer.go
+++ b/types/tx/payload/batch_transfer.go
@@ -148,6 +148,10 @@ func (p *BatchTransferPayload) Decode(r io.Reader) error {
 		return err
 	}
 
+	if numberOfRecipients > maxBatchRecipients {
+		return ErrTooManyRecipients
+	}
+
 	p.Recipients = make([]BatchRecipient, numberOfRecipients)
 	for i := uint64(0); i < numberOfRecipients; i++ {
 		err := p.Recipients[i].Decode(r)

--- a/types/tx/payload/batch_transfer_test.go
+++ b/types/tx/payload/batch_transfer_test.go
@@ -36,6 +36,15 @@ func TestBatchTransferDecoding(t *testing.T) {
 		{
 			raw: []byte{
 				0x00, // sender (Treasury)
+				0x09, // number Of Recipients (9)
+			},
+			value:    0,
+			readErr:  ErrTooManyRecipients,
+			basicErr: nil,
+		},
+		{
+			raw: []byte{
+				0x00, // sender (Treasury)
 				0x02, // number Of Recipients (2)
 				0x02, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
 				0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20,

--- a/types/tx/payload/errors.go
+++ b/types/tx/payload/errors.go
@@ -3,7 +3,10 @@ package payload
 import "errors"
 
 // ErrInvalidPublicKeySize is returned when the public key size is not valid.
-var ErrInvalidPublicKeySize = errors.New("invalid public key size")
+var (
+	ErrInvalidPublicKeySize = errors.New("invalid public key size")
+	ErrTooManyRecipients    = errors.New("too many recipients in batch transfer")
+)
 
 // BasicCheckError describes is returned when the basic check on the transaction's payload fails.
 type BasicCheckError struct {

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -9,7 +9,6 @@ package encoding
 import (
 	"bytes"
 	"crypto/rand"
-	"fmt"
 	"io"
 	"math/big"
 	"reflect"

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -9,6 +9,7 @@ package encoding
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"math/big"
 	"reflect"
@@ -412,6 +413,14 @@ func TestWriteElements(t *testing.T) {
 	err := WriteElements(&buf, &el1, &el2, &el3, &el4)
 	assert.NoError(t, err)
 	assert.Equal(t, buf.Bytes(), []byte{0x1, 0x2, 0x0, 0x3, 0x0, 0x0, 0x0, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+}
+
+func TestWriteElements2(t *testing.T) {
+	el3 := uint64(52)
+	var buf bytes.Buffer
+	err := WriteVarInt(&buf, el3)
+	assert.NoError(t, err)
+	fmt.Printf("\n--%x--\n", buf.Bytes())
 }
 
 func TestReadElements(t *testing.T) {

--- a/util/encoding/encoding_test.go
+++ b/util/encoding/encoding_test.go
@@ -415,14 +415,6 @@ func TestWriteElements(t *testing.T) {
 	assert.Equal(t, buf.Bytes(), []byte{0x1, 0x2, 0x0, 0x3, 0x0, 0x0, 0x0, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
 }
 
-func TestWriteElements2(t *testing.T) {
-	el3 := uint64(52)
-	var buf bytes.Buffer
-	err := WriteVarInt(&buf, el3)
-	assert.NoError(t, err)
-	fmt.Printf("\n--%x--\n", buf.Bytes())
-}
-
 func TestReadElements(t *testing.T) {
 	el1 := uint8(1)
 	el2 := uint16(2)


### PR DESCRIPTION
## Description

This PR checks the length of the decoding object to prevent the length attack.

## Related Issue

Fixes #1903

