### PR TITLE
fix(grpc): set required fields in OpenRPC spec

### DIFF
--- a/www/grpc/buf/openrpc.tmpl
+++ b/www/grpc/buf/openrpc.tmpl
@@ -34,11 +34,18 @@
         "name": "fields",
         "schema": {
           "type": "object",
-          "properties": {
 {{- with getMessage .ResponseLongType -}}
+          "required": [
+          {{- $firstField := true -}}
+          {{- range .Fields -}}
+            {{- if not $firstField }},{{- end -}}
+            {{- $firstField = false -}}
+            "{{ .SnakeName }}"
+          {{- end -}} ],
+          "properties": {
   {{- $firstField := true -}}
   {{- range .Fields -}}
-              {{- if not $firstField }},{{ end -}}
+              {{- if not $firstField }},{{- end -}}
               {{- $firstField = false -}}
               "{{ .SnakeName }}": {{ template "renderFieldSchema" . -}}
   {{- end -}}
@@ -76,8 +83,15 @@
 {{- else -}}
 {
   "type": "object",
-  "properties": {
 {{- with getMessage .LongType -}}
+  "required": [
+    {{- $firstField := true -}}
+    {{- range .Fields -}}
+      {{- if not $firstField }},{{- end -}}
+      {{- $firstField = false -}}
+      "{{ .SnakeName }}"
+    {{- end -}} ],
+  "properties": {
   {{- $first := true -}}
   {{- range .Fields -}}
     {{- if not $first -}},{{- end -}}

--- a/www/grpc/gen/open-rpc/pactus-openrpc.json
+++ b/www/grpc/gen/open-rpc/pactus-openrpc.json
@@ -25,31 +25,31 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["block_height","block_time","transaction"],
           "properties": {"block_height": { "type": "integer" },"block_time": { "type": "integer" },"transaction": {
-  "type": "object",
+  "type": "object","required": ["id","data","version","lock_time","value","fee","payload_type","transfer","bond","sortition","unbond","withdraw","batch_transfer","memo","public_key","signature"],
   "properties": {"id": { "type": "string" },"data": { "type": "string" },"version": { "type": "integer" },"lock_time": { "type": "integer" },"value": { "type": "integer" },"fee": { "type": "integer" },"payload_type": { "type": "integer" },"transfer": {
-  "type": "object",
+  "type": "object","required": ["sender","receiver","amount"],
   "properties": {"sender": { "type": "string" },"receiver": { "type": "string" },"amount": { "type": "integer" }}
 },"bond": {
-  "type": "object",
+  "type": "object","required": ["sender","receiver","stake","public_key"],
   "properties": {"sender": { "type": "string" },"receiver": { "type": "string" },"stake": { "type": "integer" },"public_key": { "type": "string" }}
 },"sortition": {
-  "type": "object",
+  "type": "object","required": ["address","proof"],
   "properties": {"address": { "type": "string" },"proof": { "type": "string" }}
 },"unbond": {
-  "type": "object",
+  "type": "object","required": ["validator"],
   "properties": {"validator": { "type": "string" }}
 },"withdraw": {
-  "type": "object",
+  "type": "object","required": ["validator_address","account_address","amount"],
   "properties": {"validator_address": { "type": "string" },"account_address": { "type": "string" },"amount": { "type": "integer" }}
 },"batch_transfer": {
-  "type": "object",
-  "properties": {"sender": { "type": "string" },"recipients": 
+  "type": "object","required": ["sender","recipients"],
+  "properties": {"sender": { "type": "string" },"recipients":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["receiver","amount"],
   "properties": {"receiver": { "type": "string" },"amount": { "type": "integer" }}
 }
 }}
@@ -84,7 +84,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["amount","fee"],
           "properties": {"amount": { "type": "integer" },"fee": { "type": "integer" }}
           }
         }
@@ -105,7 +105,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["id"],
           "properties": {"id": { "type": "string" }}
           }
         }
@@ -151,7 +151,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["raw_transaction","id"],
           "properties": {"raw_transaction": { "type": "string" },"id": { "type": "string" }}
           }
         }
@@ -202,7 +202,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["raw_transaction","id"],
           "properties": {"raw_transaction": { "type": "string" },"id": { "type": "string" }}
           }
         }
@@ -233,7 +233,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["raw_transaction","id"],
           "properties": {"raw_transaction": { "type": "string" },"id": { "type": "string" }}
           }
         }
