### PR TITLE
fix(wallet): check Pending transactions

### DIFF
--- a/wallet/provider/interface.go
+++ b/wallet/provider/interface.go
@@ -12,6 +12,7 @@ type IBlockchainProvider interface {
 	GetAccount(addrStr string) (*account.Account, error)
 	GetValidator(addrStr string) (*validator.Validator, error)
 	GetTransaction(txID string) (*tx.Tx, types.Height, error)
+	CheckTransaction(data []byte) error
 
 	SendTx(trx *tx.Tx) (string, error)
 

--- a/wallet/provider/local/local.go
+++ b/wallet/provider/local/local.go
@@ -75,3 +75,12 @@ func (p *LocalBlockchainProvider) SendTx(trx *tx.Tx) (string, error) {
 func (*LocalBlockchainProvider) Close() error {
 	return nil
 }
+
+func (p *LocalBlockchainProvider) CheckTransaction(data []byte) error {
+	trx, err := tx.FromBytes(data)
+	if err != nil {
+		return err
+	}
+
+	return p.state.CheckTransaction(trx)
+}

--- a/wallet/provider/offline/offline.go
+++ b/wallet/provider/offline/offline.go
@@ -44,3 +44,7 @@ func (*OfflineBlockchainProvider) SendTx(*tx.Tx) (string, error) {
 func (*OfflineBlockchainProvider) Close() error {
 	return nil
 }
+
+func (*OfflineBlockchainProvider) CheckTransaction([]byte) error {
+	return ErrOffline
+}

--- a/wallet/provider/provider_mock.go
+++ b/wallet/provider/provider_mock.go
@@ -43,6 +43,20 @@ func (m *MockIBlockchainProvider) EXPECT() *MockIBlockchainProviderMockRecorder 
 	return m.recorder
 }
 
+// CheckTransaction mocks base method.
+func (m *MockIBlockchainProvider) CheckTransaction(data []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckTransaction", data)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckTransaction indicates an expected call of CheckTransaction.
+func (mr *MockIBlockchainProviderMockRecorder) CheckTransaction(data any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckTransaction", reflect.TypeOf((*MockIBlockchainProvider)(nil).CheckTransaction), data)
+}
+
 // Close mocks base method.
 func (m *MockIBlockchainProvider) Close() error {
 	m.ctrl.T.Helper()

--- a/wallet/provider/remote/remote.go
+++ b/wallet/provider/remote/remote.go
@@ -262,3 +262,20 @@ func (p *RemoteBlockchainProvider) GetTransaction(txID string) (*tx.Tx, types.He
 
 	return tx, types.Height(res.BlockHeight), nil
 }
+
+func (p *RemoteBlockchainProvider) CheckTransaction(data []byte) error {
+	if err := p.connect(); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(p.ctx, p.timeout)
+	defer cancel()
+
+	_, err := p.transactionClient.CheckTransaction(ctx,
+		&pactus.CheckTransactionRequest{RawTransaction: hex.EncodeToString(data)})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/wallet/transactions.go
+++ b/wallet/transactions.go
@@ -153,11 +153,22 @@ func (t *transactions) getPendingTransaction() map[string]*wtypes.TransactionInf
 			continue
 		}
 
-		// TODO: check for expired and failed transactions
+		err = t.provider.CheckTransaction(pendingInfo.Data)
+		if err != nil {
+			logger.Warn("pending transaction is invalid", "error", err, "id", pendingInfo.TxID)
+			if err := t.storage.UpdateTransactionStatus(pendingInfo.No,
+				wtypes.TransactionStatusFailed, 0); err != nil {
+				logger.Warn("failed to update transaction status", "error", err, "id", pendingInfo.TxID)
+			}
+
+			continue
+		}
 
 		// Re-broadcast the transaction
 		_, err = t.provider.SendTx(trx)
 		if err != nil {
+			logger.Debug("failed to re-broadcast pending transaction", "error", err, "id", pendingInfo.TxID)
+
 			continue
 		}
 	}


### PR DESCRIPTION
## Description

Check the Pending transactions in the wallet and mark them as failed if they are invalid.
Example: Expired Lock Time

## Related Issue

Fixes #2152
