### PR TITLE
fix(sync): check vote message for empty vote

### DIFF
--- a/sync/bundle/message/vote.go
+++ b/sync/bundle/message/vote.go
@@ -17,6 +17,10 @@ func NewVoteMessage(v *vote.Vote) *VoteMessage {
 }
 
 func (m *VoteMessage) BasicCheck() error {
+	if m.Vote == nil {
+		return BasicCheckError{Reason: "no vote"}
+	}
+
 	return m.Vote.BasicCheck()
 }
 

--- a/sync/bundle/message/vote_test.go
+++ b/sync/bundle/message/vote_test.go
@@ -17,6 +17,12 @@ func TestVoteType(t *testing.T) {
 func TestVoteMessage(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
+	t.Run("No vote", func(t *testing.T) {
+		msg := NewVoteMessage(nil)
+
+		require.ErrorIs(t, msg.BasicCheck(), BasicCheckError{Reason: "no vote"})
+	})
+
 	t.Run("Invalid vote", func(t *testing.T) {
 		vte := vote.NewPrepareVote(ts.RandHash(), ts.RandHeight(), -1, ts.RandValAddress())
 		msg := NewVoteMessage(vte)


### PR DESCRIPTION
## Description

This PR checks if the vote message is `nil`.
