### PR TITLE
fix(sync): check proposal message for empty proposal

### DIFF
--- a/sync/bundle/message/proposal.go
+++ b/sync/bundle/message/proposal.go
@@ -19,7 +19,11 @@ func NewProposalMessage(p *proposal.Proposal) *ProposalMessage {
 	}
 }
 
-func (*ProposalMessage) BasicCheck() error {
+func (m *ProposalMessage) BasicCheck() error {
+	if m.Proposal == nil {
+		return BasicCheckError{Reason: "no proposal"}
+	}
+
 	// Basic checks for the proposal are deferred to the consensus phase
 	// to avoid unnecessary validation for validators outside the committee.
 	return nil

--- a/sync/bundle/message/proposal_test.go
+++ b/sync/bundle/message/proposal_test.go
@@ -16,6 +16,13 @@ func TestProposalType(t *testing.T) {
 func TestProposalMessage(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
+	t.Run("No proposal", func(t *testing.T) {
+		msg := NewProposalMessage(nil)
+
+		err := msg.BasicCheck()
+		require.ErrorIs(t, err, BasicCheckError{Reason: "no proposal"})
+	})
+
 	t.Run("OK", func(t *testing.T) {
 		prop := ts.GenerateTestProposal(100, 0)
 		msg := NewProposalMessage(prop)


### PR DESCRIPTION
## Description

This PR checks if the proposal message is `nil`.
