### PR TITLE
fix(grpc): define map as object in OpenRPC sepc

### DIFF
--- a/www/grpc/buf/openrpc.tmpl
+++ b/www/grpc/buf/openrpc.tmpl
@@ -56,7 +56,11 @@
 {{/* --- Helpers --- */}}
 
 {{ define "renderFieldSchema" }}
-{{- if .IsRepeated }}
+{{- if .IsMap }}
+{
+  "type": "object"
+}
+{{- else if .IsRepeated }}
 {
   "type": "array",
   "items": {{ template "renderFieldItemSchema" . }}

--- a/www/grpc/gen/open-rpc/pactus-openrpc.json
+++ b/www/grpc/gen/open-rpc/pactus-openrpc.json
@@ -518,11 +518,7 @@
 }
 },"is_pruned": { "type": "boolean" },"pruning_height": { "type": "integer" },"last_block_time": { "type": "integer" },"committee_protocol_versions": 
 {
-  "type": "array",
-  "items": {
-  "type": "object",
-  "properties": {}
-}
+  "type": "object"
 }}
           }
         }
@@ -775,18 +771,10 @@
   "properties": {"bytes": { "type": "integer" },"bundles": { "type": "integer" }}
 },"message_sent": 
 {
-  "type": "array",
-  "items": {
-  "type": "object",
-  "properties": {}
-}
+  "type": "object"
 },"message_received": 
 {
-  "type": "array",
-  "items": {
-  "type": "object",
-  "properties": {}
-}
+  "type": "object"
 }}
 },"outbound_hello_sent": { "type": "boolean" }}
 }
@@ -803,18 +791,10 @@
   "properties": {"bytes": { "type": "integer" },"bundles": { "type": "integer" }}
 },"message_sent": 
 {
-  "type": "array",
-  "items": {
-  "type": "object",
-  "properties": {}
-}
+  "type": "object"
 },"message_received": 
 {
-  "type": "array",
-  "items": {
-  "type": "object",
-  "properties": {}
-}
+  "type": "object"
 }}
 }}
           }


### PR DESCRIPTION
## Description

This PR defines Maps as object in the OpenRPC spec. Previously, it was defined as an array, which caused some issues.