### PR TITLE
ci(releaser): set headerpad_max_install_names flag

### DIFF
--- a/.github/releasers/releaser_gui_macos.sh
+++ b/.github/releasers/releaser_gui_macos.sh
@@ -34,7 +34,7 @@ cd ${ROOT_DIR}
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-daemon ./cmd/daemon
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-wallet ./cmd/wallet
 CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/pactus-shell ./cmd/shell
-CGO_ENABLED=1 go build -ldflags "-s -w" -trimpath -tags gtk -o ${BUILD_DIR}/pactus-gui ./cmd/gtk
+CGO_ENABLED=1 go build -ldflags "-s -w -extldflags -headerpad_max_install_names" -trimpath -tags gtk -o ${BUILD_DIR}/pactus-gui ./cmd/gtk
 
 
 echo "Installing gtk-mac-bundler"


### PR DESCRIPTION
## Description

This PR set the `headerpad_max_install_names` build flag that fix this error on changing install names in macOS:

```
error: /Applications/Xcode_16.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: changing install names or rpaths can't be redone for: /Users/runner/work/pactus/pactus/.pactus-gui.app/Contents/MacOS/pactus-gui-bin (for architecture x86_64) because larger updated load commands do not fit (the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
```