@@ -279,7 +279,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["raw_transaction","id"],
           "properties": {"raw_transaction": { "type": "string" },"id": { "type": "string" }}
           }
         }
@@ -304,11 +304,11 @@
         {
           "name": "recipients",
           "description": "The recipients list of receiver with amount, min 2 recipients.",
-          "schema": 
+          "schema":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["receiver","amount"],
   "properties": {"receiver": { "type": "string" },"amount": { "type": "integer" }}
 }
 }
@@ -327,7 +327,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["raw_transaction","id"],
           "properties": {"raw_transaction": { "type": "string" },"id": { "type": "string" }}
           }
         }
@@ -348,31 +348,31 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["transaction"],
           "properties": {"transaction": {
-  "type": "object",
+  "type": "object","required": ["id","data","version","lock_time","value","fee","payload_type","transfer","bond","sortition","unbond","withdraw","batch_transfer","memo","public_key","signature"],
   "properties": {"id": { "type": "string" },"data": { "type": "string" },"version": { "type": "integer" },"lock_time": { "type": "integer" },"value": { "type": "integer" },"fee": { "type": "integer" },"payload_type": { "type": "integer" },"transfer": {
-  "type": "object",
+  "type": "object","required": ["sender","receiver","amount"],
   "properties": {"sender": { "type": "string" },"receiver": { "type": "string" },"amount": { "type": "integer" }}
 },"bond": {
-  "type": "object",
+  "type": "object","required": ["sender","receiver","stake","public_key"],
   "properties": {"sender": { "type": "string" },"receiver": { "type": "string" },"stake": { "type": "integer" },"public_key": { "type": "string" }}
 },"sortition": {
-  "type": "object",
+  "type": "object","required": ["address","proof"],
   "properties": {"address": { "type": "string" },"proof": { "type": "string" }}
 },"unbond": {
-  "type": "object",
+  "type": "object","required": ["validator"],
   "properties": {"validator": { "type": "string" }}
 },"withdraw": {
-  "type": "object",
+  "type": "object","required": ["validator_address","account_address","amount"],
   "properties": {"validator_address": { "type": "string" },"account_address": { "type": "string" },"amount": { "type": "integer" }}
 },"batch_transfer": {
-  "type": "object",
-  "properties": {"sender": { "type": "string" },"recipients": 
+  "type": "object","required": ["sender","recipients"],
+  "properties": {"sender": { "type": "string" },"recipients":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["receiver","amount"],
   "properties": {"receiver": { "type": "string" },"amount": { "type": "integer" }}
 }
 }}
@@ -381,8 +381,8 @@
           }
         }
       }
