### PR TITLE
ci(releaser): set CGO_ENABLED for building Pactus-GUI

### DIFF
--- a/.github/releasers/releaser_gui_linux.sh
+++ b/.github/releasers/releaser_gui_linux.sh
@@ -28,7 +28,7 @@ cd ${ROOT_DIR}
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-daemon ./cmd/daemon
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-wallet ./cmd/wallet
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-shell ./cmd/shell
-go build -ldflags "-s -w" -trimpath -tags gtk -o ${BUILD_DIR}/pactus-gui ./cmd/gtk
+CGO_ENABLED=1 go build -ldflags "-s -w" -trimpath -tags gtk -o ${BUILD_DIR}/pactus-gui ./cmd/gtk
 
 # Moving binaries to package directory
 echo "Moving binaries"

--- a/.github/releasers/releaser_gui_macos.sh
+++ b/.github/releasers/releaser_gui_macos.sh
@@ -34,7 +34,7 @@ cd ${ROOT_DIR}
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-daemon ./cmd/daemon
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-wallet ./cmd/wallet
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-shell ./cmd/shell
-go build -ldflags "-s -w" -trimpath -tags gtk -o ${BUILD_DIR}/pactus-gui ./cmd/gtk
+CGO_ENABLED=1 go build -ldflags "-s -w" -trimpath -tags gtk -o ${BUILD_DIR}/pactus-gui ./cmd/gtk
 
 
 echo "Installing gtk-mac-bundler"

--- a/.github/releasers/releaser_gui_windows_build.sh
+++ b/.github/releasers/releaser_gui_windows_build.sh
@@ -14,4 +14,4 @@ sed -i -e 's/-Wl,-luuid/-luuid/g' /mingw64/lib/pkgconfig/gdk-3.0.pc
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/unsigned/pactus-daemon.exe        ./cmd/daemon
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/unsigned/pactus-wallet.exe        ./cmd/wallet
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/unsigned/pactus-shell.exe         ./cmd/shell
-go build -ldflags "-s -w -H windowsgui" -trimpath -tags gtk -o ${BUILD_DIR}/unsigned/pactus-gui.exe ./cmd/gtk
+CGO_ENABLED=1 go build -ldflags "-s -w -H windowsgui" -trimpath -tags gtk -o ${BUILD_DIR}/unsigned/pactus-gui.exe ./cmd/gtk


### PR DESCRIPTION
## Description

This PR explicitly sets CGO_ENABLED=1 to build the Pactus GUI.
