### PR TITLE
refactor(crypto): use b.Loop() to simplify the code and improve performance

### DIFF
--- a/crypto/bls/bls_bench_test.go
+++ b/crypto/bls/bls_bench_test.go
@@ -16,9 +16,7 @@ func BenchmarkEncode(b *testing.B) {
 	prv, _ := bls.PrivateKeyFromBytes(buf)
 	pub := prv.PublicKeyNative()
 
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = pub.Bytes()
 	}
 }
@@ -34,9 +32,7 @@ func BenchmarkDecodeSign(b *testing.B) {
 	sig := prv.Sign(bufMsg)
 	sigBytes := sig.Bytes()
 
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = bls.SignatureFromBytes(sigBytes)
 	}
 }
@@ -52,9 +48,7 @@ func BenchmarkVerify(b *testing.B) {
 	bufMsg := []byte("pactus")
 	sig1 := prv.Sign(bufMsg)
 
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = pub.Verify(bufMsg, sig1)
 	}
 }
@@ -67,9 +61,8 @@ func BenchmarkDecode(b *testing.B) {
 	prv, _ := bls.PrivateKeyFromBytes(buf)
 	pub := prv.PublicKeyNative()
 	pubBytes := pub.Bytes()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = bls.PublicKeyFromBytes(pubBytes)
 	}
 }


### PR DESCRIPTION


## Description

Inspired by https://github.com/pactus-project/pactus/pull/1957 and replace all.

These changes use b.Loop() to simplify the code and improve performance
Supported by Go Team, more info: https://go.dev/blog/testing-b-loop



## Related Issue

Fixes # (issue)
