### PR TITLE
refactor(util): use b.Loop() to simplify the code and improve performance

### DIFF
--- a/util/bech32m/bech32m_test.go
+++ b/util/bech32m/bech32m_test.go
@@ -415,8 +415,8 @@ func BenchmarkEncodeDecodeCycle(b *testing.B) {
 	// (that is, one Encode() and one Decode() operation), we expect at most
 	// 2 allocations per reported test op.
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		str, err := Encode(hrp, base32Input)
 		if err != nil {
 			b.Fatalf("failed to encode input: %v", err)
@@ -560,8 +560,8 @@ func BenchmarkConvertBitsDown(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := ConvertBits(inputData, 8, 5, true)
 		if err != nil {
 			b.Fatalf("error converting bits: %v", err)
@@ -584,8 +584,8 @@ func BenchmarkConvertBitsUp(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := ConvertBits(inputData, 8, 5, true)
 		if err != nil {
 			b.Fatalf("error converting bits: %v", err)

--- a/util/htpasswd/htpasswd_test.go
+++ b/util/htpasswd/htpasswd_test.go
@@ -109,9 +109,8 @@ func BenchmarkParseHtpasswd(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, a := range auth {
 			_, _, err := ExtractBasicAuth(a)
 			if err != nil {
@@ -150,9 +149,8 @@ func BenchmarkCompareBasicAuth(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, tt := range tests {
 			_ = CompareBasicAuth(tt.input, tt.user, tt.password)
 		}


### PR DESCRIPTION
## Description

These changes use b.Loop() to simplify the code and improve performance
Supported by Go Team, more info: https://go.dev/blog/testing-b-loop

