### PR TITLE
fix(types): define encode options for transaction

### DIFF
--- a/store/block.go
+++ b/store/block.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pactus-project/pactus/sortition"
 	"github.com/pactus-project/pactus/types"
 	"github.com/pactus-project/pactus/types/block"
+	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/util/encoding"
 	"github.com/pactus-project/pactus/util/pairslice"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -76,24 +77,23 @@ func (bs *blockStore) saveBlock(batch *leveldb.Batch, height types.Height, blk *
 		regs[i].height = height
 		regs[i].offset = uint32(offset)
 
+		var encodeOpts []tx.EncodeOption
 		pubKey := trx.PublicKey()
 		if pubKey != nil {
 			if !bs.hasPublicKey(trx.Payload().Signer()) {
 				publicKeyKey := publicKeyKey(trx.Payload().Signer())
 				batch.Put(publicKeyKey, pubKey.Bytes())
 			} else {
-				// we have indexed this public key, se we can remove it
-				trx.SetPublicKey(nil)
+				// we have indexed this public key, so we can skip encoding it
+				encodeOpts = append(encodeOpts, tx.StripPublicKey())
 			}
 		}
 
-		err := trx.Encode(buf)
+		err := trx.Encode(buf, encodeOpts...)
 		if err != nil {
 			panic(err) // Should we panic?
 		}
 		regs[i].length = uint32(buf.Len() - offset)
-
-		trx.SetPublicKey(pubKey)
 	}
 	blockKey := blockKey(height)
 	blockHashKey := blockHashKey(blockHash)