-    
-  
+
+
 ,
     {
       "name": "pactus.blockchain.get_block",
@@ -404,48 +404,48 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["height","hash","data","block_time","header","prev_cert","txs"],
           "properties": {"height": { "type": "integer" },"hash": { "type": "string" },"data": { "type": "string" },"block_time": { "type": "integer" },"header": {
-  "type": "object",
+  "type": "object","required": ["version","prev_block_hash","state_root","sortition_seed","proposer_address"],
   "properties": {"version": { "type": "integer" },"prev_block_hash": { "type": "string" },"state_root": { "type": "string" },"sortition_seed": { "type": "string" },"proposer_address": { "type": "string" }}
 },"prev_cert": {
-  "type": "object",
-  "properties": {"hash": { "type": "string" },"round": { "type": "integer" },"committers": 
+  "type": "object","required": ["hash","round","committers","absentees","signature"],
+  "properties": {"hash": { "type": "string" },"round": { "type": "integer" },"committers":
 {
   "type": "array",
   "items": { "type": "integer" }
-},"absentees": 
+},"absentees":
 {
   "type": "array",
   "items": { "type": "integer" }
 },"signature": { "type": "string" }}
-},"txs": 
+},"txs":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["id","data","version","lock_time","value","fee","payload_type","transfer","bond","sortition","unbond","withdraw","batch_transfer","memo","public_key","signature"],
   "properties": {"id": { "type": "string" },"data": { "type": "string" },"version": { "type": "integer" },"lock_time": { "type": "integer" },"value": { "type": "integer" },"fee": { "type": "integer" },"payload_type": { "type": "integer" },"transfer": {
-  "type": "object",
+  "type": "object","required": ["sender","receiver","amount"],
   "properties": {"sender": { "type": "string" },"receiver": { "type": "string" },"amount": { "type": "integer" }}
 },"bond": {
-  "type": "object",
+  "type": "object","required": ["sender","receiver","stake","public_key"],
   "properties": {"sender": { "type": "string" },"receiver": { "type": "string" },"stake": { "type": "integer" },"public_key": { "type": "string" }}
 },"sortition": {
-  "type": "object",
+  "type": "object","required": ["address","proof"],
   "properties": {"address": { "type": "string" },"proof": { "type": "string" }}
 },"unbond": {
-  "type": "object",
+  "type": "object","required": ["validator"],
   "properties": {"validator": { "type": "string" }}
 },"withdraw": {
-  "type": "object",
+  "type": "object","required": ["validator_address","account_address","amount"],
   "properties": {"validator_address": { "type": "string" },"account_address": { "type": "string" },"amount": { "type": "integer" }}
 },"batch_transfer": {
-  "type": "object",
-  "properties": {"sender": { "type": "string" },"recipients": 
+  "type": "object","required": ["sender","recipients"],
+  "properties": {"sender": { "type": "string" },"recipients":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["receiver","amount"],
   "properties": {"receiver": { "type": "string" },"amount": { "type": "integer" }}
 }
 }}
@@ -471,7 +471,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["hash"],
           "properties": {"hash": { "type": "string" }}
           }
         }
@@ -492,7 +492,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["height"],
           "properties": {"height": { "type": "integer" }}
           }
         }
@@ -508,15 +508,15 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
-          "properties": {"last_block_height": { "type": "integer" },"last_block_hash": { "type": "string" },"total_accounts": { "type": "integer" },"total_validators": { "type": "integer" },"total_power": { "type": "integer" },"committee_power": { "type": "integer" },"committee_validators": 
+          "type": "object","required": ["last_block_height","last_block_hash","total_accounts","total_validators","total_power","committee_power","committee_validators","is_pruned","pruning_height","last_block_time","committee_protocol_versions"],
+          "properties": {"last_block_height": { "type": "integer" },"last_block_hash": { "type": "string" },"total_accounts": { "type": "integer" },"total_validators": { "type": "integer" },"total_power": { "type": "integer" },"committee_power": { "type": "integer" },"committee_validators":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["hash","data","public_key","number","stake","last_bonding_height","last_sortition_height","unbonding_height","address","availability_score","protocol_version"],
   "properties": {"hash": { "type": "string" },"data": { "type": "string" },"public_key": { "type": "string" },"number": { "type": "integer" },"stake": { "type": "integer" },"last_bonding_height": { "type": "integer" },"last_sortition_height": { "type": "integer" },"unbonding_height": { "type": "integer" },"address": { "type": "string" },"availability_score": { "type": "number" },"protocol_version": { "type": "integer" }}
 }
-},"is_pruned": { "type": "boolean" },"pruning_height": { "type": "integer" },"last_block_time": { "type": "integer" },"committee_protocol_versions": 
+},"is_pruned": { "type": "boolean" },"pruning_height": { "type": "integer" },"last_block_time": { "type": "integer" },"committee_protocol_versions":
 {
   "type": "object"
 }}
