### PR TITLE
fix(zmq): follow Little-Endian for encoding messages

### DIFF
--- a/www/zmq/publisher.go
+++ b/www/zmq/publisher.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-zeromq/zmq4"
 	"github.com/pactus-project/pactus/crypto"
+	"github.com/pactus-project/pactus/types"
 	"github.com/pactus-project/pactus/types/block"
 	"github.com/pactus-project/pactus/util/logger"
 )
@@ -54,19 +55,23 @@ func (b *basePub) makeTopicMsg(parts ...any) []byte {
 		switch castedVal := part.(type) {
 		case crypto.Address:
 			result = append(result, castedVal.Bytes()...)
+		case types.Height:
+			result = append(result, castedVal.EncodeAsSlice()...)
+		case types.Round:
+			result = append(result, castedVal.EncodeAsSlice()...)
 		case []byte:
 			result = append(result, castedVal...)
-		case uint32:
-			result = binary.BigEndian.AppendUint32(result, castedVal)
 		case uint16:
-			result = binary.BigEndian.AppendUint16(result, castedVal)
+			result = binary.LittleEndian.AppendUint16(result, castedVal)
+		case uint32:
+			result = binary.LittleEndian.AppendUint32(result, castedVal)
 		default:
 			panic("implement me!!")
 		}
 	}
 
-	// Append sequence number to the message (4 Bytes, Big Endian encoding)
-	result = binary.BigEndian.AppendUint32(result, b.seqNo)
+	// Append sequence number to the message (4 Bytes, Little Endian encoding)
+	result = binary.LittleEndian.AppendUint32(result, b.seqNo)
 
 	return result
 }

--- a/www/zmq/publisher_block_info.go
+++ b/www/zmq/publisher_block_info.go
@@ -26,7 +26,7 @@ func (b *blockInfoPub) onNewBlock(blk *block.Block) {
 		blk.Header().ProposerAddress(),
 		blk.Header().UnixTime(),
 		uint16(len(blk.Transactions())),
-		uint32(blk.Height()),
+		blk.Height(),
 	)
 
 	message := zmq4.NewMsg(rawMsg)

