### PR TITLE
fix(wallet): use GetAccount API to check active account

### DIFF
--- a/wallet/client.go
+++ b/wallet/client.go
@@ -158,16 +158,3 @@ func (c *grpcClient) getTransaction(txID tx.ID) (*pactus.GetTransactionResponse,
 
 	return res, nil
 }
-
-func (c *grpcClient) getPublicKeyByAddress(ctx context.Context, addr string) (string, error) {
-	if err := c.connect(); err != nil {
-		return "", err
-	}
-
-	res, err := c.blockchainClient.GetPublicKey(ctx, &pactus.GetPublicKeyRequest{Address: addr})
-	if err != nil {
-		return "", err
-	}
-
-	return res.PublicKey, nil
-}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -212,7 +212,7 @@ func (w *Wallet) RecoveryAddresses(ctx context.Context, password string,
 	eventFunc func(addr string),
 ) error {
 	return w.store.Vault.RecoverAddresses(ctx, password, func(addr string) (bool, error) {
-		pub, err := w.grpcClient.getPublicKeyByAddress(ctx, addr)
+		_, err := w.grpcClient.getAccount(addr)
 		if err != nil {
 			sErr, ok := status.FromError(err)
 			if ok && sErr.Code() == codes.NotFound {
@@ -222,13 +222,11 @@ func (w *Wallet) RecoveryAddresses(ctx context.Context, password string,
 			return false, err
 		}
 
-		ok := pub != ""
-
-		if ok && eventFunc != nil {
+		if eventFunc != nil {
 			eventFunc(addr)
 		}
 
-		return ok, nil
+		return true, nil
 	})
 }
 


### PR DESCRIPTION
## Description

This PR replaces `getPublicKeyByAddress` with `getAccount` for recovery, because if an address hasn’t sent a transaction on-chain, its public key isn’t indexed and it always shows as not found.

https://pips.pactus.org/PIPs/pip-41#solution