### PR TITLE
chore(util): add LE suffix for slice convertions

### DIFF
--- a/store/block.go
+++ b/store/block.go
@@ -17,7 +17,7 @@ import (
 )
 
 func blockKey(height types.Height) []byte {
-	return append(blockPrefix, height.EncodeAsSlice()...)
+	return append(blockPrefix, height.BytesLE()...)
 }
 
 func publicKeyKey(addr crypto.Address) []byte {
@@ -99,7 +99,7 @@ func (bs *blockStore) saveBlock(batch *leveldb.Batch, height types.Height, blk *
 	blockHashKey := blockHashKey(blockHash)
 
 	batch.Put(blockKey, buf.Bytes())
-	batch.Put(blockHashKey, height.EncodeAsSlice())
+	batch.Put(blockHashKey, height.BytesLE())
 
 	sortitionSeed := blk.Header().SortitionSeed()
 	bs.addToCache(height, sortitionSeed)
@@ -122,7 +122,7 @@ func (bs *blockStore) blockHeight(h hash.Hash) types.Height {
 		return 0
 	}
 
-	return types.HeightFromSlice(data)
+	return types.HeightFromBytesLE(data)
 }
 
 func (bs *blockStore) sortitionSeed(blockHeight types.Height) *sortition.VerifiableSeed {

--- a/store/store.go
+++ b/store/store.go
@@ -271,7 +271,7 @@ func (s *store) Transaction(txID tx.ID) (*CommittedTx, error) {
 	if end > uint32(len(data)) {
 		return nil, ErrBadOffset
 	}
-	blockTime := util.SliceToUint32(data[hash.HashSize+1 : hash.HashSize+5])
+	blockTime := util.BytesToUint32LE(data[hash.HashSize+1 : hash.HashSize+5])
 
 	return &CommittedTx{
 		store:     s,

--- a/types/block/block.go
+++ b/types/block/block.go
@@ -142,7 +142,7 @@ func (b *Block) Hash() hash.Hash {
 		buf.Write(b.data.PrevCert.Hash().Bytes())
 	}
 	buf.Write(b.data.Txs.Root().Bytes())
-	buf.Write(util.Int32ToSlice(int32(b.data.Txs.Len())))
+	buf.Write(util.Int32ToBytesLE(int32(b.data.Txs.Len())))
 
 	h := hash.CalcHash(buf.Bytes())
 	b.memorizedHash = &h

--- a/types/block/block_test.go
+++ b/types/block/block_test.go
@@ -360,7 +360,7 @@ func TestBlockHash(t *testing.T) {
 	hashData := headerData
 	hashData = append(hashData, certHash.Bytes()...)
 	hashData = append(hashData, txRoot.Bytes()...)
-	hashData = append(hashData, util.Int32ToSlice(int32(blk.Transactions().Len()))...)
+	hashData = append(hashData, util.Int32ToBytesLE(int32(blk.Transactions().Len()))...)
 
 	expected1 := hash.CalcHash(hashData)
 	expected2, _ := hash.FromString("43399fa59adcfb7d8c515460ec9ca27b6a1cb865f5b7d9bde8fe56c18eaec9ab")

--- a/types/certificate/certificate.go
+++ b/types/certificate/certificate.go
@@ -236,29 +236,29 @@ func (cert *Certificate) SignBytesPrecommit(blockHash hash.Hash) []byte {
 func (cert *Certificate) SignBytesCPPreVote(blockHash hash.Hash, cpRound int16, cpValue byte) []byte {
 	return cert.signBytes(blockHash,
 		util.StringToBytes("PRE-VOTE"),
-		util.Int16ToSlice(cpRound),
+		util.Int16ToBytesLE(cpRound),
 		[]byte{cpValue})
 }
 
 func (cert *Certificate) SignBytesCPMainVote(blockHash hash.Hash, cpRound int16, cpValue byte) []byte {
 	return cert.signBytes(blockHash,
 		util.StringToBytes("MAIN-VOTE"),
-		util.Int16ToSlice(cpRound),
+		util.Int16ToBytesLE(cpRound),
 		[]byte{cpValue})
 }
 
 func (cert *Certificate) SignBytesCPDecided(blockHash hash.Hash, cpRound int16, cpValue byte) []byte {
 	return cert.signBytes(blockHash,
 		util.StringToBytes("DECIDED"),
-		util.Int16ToSlice(cpRound),
+		util.Int16ToBytesLE(cpRound),
 		[]byte{cpValue})
 }
 
 // signBytes returns the sign bytes for the vote certificate.
 func (cert *Certificate) signBytes(blockHash hash.Hash, extraData ...[]byte) []byte {
 	signBytes := blockHash.Bytes()
-	signBytes = append(signBytes, cert.height.EncodeAsSlice()...)
-	signBytes = append(signBytes, cert.round.EncodeAsSlice()...)
+	signBytes = append(signBytes, cert.height.BytesLE()...)
+	signBytes = append(signBytes, cert.round.BytesLE()...)
 	for _, data := range extraData {
 		signBytes = append(signBytes, data...)
 	}

--- a/types/height.go
+++ b/types/height.go
@@ -4,9 +4,9 @@ import "github.com/pactus-project/pactus/util"
 
 type Height uint32
 
-// HeightFromSlice creates a Height from a byte slice in little-endian format.
-func HeightFromSlice(data []byte) Height {
-	return Height(util.SliceToUint32(data))
+// HeightFromBytesLE creates a Height from a byte slice in little-endian format.
+func HeightFromBytesLE(data []byte) Height {
+	return Height(util.BytesToUint32LE(data))
 }
 
 // SafeIncrease returns a new Height that is the result of adding count to h.
@@ -34,7 +34,7 @@ func (h Height) SafeSub(other Height) uint32 {
 	return uint32(h - other)
 }
 
-// EncodeAsSlice encodes the height as a byte slice in little-endian format.
-func (h Height) EncodeAsSlice() []byte {
-	return util.Uint32ToSlice(uint32(h))
+// BytesLE encodes the height as a byte slice in little-endian format.
+func (h Height) BytesLE() []byte {
+	return util.Uint32ToBytesLE(uint32(h))
 }

--- a/types/height_test.go
+++ b/types/height_test.go
@@ -32,8 +32,8 @@ func TestHeightEncodeAsSlice(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		slice := test.height.EncodeAsSlice()
-		height := types.HeightFromSlice(slice)
+		slice := test.height.BytesLE()
+		height := types.HeightFromBytesLE(slice)
 
 		assert.Equal(t, test.expected, slice)
 		assert.Equal(t, test.height, height)

--- a/types/proposal/proposal.go
+++ b/types/proposal/proposal.go
@@ -111,8 +111,8 @@ func (p Proposal) LogString() string {
 
 func SignBytes(blockHash hash.Hash, height types.Height, round types.Round) []byte {
 	sb := blockHash.Bytes()
-	sb = append(sb, height.EncodeAsSlice()...)
-	sb = append(sb, round.EncodeAsSlice()...)
+	sb = append(sb, height.BytesLE()...)
+	sb = append(sb, round.BytesLE()...)
 
 	return sb
 }

--- a/types/proposal/proposal_test.go
+++ b/types/proposal/proposal_test.go
@@ -28,8 +28,8 @@ func TestProposalSignBytes(t *testing.T) {
 
 	prop := ts.GenerateTestProposal(ts.RandHeight(), ts.RandRound())
 	sb := prop.Block().Hash().Bytes()
-	sb = append(sb, prop.Height().EncodeAsSlice()...)
-	sb = append(sb, prop.Round().EncodeAsSlice()...)
+	sb = append(sb, prop.Height().BytesLE()...)
+	sb = append(sb, prop.Round().BytesLE()...)
 
 	assert.Equal(t, sb, prop.SignBytes())
 	assert.Equal(t, hash.CalcHash(sb), prop.Hash())

--- a/types/round.go
+++ b/types/round.go
@@ -4,9 +4,9 @@ import "github.com/pactus-project/pactus/util"
 
 type Round int16
 
-// RoundFromSlice creates a Round from a byte slice in little-endian format.
-func RoundFromSlice(data []byte) Round {
-	return Round(util.SliceToInt16(data))
+// RoundFromBytesLE creates a Round from a byte slice in little-endian format.
+func RoundFromBytesLE(data []byte) Round {
+	return Round(util.BytesToInt16LE(data))
 }
 
 // SafeIncrease returns a new Round that is the result of adding count to h.
@@ -34,7 +34,7 @@ func (h Round) SafeSub(other Round) uint32 {
 	return uint32(h - other)
 }
 
-// EncodeAsSlice encodes the Round as a byte slice in little-endian format.
-func (h Round) EncodeAsSlice() []byte {
-	return util.Int16ToSlice(int16(h))
+// BytesLE encodes the Round as a byte slice in little-endian format.
+func (h Round) BytesLE() []byte {
+	return util.Int16ToBytesLE(int16(h))
 }

--- a/types/round_test.go
+++ b/types/round_test.go
@@ -31,8 +31,8 @@ func TestRoundEncodeAsSlice(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		slice := test.round.EncodeAsSlice()
-		round := types.RoundFromSlice(slice)
+		slice := test.round.BytesLE()
+		round := types.RoundFromBytesLE(slice)
 
 		assert.Equal(t, test.expected, slice)
 		assert.Equal(t, test.round, round)

--- a/util/slice.go
+++ b/util/slice.go
@@ -9,63 +9,63 @@ import (
 	"slices"
 )
 
-func Uint16ToSlice(n uint16) []byte {
+func Uint16ToBytesLE(n uint16) []byte {
 	bs := make([]byte, 2)
 	binary.LittleEndian.PutUint16(bs, n)
 
 	return bs
 }
 
-func Int16ToSlice(n int16) []byte {
-	return Uint16ToSlice(uint16(n))
+func Int16ToBytesLE(n int16) []byte {
+	return Uint16ToBytesLE(uint16(n))
 }
 
-func SliceToUint16(bs []byte) uint16 {
+func BytesToUint16LE(bs []byte) uint16 {
 	return binary.LittleEndian.Uint16(bs)
 }
 
-func SliceToInt16(bs []byte) int16 {
-	return int16(SliceToUint16(bs))
+func BytesToInt16LE(bs []byte) int16 {
+	return int16(BytesToUint16LE(bs))
 }
 
-func Uint32ToSlice(n uint32) []byte {
+func Uint32ToBytesLE(n uint32) []byte {
 	bs := make([]byte, 4)
 	binary.LittleEndian.PutUint32(bs, n)
 
 	return bs
 }
 
-func Int32ToSlice(n int32) []byte {
-	return Uint32ToSlice(uint32(n))
+func Int32ToBytesLE(n int32) []byte {
+	return Uint32ToBytesLE(uint32(n))
 }
 
-func SliceToUint32(bs []byte) uint32 {
+func BytesToUint32LE(bs []byte) uint32 {
 	return binary.LittleEndian.Uint32(bs)
 }
 
-func SliceToInt32(bs []byte) int32 {
-	return int32(SliceToUint32(bs))
+func BytesToInt32LE(bs []byte) int32 {
+	return int32(BytesToUint32LE(bs))
 }
 
-func Uint64ToSlice(n uint64) []byte {
+func Uint64ToBytesLE(n uint64) []byte {
 	bs := make([]byte, 8)
 	binary.LittleEndian.PutUint64(bs, n)
 
 	return bs
 }
 
-func Int64ToSlice(n int64) []byte {
-	return Uint64ToSlice(uint64(n))
+func Int64ToBytesLE(n int64) []byte {
+	return Uint64ToBytesLE(uint64(n))
 }
 
-func SliceToUint64(bs []byte) uint64 {
+func BytesToUint64LE(bs []byte) uint64 {
 	n := binary.LittleEndian.Uint64(bs)
 
 	return n
 }
 
-func SliceToInt64(bs []byte) int64 {
-	return int64(SliceToUint64(bs))
+func BytesToInt64LE(bs []byte) int64 {
+	return int64(BytesToUint64LE(bs))
 }
 
 // StringToBytes converts a string to a slice of bytes.

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -23,13 +23,13 @@ func TestSliceToInt16(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		s1 := Uint16ToSlice(uint16(tt.in))
-		s2 := Int16ToSlice(tt.in)
+		s1 := Uint16ToBytesLE(uint16(tt.in))
+		s2 := Int16ToBytesLE(tt.in)
 		assert.Equal(t, s1, s2)
 		assert.Equal(t, tt.slice, s1)
 
-		v1 := SliceToInt16(tt.slice)
-		v2 := SliceToUint16(tt.slice)
+		v1 := BytesToInt16LE(tt.slice)
+		v2 := BytesToUint16LE(tt.slice)
 		assert.Equal(t, int16(v2), v1)
 		assert.Equal(t, tt.in, v1)
 	}
@@ -50,13 +50,13 @@ func TestSliceToInt32(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		s1 := Uint32ToSlice(uint32(tt.in))
-		s2 := Int32ToSlice(tt.in)
+		s1 := Uint32ToBytesLE(uint32(tt.in))
+		s2 := Int32ToBytesLE(tt.in)
 		assert.Equal(t, s1, s2)
 		assert.Equal(t, tt.slice, s1)
 
-		v1 := SliceToInt32(tt.slice)
-		v2 := SliceToUint32(tt.slice)
+		v1 := BytesToInt32LE(tt.slice)
+		v2 := BytesToUint32LE(tt.slice)
 		assert.Equal(t, int32(v2), v1)
 		assert.Equal(t, tt.in, v1)
 	}
@@ -77,13 +77,13 @@ func TestSliceToInt64(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		s1 := Uint64ToSlice(uint64(tt.in))
-		s2 := Int64ToSlice(tt.in)
+		s1 := Uint64ToBytesLE(uint64(tt.in))
+		s2 := Int64ToBytesLE(tt.in)
 		assert.Equal(t, s1, s2)
 		assert.Equal(t, tt.slice, s1)
 
-		v1 := SliceToInt64(tt.slice)
-		v2 := SliceToUint64(tt.slice)
+		v1 := BytesToInt64LE(tt.slice)
+		v2 := BytesToUint64LE(tt.slice)
 		assert.Equal(t, int64(v2), v1)
 		assert.Equal(t, tt.in, v1)
 	}

--- a/util/testsuite/testsuite.go
+++ b/util/testsuite/testsuite.go
@@ -268,7 +268,7 @@ func (ts *TestSuite) RandEd25519Signature() *ed25519.Signature {
 
 // RandHash generates a random hash for testing purposes.
 func (ts *TestSuite) RandHash() hash.Hash {
-	return hash.CalcHash(util.Int64ToSlice(ts.RandInt64(testsuite.WithMax(util.MaxInt64))))
+	return hash.CalcHash(util.Int64ToBytesLE(ts.RandInt64(testsuite.WithMax(util.MaxInt64))))
 }
 
 // RandAccAddress generates a random account address for testing purposes.


### PR DESCRIPTION
## Description

For better naming consistency, this PR adds the `LE` suffix (short for Little Endian) to slice converter functions.