### PR TITLE
ci(packager): remove npmjs token

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -122,8 +122,6 @@ jobs:
           else
             npm publish --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
 
   publish-npm-jsonrpc:
     name: Publish pactus-jsonrpc package to npm
@@ -153,8 +151,6 @@ jobs:
           else
             npm publish --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
 
   publish-pypi-grpc:
     name: Publish pactus-grpc package to PyPI


### PR DESCRIPTION
## Description

Follow [Trusted publishing for npm packages](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow) and remove NPM-JS token.