@@ -534,20 +534,20 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["proposal","instances"],
           "properties": {"proposal": {
-  "type": "object",
+  "type": "object","required": ["height","round","block_data","signature"],
   "properties": {"height": { "type": "integer" },"round": { "type": "integer" },"block_data": { "type": "string" },"signature": { "type": "string" }}
-},"instances": 
+},"instances":
 {
   "type": "array",
   "items": {
-  "type": "object",
-  "properties": {"address": { "type": "string" },"active": { "type": "boolean" },"height": { "type": "integer" },"round": { "type": "integer" },"votes": 
+  "type": "object","required": ["address","active","height","round","votes"],
+  "properties": {"address": { "type": "string" },"active": { "type": "boolean" },"height": { "type": "integer" },"round": { "type": "integer" },"votes":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["type","voter","block_hash","round","cp_round","cp_value"],
   "properties": {"type": { "type": "integer" },"voter": { "type": "string" },"block_hash": { "type": "string" },"round": { "type": "integer" },"cp_round": { "type": "integer" },"cp_value": { "type": "integer" }}
 }
 }}
@@ -572,9 +572,9 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["account"],
           "properties": {"account": {
-  "type": "object",
+  "type": "object","required": ["hash","data","number","balance","address"],
   "properties": {"hash": { "type": "string" },"data": { "type": "string" },"number": { "type": "integer" },"balance": { "type": "integer" },"address": { "type": "string" }}
 }}
           }
@@ -596,9 +596,9 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["validator"],
           "properties": {"validator": {
-  "type": "object",
+  "type": "object","required": ["hash","data","public_key","number","stake","last_bonding_height","last_sortition_height","unbonding_height","address","availability_score","protocol_version"],
   "properties": {"hash": { "type": "string" },"data": { "type": "string" },"public_key": { "type": "string" },"number": { "type": "integer" },"stake": { "type": "integer" },"last_bonding_height": { "type": "integer" },"last_sortition_height": { "type": "integer" },"unbonding_height": { "type": "integer" },"address": { "type": "string" },"availability_score": { "type": "number" },"protocol_version": { "type": "integer" }}
 }}
           }
@@ -620,9 +620,9 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["validator"],
           "properties": {"validator": {
-  "type": "object",
+  "type": "object","required": ["hash","data","public_key","number","stake","last_bonding_height","last_sortition_height","unbonding_height","address","availability_score","protocol_version"],
   "properties": {"hash": { "type": "string" },"data": { "type": "string" },"public_key": { "type": "string" },"number": { "type": "integer" },"stake": { "type": "integer" },"last_bonding_height": { "type": "integer" },"last_sortition_height": { "type": "integer" },"unbonding_height": { "type": "integer" },"address": { "type": "string" },"availability_score": { "type": "number" },"protocol_version": { "type": "integer" }}
 }}
           }