--- a/types/tx/tx.go
+++ b/types/tx/tx.go
@@ -36,7 +36,6 @@ type Tx struct {
 }
 
 type txData struct {
-	Flags     uint8
 	Version   uint8
 	LockTime  types.Height
 	Fee       amount.Amount
@@ -56,7 +55,6 @@ func WithMemo(memo string) TxOption {
 
 func newTx(lockTime types.Height, pld payload.Payload, fee amount.Amount, opts ...TxOption) *Tx {
 	data := txData{
-		Flags:    flagNotSigned,
 		LockTime: lockTime,
 		Version:  versionLatest,
 		Payload:  pld,
@@ -127,24 +125,11 @@ func (tx *Tx) IsFreeTx() bool {
 func (tx *Tx) SetSignature(sig crypto.Signature) {
 	tx.basicChecked = false
 	tx.data.Signature = sig
-
-	if sig == nil {
-		tx.data.Flags = util.SetFlag(tx.data.Flags, flagNotSigned)
-	} else {
-		tx.data.Flags = util.UnsetFlag(tx.data.Flags, flagNotSigned)
-	}
 }
 
 func (tx *Tx) SetPublicKey(pub crypto.PublicKey) {
 	tx.basicChecked = false
 	tx.data.PublicKey = pub
-	if pub == nil {
-		if !tx.IsSubsidyTx() {
-			tx.data.Flags = util.SetFlag(tx.data.Flags, flagStripedPublicKey)
-		}
-	} else {
-		tx.data.Flags = util.UnsetFlag(tx.data.Flags, flagStripedPublicKey)
-	}
 }
 
 func (tx *Tx) BasicCheck() error {
@@ -295,8 +280,51 @@ func (tx *Tx) SerializeSize() int {
 	return size
 }
 
-func (tx *Tx) Encode(w io.Writer) error {
-	err := tx.encodeWithNoSignatory(w)
+type EncodeOption func(*encodeOptions)
+
+type encodeOptions struct {
+	stripPublicKey bool
+}
+
+func defaultEncodeOptions() *encodeOptions {
+	return &encodeOptions{
+		stripPublicKey: false,
+	}
+}
+
+func StripPublicKey() EncodeOption {
+	return func(opts *encodeOptions) {
+		opts.stripPublicKey = true
+	}
+}
+
+func (tx *Tx) Encode(w io.Writer, opts ...EncodeOption) error {
+	encOpts := defaultEncodeOptions()
+	for _, opt := range opts {
+		opt(encOpts)
+	}
+
+	flags := uint8(flagNotSigned)
+	if tx.IsSigned() {
+		flags = util.UnsetFlag(flags, flagNotSigned)
+		if encOpts.stripPublicKey || tx.IsPublicKeyStriped() {
+			flags = util.SetFlag(flags, flagStripedPublicKey)
+		}
+	}
+
+	if pld, ok := tx.data.Payload.(*payload.BondPayload); ok && pld.IsDelegated() {
+		flags = util.SetFlag(flags, flagWithDelegation)
+	}
+	if pld, ok := tx.data.Payload.(*payload.UnbondPayload); ok && pld.IsDelegated() {
+		flags = util.SetFlag(flags, flagWithDelegation)
+	}
+
+	err := encoding.WriteElement(w, flags)
+	if err != nil {
+		return err
+	}
+
+	err = tx.encodeWithNoSignatory(w)
 	if err != nil {
 		return err
 	}
@@ -307,7 +335,7 @@ func (tx *Tx) Encode(w io.Writer) error {
 			return err
 		}
 	}
-	if tx.data.PublicKey != nil {
+	if tx.data.PublicKey != nil && !encOpts.stripPublicKey {
 		err = tx.data.PublicKey.Encode(w)
 		if err != nil {
 			return err
@@ -318,14 +346,7 @@ func (tx *Tx) Encode(w io.Writer) error {
 }
 
 func (tx *Tx) encodeWithNoSignatory(w io.Writer) error {
-	flags := tx.data.Flags
-	if pld, ok := tx.data.Payload.(*payload.BondPayload); ok && pld.IsDelegated() {
-		flags = util.SetFlag(flags, flagWithDelegation)
-	}
-	if pld, ok := tx.data.Payload.(*payload.UnbondPayload); ok && pld.IsDelegated() {
-		flags = util.SetFlag(flags, flagWithDelegation)
-	}
-	err := encoding.WriteElements(w, flags, tx.data.Version, tx.data.LockTime)
+	err := encoding.WriteElements(w, tx.data.Version, tx.data.LockTime)
 	if err != nil {
 		return err
 	}
@@ -350,7 +371,8 @@ func (tx *Tx) encodeWithNoSignatory(w io.Writer) error {
 }
 
 func (tx *Tx) Decode(r io.Reader) error {
-	err := encoding.ReadElements(r, &tx.data.Flags, &tx.data.Version, &tx.data.LockTime)
+	flags := uint8(0)
+	err := encoding.ReadElements(r, &flags, &tx.data.Version, &tx.data.LockTime)
 	if err != nil {
 		return err
 	}
@@ -393,17 +415,16 @@ func (tx *Tx) Decode(r io.Reader) error {
 	}
 
 	ctx := payload.DecodeContext{
-		WithDelegation: util.IsFlagSet(tx.data.Flags, flagWithDelegation),
+		WithDelegation: util.IsFlagSet(flags, flagWithDelegation),
 	}
 	err = tx.data.Payload.Decode(ctx, r)
 	if err != nil {
 		return err
 	}
 
-	if !tx.IsSigned() {
+	if util.IsFlagSet(flags, flagNotSigned) {
 		return nil
 	}
-
 	// It is a signed transaction, Decode signatory.
 	sig, err := tx.decodeSignature(r)
 	if err != nil {
@@ -411,13 +432,15 @@ func (tx *Tx) Decode(r io.Reader) error {
 	}
 	tx.data.Signature = sig
 
-	if !tx.IsPublicKeyStriped() {
-		pub, err := tx.decodePublicKey(r)
-		if err != nil {
-			return err
-		}
-		tx.data.PublicKey = pub
+	if util.IsFlagSet(flags, flagStripedPublicKey) {
+		return nil
 	}
+	// It has a public key, decode it.
+	pub, err := tx.decodePublicKey(r)
+	if err != nil {
+		return err
+	}
+	tx.data.PublicKey = pub
 
 	return nil
 }
@@ -483,7 +506,7 @@ func (tx *Tx) SignBytes() []byte {
 		return nil
 	}
 
-	return buf.Bytes()[1:] // Exclude flags
+	return buf.Bytes()
 }
 
 func (tx *Tx) ID() ID {
@@ -532,10 +555,19 @@ func (tx *Tx) StripPublicKey() {
 
 // IsPublicKeyStriped returns true if the public key stripped from the transaction.
 func (tx *Tx) IsPublicKeyStriped() bool {
-	return util.IsFlagSet(tx.data.Flags, flagStripedPublicKey)
+	if tx.data.PublicKey != nil {
+		return false
+	}
+
+	if tx.IsSubsidyTx() {
+		// Subsidy transactions do not have a public key, but they are not considered striped.
+		return false
+	}
+
+	return true
 }
 
 // IsSigned returns true if the transaction has been signed and includes the signature.
 func (tx *Tx) IsSigned() bool {
-	return !util.IsFlagSet(tx.data.Flags, flagNotSigned)
+	return tx.data.Signature != nil
 }

--- a/types/tx/tx_test.go
+++ b/types/tx/tx_test.go
@@ -38,13 +38,14 @@ func TestEncodingTx(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	trx1 := ts.GenerateTestTransferTx()
-	trx2 := ts.GenerateTestBatchTransferTx()
-	trx3 := ts.GenerateTestBondTx()
-	trx4 := ts.GenerateTestUnbondTx()
-	trx5 := ts.GenerateTestWithdrawTx()
-	trx6 := ts.GenerateTestSortitionTx()
+	trx2 := ts.GenerateTestSubsidyTx()
+	trx3 := ts.GenerateTestBatchTransferTx()
+	trx4 := ts.GenerateTestBondTx()
+	trx5 := ts.GenerateTestUnbondTx()
+	trx6 := ts.GenerateTestWithdrawTx()
+	trx7 := ts.GenerateTestSortitionTx()
 
-	tests := []*tx.Tx{trx1, trx2, trx3, trx4, trx5, trx6}
+	tests := []*tx.Tx{trx1, trx2, trx3, trx4, trx5, trx6, trx7}
 	for _, trx := range tests {
 		require.NoError(t, trx.BasicCheck())
 		require.NoError(t, trx.BasicCheck()) // double basic check
@@ -77,18 +78,14 @@ func TestEncodingTx(t *testing.T) {
 func TestTxIDNoSignatory(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
-	tx1 := ts.GenerateTestTransferTx()
-	tx2 := new(tx.Tx)
-	*tx2 = *tx1
+	trx := ts.GenerateTestTransferTx()
+	id1 := trx.ID()
 
-	tx2.SetPublicKey(nil)
-	tx2.SetSignature(nil)
+	trx.SetSignature(nil)
+	trx.SetPublicKey(nil)
+	id2 := trx.ID()
 
-	require.True(t, tx1.IsSigned())
-	require.False(t, tx2.IsSigned())
-
-	require.Equal(t, tx1.ID(), tx2.ID())
-	require.Equal(t, tx1.SignBytes(), tx2.SignBytes())
+	require.Equal(t, id1, id2)
 }
 
 func TestBasicCheck(t *testing.T) {

--- a/util/testsuite/testsuite.go
+++ b/util/testsuite/testsuite.go
@@ -629,11 +629,13 @@ func (ts *TestSuite) NewTransactionMaker() *TransactionMaker {
 		}
 	}
 
+	_, signer := ts.RandBLSKeyPair()
+
 	return &TransactionMaker{
 		LockTime:   ts.RandHeight(),
 		Amount:     ts.RandAmount(),
 		Fee:        ts.RandFee(),
-		Signer:     nil,
+		Signer:     signer,
 		ValPubKey:  nil,
 		Recipients: recipients,
 		Receiver:   ts.RandAccAddress(),
@@ -697,17 +699,6 @@ func (ts *TestSuite) GenerateTestTransferTx(opts ...TransactionMakerOption) *tx.
 		opt(tmk)
 	}
 
-	if tmk.Signer == nil {
-		useBLSSigner := ts.RandBool()
-		if useBLSSigner {
-			_, prv := ts.RandBLSKeyPair()
-			tmk.Signer = prv
-		} else {
-			_, prv := ts.RandEd25519KeyPair()
-			tmk.Signer = prv
-		}
-	}
-
 	sender := tmk.SignerAccountAddress()
 	trx := tx.NewTransferTx(tmk.LockTime, sender, tmk.Receiver, tmk.Amount, tmk.Fee)
 	ts.HelperSignTransaction(tmk.Signer, trx)
@@ -721,17 +712,6 @@ func (ts *TestSuite) GenerateTestBatchTransferTx(opts ...TransactionMakerOption)
 
 	for _, opt := range opts {
 		opt(tmk)
-	}
-
-	if tmk.Signer == nil {
-		useBLSSigner := ts.RandBool()
-		if useBLSSigner {
-			_, prv := ts.RandBLSKeyPair()
-			tmk.Signer = prv
-		} else {
-			_, prv := ts.RandEd25519KeyPair()
-			tmk.Signer = prv
-		}
 	}
 
 	numOfRecip := ts.RandInt(testsuite.WithMax(6)) + 2
@@ -771,17 +751,6 @@ func (ts *TestSuite) GenerateTestBondTx(opts ...TransactionMakerOption) *tx.Tx {
 		opt(tmk)
 	}
 
-	if tmk.Signer == nil {
-		useBLSSigner := ts.RandBool()
-		if useBLSSigner {
-			_, prv := ts.RandBLSKeyPair()
-			tmk.Signer = prv
-		} else {
-			_, prv := ts.RandEd25519KeyPair()
-			tmk.Signer = prv
-		}
-	}
-
 	sender := tmk.SignerAccountAddress()
 	receiver := ts.RandValAddress()
 	if tmk.ValPubKey != nil {
@@ -801,11 +770,6 @@ func (ts *TestSuite) GenerateTestSortitionTx(opts ...TransactionMakerOption) *tx
 		opt(tmk)
 	}
 
-	if tmk.Signer == nil {
-		_, prv := ts.RandBLSKeyPair()
-		tmk.Signer = prv
-	}
-
 	proof := ts.RandProof()
 	sender := tmk.SignerValidatorAddress()
 	trx := tx.NewSortitionTx(tmk.LockTime, sender, proof)
@@ -822,11 +786,6 @@ func (ts *TestSuite) GenerateTestUnbondTx(opts ...TransactionMakerOption) *tx.Tx
 		opt(tmk)
 	}
 
-	if tmk.Signer == nil {
-		_, prv := ts.RandBLSKeyPair()
-		tmk.Signer = prv
-	}
-
 	sender := tmk.SignerValidatorAddress()
 	trx := tx.NewUnbondTx(tmk.LockTime, sender)
 	ts.HelperSignTransaction(tmk.Signer, trx)
@@ -840,11 +799,6 @@ func (ts *TestSuite) GenerateTestWithdrawTx(opts ...TransactionMakerOption) *tx.
 
 	for _, opt := range opts {
 		opt(tmk)
-	}
-
-	if tmk.Signer == nil {
-		_, prv := ts.RandBLSKeyPair()
-		tmk.Signer = prv
 	}
 
 	sender := tmk.SignerValidatorAddress()
@@ -913,9 +867,11 @@ func (*TestSuite) HelperSignProposal(valKey *bls.ValidatorKey, p *proposal.Propo
 }
 
 func (*TestSuite) HelperSignTransaction(prv crypto.PrivateKey, trx *tx.Tx) {
-	sig := prv.Sign(trx.SignBytes())
-	trx.SetSignature(sig)
-	trx.SetPublicKey(prv.PublicKey())
+	if prv != nil {
+		sig := prv.Sign(trx.SignBytes())
+		trx.SetSignature(sig)
+		trx.SetPublicKey(prv.PublicKey())
+	}
 }
 
 func FindFreePort() int {


### PR DESCRIPTION
## Description

This PR defines encoding options for transactions and makes the transaction structure immutable (even when stripping the public key). This helps prevent data race issues in rare conditions where multiple routines read (but not modify) the same transaction data.
