### PR TITLE
chore(other): ignore mocks in Codecov report

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -13,5 +13,5 @@ coverage:
         threshold: "10%"
 
 ignore:
-  - "*/mock.go"
+  - "**/*mock.go"
   - "www/grpc/gen"


### PR DESCRIPTION
## Description

Ignore mock files from codecov. Read more [here](https://docs.codecov.com/docs/ignoring-paths)