@@ -639,8 +639,8 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
-          "properties": {"addresses": 
+          "type": "object","required": ["addresses"],
+          "properties": {"addresses":
 {
   "type": "array",
   "items": { "type": "string" }
@@ -664,7 +664,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["public_key"],
           "properties": {"public_key": { "type": "string" }}
           }
         }
@@ -685,34 +685,34 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
-          "properties": {"txs": 
+          "type": "object","required": ["txs"],
+          "properties": {"txs":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["id","data","version","lock_time","value","fee","payload_type","transfer","bond","sortition","unbond","withdraw","batch_transfer","memo","public_key","signature"],
   "properties": {"id": { "type": "string" },"data": { "type": "string" },"version": { "type": "integer" },"lock_time": { "type": "integer" },"value": { "type": "integer" },"fee": { "type": "integer" },"payload_type": { "type": "integer" },"transfer": {
-  "type": "object",
+  "type": "object","required": ["sender","receiver","amount"],
   "properties": {"sender": { "type": "string" },"receiver": { "type": "string" },"amount": { "type": "integer" }}
 },"bond": {
-  "type": "object",
+  "type": "object","required": ["sender","receiver","stake","public_key"],
   "properties": {"sender": { "type": "string" },"receiver": { "type": "string" },"stake": { "type": "integer" },"public_key": { "type": "string" }}
 },"sortition": {
-  "type": "object",
+  "type": "object","required": ["address","proof"],
   "properties": {"address": { "type": "string" },"proof": { "type": "string" }}
 },"unbond": {
-  "type": "object",
+  "type": "object","required": ["validator"],
   "properties": {"validator": { "type": "string" }}
 },"withdraw": {
-  "type": "object",
+  "type": "object","required": ["validator_address","account_address","amount"],
   "properties": {"validator_address": { "type": "string" },"account_address": { "type": "string" },"amount": { "type": "integer" }}
 },"batch_transfer": {
-  "type": "object",
-  "properties": {"sender": { "type": "string" },"recipients": 
+  "type": "object","required": ["sender","recipients"],
+  "properties": {"sender": { "type": "string" },"recipients":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["receiver","amount"],
   "properties": {"receiver": { "type": "string" },"amount": { "type": "integer" }}
 }
 }}
@@ -722,8 +722,8 @@
           }
         }
       }
-    
-  
+
+
 ,
     {
       "name": "pactus.network.get_network_info",
@@ -740,59 +740,59 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
-          "properties": {"network_name": { "type": "string" },"connected_peers_count": { "type": "integer" },"connected_peers": 
+          "type": "object","required": ["network_name","connected_peers_count","connected_peers","metric_info"],
+          "properties": {"network_name": { "type": "string" },"connected_peers_count": { "type": "integer" },"connected_peers":
 {
   "type": "array",
   "items": {
-  "type": "object",
-  "properties": {"status": { "type": "integer" },"moniker": { "type": "string" },"agent": { "type": "string" },"peer_id": { "type": "string" },"consensus_keys": 
+  "type": "object","required": ["status","moniker","agent","peer_id","consensus_keys","consensus_addresses","services","last_block_hash","height","last_sent","last_received","address","direction","protocols","total_sessions","completed_sessions","metric_info","outbound_hello_sent"],
+  "properties": {"status": { "type": "integer" },"moniker": { "type": "string" },"agent": { "type": "string" },"peer_id": { "type": "string" },"consensus_keys":
 {
   "type": "array",
   "items": { "type": "string" }
-},"consensus_addresses": 
+},"consensus_addresses":
 {
   "type": "array",
   "items": { "type": "string" }
-},"services": { "type": "integer" },"last_block_hash": { "type": "string" },"height": { "type": "integer" },"last_sent": { "type": "integer" },"last_received": { "type": "integer" },"address": { "type": "string" },"direction": { "type": "integer" },"protocols": 
+},"services": { "type": "integer" },"last_block_hash": { "type": "string" },"height": { "type": "integer" },"last_sent": { "type": "integer" },"last_received": { "type": "integer" },"address": { "type": "string" },"direction": { "type": "integer" },"protocols":
 {
   "type": "array",
   "items": { "type": "string" }
 },"total_sessions": { "type": "integer" },"completed_sessions": { "type": "integer" },"metric_info": {
-  "type": "object",
+  "type": "object","required": ["total_invalid","total_sent","total_received","message_sent","message_received"],
   "properties": {"total_invalid": {
-  "type": "object",
+  "type": "object","required": ["bytes","bundles"],
   "properties": {"bytes": { "type": "integer" },"bundles": { "type": "integer" }}
 },"total_sent": {
-  "type": "object",
+  "type": "object","required": ["bytes","bundles"],
   "properties": {"bytes": { "type": "integer" },"bundles": { "type": "integer" }}
 },"total_received": {
-  "type": "object",
+  "type": "object","required": ["bytes","bundles"],
   "properties": {"bytes": { "type": "integer" },"bundles": { "type": "integer" }}
-},"message_sent": 
+},"message_sent":
 {
   "type": "object"
-},"message_received": 
+},"message_received":
 {
   "type": "object"
 }}
 },"outbound_hello_sent": { "type": "boolean" }}
 }
 },"metric_info": {
-  "type": "object",
+  "type": "object","required": ["total_invalid","total_sent","total_received","message_sent","message_received"],
   "properties": {"total_invalid": {
-  "type": "object",
+  "type": "object","required": ["bytes","bundles"],
   "properties": {"bytes": { "type": "integer" },"bundles": { "type": "integer" }}
 },"total_sent": {
-  "type": "object",
+  "type": "object","required": ["bytes","bundles"],
   "properties": {"bytes": { "type": "integer" },"bundles": { "type": "integer" }}
 },"total_received": {
-  "type": "object",
+  "type": "object","required": ["bytes","bundles"],
   "properties": {"bytes": { "type": "integer" },"bundles": { "type": "integer" }}
-},"message_sent": 
+},"message_sent":
 {
   "type": "object"
-},"message_received": 
+},"message_received":
 {
   "type": "object"
 }}
