### PR TITLE
fix(sync): set supporting version to 1.9.0

### DIFF
--- a/sync/config.go
+++ b/sync/config.go
@@ -32,10 +32,10 @@ func DefaultConfig() *Config {
 		BlockPerMessage:   60,
 		PruneWindow:       86_400, // Default retention blocks in prune mode
 		Firewall:          firewall.DefaultConfig(),
-		// v1.5.0 is the hard-fork for Ed25519 support.
+		// v1.9.0 is the hard-fork for Split-Reward support.
 		LatestSupportingVer: version.Version{
 			Major: 1,
-			Minor: 5,
+			Minor: 9,
 			Patch: 0,
 		},
 	}

--- a/sync/handler_hello_test.go
+++ b/sync/handler_hello_test.go
@@ -77,7 +77,7 @@ func TestHandlerHelloParsingMessages(t *testing.T) {
 			nodeAgent := version.NodeAgent
 			nodeAgent.Version = version.Version{
 				Major: 1,
-				Minor: 4,
+				Minor: 8,
 				Patch: 0,
 			}
 			msg.Agent = nodeAgent.String()


### PR DESCRIPTION
## Description

This PR updates the supported version to `1.9.0` and rejects connections from nodes running lower versions.
