### PR TITLE
test(http): add CORS tests for gRPC-Gateway (#1760)

### DIFF
--- a/www/http/server_test.go
+++ b/www/http/server_test.go
@@ -3,24 +3,23 @@ package http
 import (
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // passThroughHandler is a minimal handler that records that it was called and
 // optionally sets a body so tests can assert whether the CORS wrapper invoked it.
 func passThroughHandler(t *testing.T, called *bool) http.Handler {
 	t.Helper()
+
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if called != nil {
 			*called = true
 		}
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("ok"))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 }
 
@@ -89,7 +88,12 @@ func TestAllowCORS(t *testing.T) {
 			called := false
 			handler := allowCORS(passThroughHandler(t, &called))
 
-			req := httptest.NewRequest(tt.method, "/http/api/blockchain/get_block_hash", nil)
+			req := httptest.NewRequestWithContext(
+				t.Context(),
+				tt.method,
+				"/http/api/blockchain/get_block_hash",
+				http.NoBody,
+			)
 			if tt.origin != "" {
 				req.Header.Set("Origin", tt.origin)
 			}
@@ -131,21 +135,11 @@ func TestPreflightHandlerSetsAllMethodsAndHeaders(t *testing.T) {
 
 	// Headers must include everything documented in the preflightHandler comment.
 	for _, h := range []string{"Content-Type", "Accept", "Authorization"} {
-		assert.Truef(
-			t,
-			strings.Contains(allowHeaders, h),
-			"preflight Access-Control-Allow-Headers %q missing %q",
-			allowHeaders, h,
-		)
+		assert.Containsf(t, allowHeaders, h, "preflight Access-Control-Allow-Headers %q missing %q", allowHeaders, h)
 	}
 
 	// Methods must include everything documented in the preflightHandler comment.
 	for _, m := range []string{"GET", "HEAD", "POST", "PUT", "DELETE"} {
-		assert.Truef(
-			t,
-			strings.Contains(allowMethods, m),
-			"preflight Access-Control-Allow-Methods %q missing %q",
-			allowMethods, m,
-		)
+		assert.Containsf(t, allowMethods, m, "preflight Access-Control-Allow-Methods %q missing %q", allowMethods, m)
 	}
 }

--- a/www/http/server_test.go
+++ b/www/http/server_test.go
@@ -1,0 +1,151 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// passThroughHandler is a minimal handler that records that it was called and
+// optionally sets a body so tests can assert whether the CORS wrapper invoked it.
+func passThroughHandler(t *testing.T, called *bool) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if called != nil {
+			*called = true
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("ok"))
+		require.NoError(t, err)
+	})
+}
+
+func TestAllowCORS(t *testing.T) {
+	tests := []struct {
+		name              string
+		method            string
+		origin            string
+		preflightMethod   string
+		wantAllowOrigin   string
+		wantPreflight     bool
+		wantHandlerCalled bool
+	}{
+		{
+			name:              "SimpleGETWithOriginSetsAllowOrigin",
+			method:            http.MethodGet,
+			origin:            "https://example.com",
+			wantAllowOrigin:   "https://example.com",
+			wantHandlerCalled: true,
+		},
+		{
+			name:              "SimplePOSTWithOriginSetsAllowOrigin",
+			method:            http.MethodPost,
+			origin:            "https://app.example.com",
+			wantAllowOrigin:   "https://app.example.com",
+			wantHandlerCalled: true,
+		},
+		{
+			name:              "RequestWithoutOriginGetsNoCORSHeaders",
+			method:            http.MethodGet,
+			origin:            "",
+			wantAllowOrigin:   "",
+			wantHandlerCalled: true,
+		},
+		{
+			name:              "PreflightOPTIONSSetsPreflightHeaders",
+			method:            http.MethodOptions,
+			origin:            "https://example.com",
+			preflightMethod:   http.MethodPost,
+			wantAllowOrigin:   "https://example.com",
+			wantPreflight:     true,
+			wantHandlerCalled: false,
+		},
+		{
+			name:              "OPTIONSWithoutPreflightHeaderFallsThrough",
+			method:            http.MethodOptions,
+			origin:            "https://example.com",
+			preflightMethod:   "",
+			wantAllowOrigin:   "https://example.com",
+			wantPreflight:     false,
+			wantHandlerCalled: true,
+		},
+		{
+			name:              "PreflightWithoutOriginDoesNothing",
+			method:            http.MethodOptions,
+			origin:            "",
+			preflightMethod:   http.MethodPost,
+			wantAllowOrigin:   "",
+			wantPreflight:     false,
+			wantHandlerCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			handler := allowCORS(passThroughHandler(t, &called))
+
+			req := httptest.NewRequest(tt.method, "/http/api/blockchain/get_block_hash", nil)
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			if tt.preflightMethod != "" {
+				req.Header.Set("Access-Control-Request-Method", tt.preflightMethod)
+			}
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.wantAllowOrigin, rec.Header().Get("Access-Control-Allow-Origin"))
+			assert.Equal(t, tt.wantHandlerCalled, called, "handler invocation expectation mismatch")
+
+			if tt.wantPreflight {
+				allowHeaders := rec.Header().Get("Access-Control-Allow-Headers")
+				allowMethods := rec.Header().Get("Access-Control-Allow-Methods")
+
+				assert.Contains(t, allowHeaders, "Authorization")
+				assert.Contains(t, allowHeaders, "Content-Type")
+				assert.Contains(t, allowHeaders, "Accept")
+
+				for _, m := range []string{"GET", "HEAD", "POST", "PUT", "DELETE"} {
+					assert.Contains(t, allowMethods, m, "preflight missing method %q", m)
+				}
+			} else {
+				assert.Empty(t, rec.Header().Get("Access-Control-Allow-Headers"))
+				assert.Empty(t, rec.Header().Get("Access-Control-Allow-Methods"))
+			}
+		})
+	}
+}
+
+func TestPreflightHandlerSetsAllMethodsAndHeaders(t *testing.T) {
+	rec := httptest.NewRecorder()
+	preflightHandler(rec)
+
+	allowHeaders := rec.Header().Get("Access-Control-Allow-Headers")
+	allowMethods := rec.Header().Get("Access-Control-Allow-Methods")
+
+	// Headers must include everything documented in the preflightHandler comment.
+	for _, h := range []string{"Content-Type", "Accept", "Authorization"} {
+		assert.Truef(
+			t,
+			strings.Contains(allowHeaders, h),
+			"preflight Access-Control-Allow-Headers %q missing %q",
+			allowHeaders, h,
+		)
+	}
+
+	// Methods must include everything documented in the preflightHandler comment.
+	for _, m := range []string{"GET", "HEAD", "POST", "PUT", "DELETE"} {
+		assert.Truef(
+			t,
+			strings.Contains(allowMethods, m),
+			"preflight Access-Control-Allow-Methods %q missing %q",
+			allowMethods, m,
+		)
+	}
+}