@@ -811,31 +811,31 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
-          "properties": {"moniker": { "type": "string" },"agent": { "type": "string" },"peer_id": { "type": "string" },"started_at": { "type": "integer" },"reachability": { "type": "string" },"services": { "type": "integer" },"services_names": { "type": "string" },"local_addrs": 
+          "type": "object","required": ["moniker","agent","peer_id","started_at","reachability","services","services_names","local_addrs","protocols","clock_offset","connection_info","zmq_publishers","current_time"],
+          "properties": {"moniker": { "type": "string" },"agent": { "type": "string" },"peer_id": { "type": "string" },"started_at": { "type": "integer" },"reachability": { "type": "string" },"services": { "type": "integer" },"services_names": { "type": "string" },"local_addrs":
 {
   "type": "array",
   "items": { "type": "string" }
-},"protocols": 
+},"protocols":
 {
   "type": "array",
   "items": { "type": "string" }
 },"clock_offset": { "type": "number" },"connection_info": {
-  "type": "object",
+  "type": "object","required": ["connections","inbound_connections","outbound_connections"],
   "properties": {"connections": { "type": "integer" },"inbound_connections": { "type": "integer" },"outbound_connections": { "type": "integer" }}
-},"zmq_publishers": 
+},"zmq_publishers":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["topic","address","hwm"],
   "properties": {"topic": { "type": "string" },"address": { "type": "string" },"hwm": { "type": "integer" }}
 }
 },"current_time": { "type": "integer" }}
           }
         }
       }
-    
-  
+
+
 ,
     {
       "name": "pactus.utils.sign_message_with_private_key",
@@ -857,7 +857,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["signature"],
           "properties": {"signature": { "type": "string" }}
           }
         }
@@ -888,7 +888,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["is_valid"],
           "properties": {"is_valid": { "type": "boolean" }}
           }
         }
@@ -903,7 +903,7 @@
         {
           "name": "public_keys",
           "description": "List of BLS public keys to be aggregated.",
-          "schema": 
+          "schema":
 {
   "type": "array",
   "items": { "type": "string" }
@@ -913,7 +913,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["public_key","address"],
           "properties": {"public_key": { "type": "string" },"address": { "type": "string" }}
           }
         }
@@ -928,7 +928,7 @@
         {
           "name": "signatures",
           "description": "List of BLS signatures to be aggregated.",
-          "schema": 
+          "schema":
 {
   "type": "array",
   "items": { "type": "string" }
@@ -938,13 +938,13 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["signature"],
           "properties": {"signature": { "type": "string" }}
           }
         }
       }
-    
-  
+
+
 ,
     {
       "name": "pactus.wallet.create_wallet",
@@ -966,7 +966,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["mnemonic"],
           "properties": {"mnemonic": { "type": "string" }}
           }
         }
