### PR TITLE
feat(util): rename Extend to PadToLeft; add PadToRight

### DIFF
--- a/consensusv2/cp.go
+++ b/consensusv2/cp.go
@@ -2,11 +2,11 @@ package consensusv2
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/types/proposal"
 	"github.com/pactus-project/pactus/types/vote"
-	"github.com/pactus-project/pactus/util"
 )
 
 type changeProposer struct {
@@ -25,7 +25,7 @@ func (cp *changeProposer) onTimeout(t *ticker) {
 }
 
 func (*changeProposer) cpCheckCPValue(value vote.CPValue, allowedValues ...vote.CPValue) error {
-	if util.Contains(allowedValues, value) {
+	if slices.Contains(allowedValues, value) {
 		return nil
 	}
 

--- a/crypto/bls/private_key.go
+++ b/crypto/bls/private_key.go
@@ -112,7 +112,7 @@ func (prv *PrivateKey) String() string {
 // Bytes return the raw bytes of the private key.
 func (prv *PrivateKey) Bytes() []byte {
 	data := prv.scalar.Bytes()
-	data = util.Extend(data, PrivateKeySize)
+	data = util.PadToLeft(data, PrivateKeySize)
 
 	return data
 }

--- a/state/state.go
+++ b/state/state.go
@@ -3,6 +3,7 @@ package state
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -285,7 +286,7 @@ func (st *state) UpdateLastCertificate(vte *vote.Vote) error {
 		return err
 	}
 
-	if !util.Contains(lastCert.Absentees(), val.Number()) {
+	if !slices.Contains(lastCert.Absentees(), val.Number()) {
 		return InvalidVoteForCertificateError{
 			Vote: vte,
 		}

--- a/types/certificate/certificate.go
+++ b/types/certificate/certificate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/pactus-project/pactus/crypto/bls"
@@ -317,7 +318,7 @@ func (cert *Certificate) validate(validators []*validator.Validator,
 			}
 		}
 
-		if !util.Contains(cert.absentees, num) {
+		if !slices.Contains(cert.absentees, num) {
 			pubs = append(pubs, val.PublicKey())
 			signedPower += val.Power()
 		}

--- a/util/slice.go
+++ b/util/slice.go
@@ -126,26 +126,6 @@ func Subtracts(slice1, slice2 []int32) []int32 {
 	return sub
 }
 
-// Contains checks whether the given slice has a specific item.
-func Contains[T comparable](slice []T, item T) bool {
-	return slices.Contains(slice, item)
-}
-
-// Equal tells whether a and b contain the same elements.
-// A nil argument is equivalent to an empty slice.
-func Equal[T comparable](a, b []T) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
 // SafeCmp compares two slices with constant time.
 // Note that we are using the subtle.ConstantTimeCompare() function for this
 // to help prevent timing attacks.
@@ -181,11 +161,23 @@ func Reverse[S ~[]E, E any](slice S) {
 	}
 }
 
-// Extend extends the slice to the given length by appending zero-valued elements.
-func Extend[T any](slice []T, length int) []T {
+// PadToLeft grows the slice to the given length by prepending zero-valued
+// elements if necessary.
+func PadToLeft[T any](slice []T, length int) []T {
 	if len(slice) < length {
 		pad := make([]T, length-len(slice), length+len(slice))
 		slice = append(pad, slice...)
+	}
+
+	return slice
+}
+
+// PadToRight grows the slice to the given length by appending zero-valued
+// elements if necessary.
+func PadToRight[T any](slice []T, length int) []T {
+	if len(slice) < length {
+		pad := make([]T, length-len(slice))
+		slice = append(slice, pad...)
 	}
 
 	return slice
@@ -225,6 +217,7 @@ func RemoveFirstOccurrenceOf[T comparable](slice []T, element T) ([]T, bool) {
 	return slice, false
 }
 
+// Trim truncates a slice to the given length.
 func Trim[T any](slice []T, newLength int) []T {
 	if newLength <= len(slice) {
 		return slice[:newLength]

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -165,22 +165,6 @@ func TestSubtractAndSubset(t *testing.T) {
 	})
 }
 
-func TestEqual(t *testing.T) {
-	assert.True(t, Equal([]int32{1, 2, 3}, []int32{1, 2, 3}))
-	assert.False(t, Equal([]int32{1, 2, 3}, []int32{1, 3, 2}))
-	assert.False(t, Equal([]int32{1, 2, 3}, []int32{1, 2, 3, 4}))
-	assert.True(t, Equal([]int32{}, []int32{}))
-	assert.True(t, Equal([]int32{}, nil))
-}
-
-func TestContains(t *testing.T) {
-	assert.True(t, Contains([]int32{1, 2, 3, 4}, 2))
-	assert.False(t, Contains([]int{1, 2, 3, 4}, 5))
-	assert.False(t, Contains([]int64{}, 0))
-	assert.True(t, Contains([]string{"foo", "bar"}, "foo"))
-	assert.False(t, Contains([]string{"foo", "bar"}, "zoo"))
-}
-
 func TestSafeCmp(t *testing.T) {
 	assert.True(t, SafeCmp([]byte{1, 2, 3}, []byte{1, 2, 3}))
 	assert.False(t, SafeCmp([]byte{1, 2, 3, 3}, []byte{1, 2, 3}))
@@ -222,7 +206,7 @@ func TestReverse(t *testing.T) {
 	}
 }
 
-func TestExtendSlice(t *testing.T) {
+func TestPadToLeft(t *testing.T) {
 	tests := []struct {
 		in   []int
 		size int
@@ -232,12 +216,31 @@ func TestExtendSlice(t *testing.T) {
 		{[]int{1, 2, 3}, 3, []int{1, 2, 3}},
 		{[]int{1, 2, 3}, 2, []int{1, 2, 3}},
 		{[]int{}, 5, []int{0, 0, 0, 0, 0}},
+		{[]int{}, 0, []int{}},
 	}
 
 	for _, tt := range tests {
-		inCopy := tt.in
-		inCopy = Extend(inCopy, tt.size)
-		assert.Equal(t, tt.want, inCopy, "ExtendSlice(%v, %v) == %v, want %v", tt.in, tt.size, tt.in, tt.want)
+		got := PadToLeft(tt.in, tt.size)
+		assert.Equal(t, tt.want, got, "PadToLeft failed, got %v, want %v", got, tt.want)
+	}
+}
+
+func TestPadToRight(t *testing.T) {
+	tests := []struct {
+		in   []int
+		size int
+		want []int
+	}{
+		{[]int{1, 2, 3}, 5, []int{1, 2, 3, 0, 0}},
+		{[]int{1, 2, 3}, 3, []int{1, 2, 3}},
+		{[]int{1, 2, 3}, 2, []int{1, 2, 3}},
+		{[]int{}, 4, []int{0, 0, 0, 0}},
+		{[]int{}, 0, []int{}},
+	}
+
+	for _, tt := range tests {
+		got := PadToRight(tt.in, tt.size)
+		assert.Equal(t, tt.want, got, "PadToRight failed, got %v, want %v", got, tt.want)
 	}
 }
 
@@ -309,7 +312,7 @@ func TestRemoveFirstOccurrenceOf(t *testing.T) {
 			removed: true,
 		},
 		{
-			name:    "element in slice",
+			name:    "two elements in slice",
 			s:       []int{1, 2, 2, 3},
 			e:       2,
 			want:    []int{1, 2, 3},
@@ -318,15 +321,10 @@ func TestRemoveFirstOccurrenceOf(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, removed := RemoveFirstOccurrenceOf(tt.s, tt.e)
-			if !Equal(got, tt.want) {
-				t.Errorf("got %v, want %v", got, tt.want)
-			}
-			if removed != tt.removed {
-				t.Errorf("got %v, want %v", removed, tt.removed)
-			}
-		})
+		got, removed := RemoveFirstOccurrenceOf(tt.s, tt.e)
+
+		assert.Equal(t, tt.want, got, "%s failed: got %v, want %v", tt.name, got, tt.want)
+		assert.Equal(t, tt.removed, removed, "%s failed: got %v, want %v", tt.name, removed, tt.removed)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR renames `Extend` to `PadToLeft` and adds a `PadToRight` function in utils.