### PR DESCRIPTION
## Description

Adds unit tests for the HTTP gRPC-Gateway's CORS wrapper (`allowCORS` and `preflightHandler` in `www/http/server.go`). Covers the scenarios called out in the issue, adapted to the two-layer architecture:

- Auth (`BasicAuth`) lives at the gRPC interceptor layer — `www/grpc/middleware_test.go` already covers its matrix (valid / invalid / malformed / missing credentials).
- CORS lives at the HTTP gateway layer and had no direct tests before this PR.

New `TestAllowCORS` scenarios:

- Simple GET / POST with `Origin` header — `Access-Control-Allow-Origin` is set to the request's origin and the wrapped handler is called through.
- Request without an `Origin` header — no CORS headers are added, handler is called.
- Preflight `OPTIONS` with `Access-Control-Request-Method` — sets `Access-Control-Allow-Headers` + `Access-Control-Allow-Methods` and short-circuits the handler.
- Plain `OPTIONS` without the preflight hint — falls through to the wrapped handler, no preflight headers.
- `OPTIONS` without `Origin` — no-op.

`TestPreflightHandlerSetsAllMethodsAndHeaders` directly verifies `preflightHandler` advertises every header and method it documents in its comment (`Content-Type`, `Accept`, `Authorization`; `GET`, `HEAD`, `POST`, `PUT`, `DELETE`).

## Related Issue

Fixes #1760

## Validation

```
go test -count=1 ./www/http/...
ok  	github.com/pactus-project/pactus/www/http	0.352s
```

`go vet ./www/http/...` and `gofmt -l www/http/` also clean.