@@ -997,7 +997,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["wallet_name"],
           "properties": {"wallet_name": { "type": "string" }}
           }
         }
@@ -1018,7 +1018,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["wallet_name"],
           "properties": {"wallet_name": { "type": "string" }}
           }
         }
@@ -1039,7 +1039,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["wallet_name"],
           "properties": {"wallet_name": { "type": "string" }}
           }
         }
@@ -1060,7 +1060,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["wallet_name","total_balance"],
           "properties": {"wallet_name": { "type": "string" },"total_balance": { "type": "integer" }}
           }
         }
@@ -1091,7 +1091,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["transaction_id","signed_raw_transaction"],
           "properties": {"transaction_id": { "type": "string" },"signed_raw_transaction": { "type": "string" }}
           }
         }
@@ -1112,7 +1112,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["address"],
           "properties": {"address": { "type": "string" }}
           }
         }
@@ -1148,9 +1148,9 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["wallet_name","address_info"],
           "properties": {"wallet_name": { "type": "string" },"address_info": {
-  "type": "object",
+  "type": "object","required": ["address","public_key","label","path"],
   "properties": {"address": { "type": "string" },"public_key": { "type": "string" },"label": { "type": "string" },"path": { "type": "string" }}
 }}
           }
@@ -1177,12 +1177,12 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
-          "properties": {"history_info": 
+          "type": "object","required": ["history_info"],
+          "properties": {"history_info":
 {
   "type": "array",
   "items": {
-  "type": "object",
+  "type": "object","required": ["transaction_id","time","payload_type","description","amount"],
   "properties": {"transaction_id": { "type": "string" },"time": { "type": "integer" },"payload_type": { "type": "string" },"description": { "type": "string" },"amount": { "type": "integer" }}
 }
 }}
@@ -1220,7 +1220,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["signature"],
           "properties": {"signature": { "type": "string" }}
           }
         }
@@ -1241,7 +1241,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["wallet_name","total_stake"],
           "properties": {"wallet_name": { "type": "string" },"total_stake": { "type": "integer" }}
           }
         }
@@ -1267,7 +1267,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["wallet_name","address","label","public_key","path"],
           "properties": {"wallet_name": { "type": "string" },"address": { "type": "string" },"label": { "type": "string" },"public_key": { "type": "string" },"path": { "type": "string" }}
           }
         }
@@ -1303,7 +1303,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": [],
           "properties": {}
           }
         }
@@ -1319,8 +1319,8 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
-          "properties": {"wallets": 
+          "type": "object","required": ["wallets"],
+          "properties": {"wallets":
 {
   "type": "array",
   "items": { "type": "string" }
@@ -1344,7 +1344,7 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
+          "type": "object","required": ["wallet_name","version","network","encrypted","uuid","created_at"],
           "properties": {"wallet_name": { "type": "string" },"version": { "type": "integer" },"network": { "type": "string" },"encrypted": { "type": "boolean" },"uuid": { "type": "string" },"created_at": { "type": "integer" }}
           }
         }
@@ -1365,20 +1365,20 @@
       "result": {
         "name": "fields",
         "schema": {
-          "type": "object",
-          "properties": {"wallet_name": { "type": "string" },"data": 
+          "type": "object","required": ["wallet_name","data"],
+          "properties": {"wallet_name": { "type": "string" },"data":
 {
   "type": "array",
   "items": {
-  "type": "object",
-  "properties": {"address": { "type": "string" },"public_key": { "type": "string" },"label": { "type": "string" },"path": { "type": "string" }}
+  "type": "object","required": ["address","public_key","label","path"],
+    "properties": {"address": { "type": "string" },"public_key": { "type": "string" },"label": { "type": "string" },"path": { "type": "string" }}
 }
 }}
           }
         }
       }
-    
-  
+
+
 
   ]
 }


### PR DESCRIPTION
## Description

In this PR, result fields are set as required to prevent `Option` in the Rust JSON-RPC package.