### PR TITLE
chore(consensus): use log string for validator address

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -125,7 +125,7 @@ func makeConsensus(
 // LogString returns a concise string representation intended for use in logs.
 func (cs *consensus) LogString() string {
 	return fmt.Sprintf("{%s %d/%d/%s/%d}",
-		cs.valKey.Address(),
+		cs.valKey.Address().LogString(),
 		cs.height, cs.round, cs.currentState.name(), cs.cpRound)
 }
 

--- a/consensusv2/consensus.go
+++ b/consensusv2/consensus.go
@@ -126,7 +126,7 @@ func makeConsensus(
 // LogString returns a concise string representation intended for use in logs.
 func (cs *consensusV2) LogString() string {
 	return fmt.Sprintf("{%s %d/%d/%s/%d}",
-		cs.valKey.Address(),
+		cs.valKey.Address().LogString(),
 		cs.height, cs.round, cs.currentState.name(), cs.cpRound)
 }
 


### PR DESCRIPTION
## Description

Use `LogString` for validator address for better and shorter log string