--- a/www/zmq/publisher_block_info_test.go
+++ b/www/zmq/publisher_block_info_test.go
@@ -43,10 +43,10 @@ func TestBlockInfoPublisher(t *testing.T) {
 
 	topic := msg[:2]
 	proposerBytes := msg[2:23]
-	timestamp := binary.BigEndian.Uint32(msg[23:27])
-	txCount := binary.BigEndian.Uint16(msg[27:29])
-	height := binary.BigEndian.Uint32(msg[29:33])
-	seqNo := binary.BigEndian.Uint32(msg[33:])
+	timestamp := binary.LittleEndian.Uint32(msg[23:27])
+	txCount := binary.LittleEndian.Uint16(msg[27:29])
+	height := binary.LittleEndian.Uint32(msg[29:33])
+	seqNo := binary.LittleEndian.Uint32(msg[33:])
 
 	require.Equal(t, TopicBlockInfo.Bytes(), topic)
 	require.Equal(t, blk.Header().ProposerAddress().Bytes(), proposerBytes)

--- a/www/zmq/publisher_raw_block_test.go
+++ b/www/zmq/publisher_raw_block_test.go
@@ -44,8 +44,8 @@ func TestRawBlockPublisher(t *testing.T) {
 
 	topic := msg[:2]
 	blockHeader := msg[2 : len(msg)-8]
-	height := binary.BigEndian.Uint32(msg[140 : len(msg)-4])
-	seqNo := binary.BigEndian.Uint32(msg[len(msg)-4:])
+	height := binary.LittleEndian.Uint32(msg[140 : len(msg)-4])
+	seqNo := binary.LittleEndian.Uint32(msg[len(msg)-4:])
 
 	buf := bytes.NewBuffer(blockHeader)
 	header := new(block.Header)

--- a/www/zmq/publisher_raw_tx_test.go
+++ b/www/zmq/publisher_raw_tx_test.go
@@ -47,8 +47,8 @@ func TestRawTxPublisher(t *testing.T) {
 		rawTx := msg[2 : len(msg)-8]
 
 		blockNumberOffset := len(msg) - 8
-		height := binary.BigEndian.Uint32(msg[blockNumberOffset : blockNumberOffset+4])
-		seqNo := binary.BigEndian.Uint32(msg[len(msg)-4:])
+		height := binary.LittleEndian.Uint32(msg[blockNumberOffset : blockNumberOffset+4])
+		seqNo := binary.LittleEndian.Uint32(msg[len(msg)-4:])
 
 		txn, err := tx.FromBytes(rawTx)
 		require.NoError(t, err)

--- a/www/zmq/publisher_test.go
+++ b/www/zmq/publisher_test.go
@@ -60,8 +60,8 @@ func TestPublisherOnSameSockets(t *testing.T) {
 
 		topic := TopicFromBytes(msg[:2])
 		blockNumberOffset := len(msg) - 8
-		height := binary.BigEndian.Uint32(msg[blockNumberOffset : blockNumberOffset+4])
-		seqNo := binary.BigEndian.Uint32(msg[len(msg)-4:])
+		height := binary.LittleEndian.Uint32(msg[blockNumberOffset : blockNumberOffset+4])
+		seqNo := binary.LittleEndian.Uint32(msg[len(msg)-4:])
 		t.Logf("[%s] %d", topic, seqNo)
 
 		require.Equal(t, types.Height(height), blk.Height())
@@ -96,8 +96,8 @@ func TestPublisherOnSameSockets(t *testing.T) {
 			require.Equal(t, header.StateRoot(), blk.Header().StateRoot())
 		case TopicBlockInfo:
 			proposerBytes := msg[2:23]
-			timestamp := binary.BigEndian.Uint32(msg[23:27])
-			txCount := binary.BigEndian.Uint16(msg[27:29])
+			timestamp := binary.LittleEndian.Uint32(msg[23:27])
+			txCount := binary.LittleEndian.Uint16(msg[27:29])
 
 			require.Equal(t, TopicBlockInfo, topic)
 			require.Equal(t, blk.Header().ProposerAddress().Bytes(), proposerBytes)

--- a/www/zmq/publisher_tx_info.go
+++ b/www/zmq/publisher_tx_info.go
@@ -22,7 +22,7 @@ func newTxInfoPub(socket zmq4.Socket, logger *logger.SubLogger) Publisher {
 
 func (t *txInfoPub) onNewBlock(blk *block.Block) {
 	for _, txn := range blk.Transactions() {
-		rawMsg := t.makeTopicMsg(txn.ID().Bytes(), uint32(blk.Height()))
+		rawMsg := t.makeTopicMsg(txn.ID().Bytes(), blk.Height())
 		message := zmq4.NewMsg(rawMsg)
 
 		if err := t.zmqSocket.Send(message); err != nil {

--- a/www/zmq/publisher_tx_info_test.go
+++ b/www/zmq/publisher_tx_info_test.go
@@ -44,8 +44,8 @@ func TestTxInfoPublisher(t *testing.T) {
 
 		topic := msg[:2]
 		txHash := msg[2:34]
-		height := binary.BigEndian.Uint32(msg[34:38])
-		seqNo := binary.BigEndian.Uint32(msg[38:])
+		height := binary.LittleEndian.Uint32(msg[34:38])
+		seqNo := binary.LittleEndian.Uint32(msg[38:])
 
 		require.Equal(t, TopicTransactionInfo.Bytes(), topic)
 		require.Equal(t, blk.Transactions()[i].ID().Bytes(), txHash)

--- a/www/zmq/topic.go
+++ b/www/zmq/topic.go
@@ -35,7 +35,7 @@ func (t Topic) String() string {
 
 func (t Topic) Bytes() []byte {
 	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, uint16(t))
+	binary.LittleEndian.PutUint16(b, uint16(t))
 
 	return b
 }
@@ -45,5 +45,5 @@ func TopicFromBytes(b []byte) Topic {
 		return 0
 	}
 
-	return Topic(binary.BigEndian.Uint16(b))
+	return Topic(binary.LittleEndian.Uint16(b))
 }


### PR DESCRIPTION
## Description

This PR encodes messages in ZMQ as little-endian to ensure compatibility with the specification (PIP-36) and other encoding formats.