### PR TITLE
fix(network): remove leading and trailing spaces from network key

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	lp2p "github.com/libp2p/go-libp2p"
@@ -47,11 +48,12 @@ type network struct {
 
 func loadOrCreateKey(path string) (lp2pcrypto.PrivKey, error) {
 	if util.PathExists(path) {
-		h, err := util.ReadFile(path)
+		data, err := util.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
-		bs, err := hex.DecodeString(string(h))
+		h := strings.TrimSpace(string(data))
+		bs, err := hex.DecodeString(h)
 		if err != nil {
 			return nil, err
 		}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -502,11 +502,21 @@ func TestLoadOrCreateKey(t *testing.T) {
 		assert.Equal(t, validKey.GetPublic(), previousValidKey.GetPublic())
 	})
 
+	t.Run("Should return error when file contains invalid data", func(t *testing.T) {
+		tempFilePath := util.TempFilePath()
+
+		err := util.WriteFile(tempFilePath, []byte("invalid_data"))
+		assert.NoError(t, err)
+
+		key, err := loadOrCreateKey(tempFilePath)
+		assert.Error(t, err)
+		assert.Nil(t, key)
+	})
+
 	t.Run("Should return error when file contains invalid private key", func(t *testing.T) {
 		tempFilePath := util.TempFilePath()
 
-		// Writes an invalid private key to the file, decoding key will fail later
-		err := util.WriteFile(tempFilePath, []byte("invalid_data"))
+		err := util.WriteFile(tempFilePath, []byte("00"))
 		assert.NoError(t, err)
 
 		key, err := loadOrCreateKey(tempFilePath)
@@ -526,5 +536,17 @@ func TestLoadOrCreateKey(t *testing.T) {
 		key, err := loadOrCreateKey(invalidPath)
 		assert.Error(t, err)
 		assert.Nil(t, key)
+	})
+
+	t.Run("Should trim spaces", func(t *testing.T) {
+		tempFilePath := util.TempFilePath()
+
+		err := util.WriteFile(tempFilePath,
+			[]byte(" 080112406da99c6b29ac8093fad3a92327aaf87acf22dbb60927786db25880f025c04cb6f80873898709981d9b75795a191eab2d29bc7983ebcb4826e2b44566c85ea194 \r\n"))
+		assert.NoError(t, err)
+
+		key, err := loadOrCreateKey(tempFilePath)
+		assert.NoError(t, err)
+		assert.NotNil(t, key)
 	})
 }


### PR DESCRIPTION
## Description

This PR ensures that if the network key contains leading and/or trailing spaces, they are removed and loaded correctly.
