### PR TITLE
feat(grpc): add health service

### DIFF
--- a/www/grpc/health_test.go
+++ b/www/grpc/health_test.go
@@ -1,0 +1,126 @@
+package grpc
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestHealthCheck(t *testing.T) {
+	td := setup(t, nil)
+	client := healthpb.NewHealthClient(td.newClient(t))
+
+	tests := []struct {
+		name    string
+		service string
+	}{
+		{
+			name:    "OverallServer",
+			service: "",
+		},
+		{
+			name:    "BlockchainService",
+			service: pactus.Blockchain_ServiceDesc.ServiceName,
+		},
+		{
+			name:    "TransactionService",
+			service: pactus.Transaction_ServiceDesc.ServiceName,
+		},
+		{
+			name:    "NetworkService",
+			service: pactus.Network_ServiceDesc.ServiceName,
+		},
+		{
+			name:    "UtilsService",
+			service: pactus.Utils_ServiceDesc.ServiceName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{
+				Service: tt.service,
+			})
+			require.NoError(t, err)
+			require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+		})
+	}
+}
+
+func TestHealthWatch(t *testing.T) {
+	td := setup(t, nil)
+	client := healthpb.NewHealthClient(td.newClient(t))
+
+	stream, err := client.Watch(t.Context(), &healthpb.HealthCheckRequest{
+		Service: pactus.Blockchain_ServiceDesc.ServiceName,
+	})
+	require.NoError(t, err)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+func TestHealthCheckWalletService(t *testing.T) {
+	conf := testConfig()
+	conf.EnableWallet = true
+
+	td := setup(t, conf)
+	client := healthpb.NewHealthClient(td.newClient(t))
+
+	resp, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{
+		Service: pactus.Wallet_ServiceDesc.ServiceName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+func TestHealthCheckBasicAuth(t *testing.T) {
+	conf := testConfig()
+	conf.BasicAuth = "user:$2y$10$5Kjd955BDWLouqckHzBjKuCF6hFOUD61lhm8QpjDVHTUwMIrYUdq2"
+
+	td := setup(t, conf)
+	client := healthpb.NewHealthClient(td.newClient(t))
+
+	_, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{})
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	ctx := contextWithBasicAuth(t.Context(), "user", "password")
+	resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+func TestHealthWatchBasicAuth(t *testing.T) {
+	conf := testConfig()
+	conf.BasicAuth = "user:$2y$10$5Kjd955BDWLouqckHzBjKuCF6hFOUD61lhm8QpjDVHTUwMIrYUdq2"
+
+	td := setup(t, conf)
+	client := healthpb.NewHealthClient(td.newClient(t))
+
+	stream, err := client.Watch(t.Context(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	_, err = stream.Recv()
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	ctx := contextWithBasicAuth(t.Context(), "user", "password")
+	stream, err = client.Watch(ctx, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+func contextWithBasicAuth(ctx context.Context, user, password string) context.Context {
+	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+password))
+
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", auth))
+}

--- a/www/grpc/middleware.go
+++ b/www/grpc/middleware.go
@@ -11,38 +11,65 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func authenticateBasicAuth(ctx context.Context, storedCredential string) error {
+	user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
+	if err != nil {
+		return status.Error(codes.Unauthenticated, "failed to extract basic auth from header")
+	}
+
+	if err := htpasswd.CompareBasicAuth(storedCredential, user, password); err != nil {
+		return status.Error(codes.Unauthenticated, "username or password is invalid")
+	}
+
+	return nil
+}
+
 func BasicAuth(storedCredential string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (
 		any, error,
 	) {
-		user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
-		if err != nil {
-			return nil, status.Error(codes.Unauthenticated, "failed to extract basic auth from header")
-		}
-
-		if err := htpasswd.CompareBasicAuth(storedCredential, user, password); err != nil {
-			return nil, status.Error(codes.Unauthenticated, "username or password is invalid")
+		if err := authenticateBasicAuth(ctx, storedCredential); err != nil {
+			return nil, err
 		}
 
 		return handler(ctx, req)
 	}
 }
 
-func (s *Server) Recovery() grpc.UnaryServerInterceptor {
-	recovery := func(p any) (err error) {
-		err = status.Errorf(codes.Unknown, "%v", p)
-		stackTrace := debug.Stack()
-		s.logger.Error(
-			"recovery panic triggered in grpc server",
-			"error", err,
-			"stacktrace", string(stackTrace),
-		)
+func BasicAuthStream(storedCredential string) grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := authenticateBasicAuth(stream.Context(), storedCredential); err != nil {
+			return err
+		}
 
-		return err
+		return handler(srv, stream)
 	}
+}
+
+func (s *Server) recoverGRPCPanic(p any) (err error) {
+	err = status.Errorf(codes.Unknown, "%v", p)
+	stackTrace := debug.Stack()
+	s.logger.Error(
+		"recovery panic triggered in grpc server",
+		"error", err,
+		"stacktrace", string(stackTrace),
+	)
+
+	return err
+}
+
+func (s *Server) Recovery() grpc.UnaryServerInterceptor {
 	opts := []rec.Option{
-		rec.WithRecoveryHandler(recovery),
+		rec.WithRecoveryHandler(s.recoverGRPCPanic),
 	}
 
 	return rec.UnaryServerInterceptor(opts...)
+}
+
+func (s *Server) StreamRecovery() grpc.StreamServerInterceptor {
+	opts := []rec.Option{
+		rec.WithRecoveryHandler(s.recoverGRPCPanic),
+	}
+
+	return rec.StreamServerInterceptor(opts...)
 }

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -67,15 +69,21 @@ func (s *Server) StartServer() error {
 }
 
 func (s *Server) startListening(listener net.Listener) error {
-	opts := make([]grpc.UnaryServerInterceptor, 0)
+	unaryInterceptors := make([]grpc.UnaryServerInterceptor, 0)
+	streamInterceptors := make([]grpc.StreamServerInterceptor, 0)
 
 	if s.config.BasicAuth != "" {
-		opts = append(opts, BasicAuth(s.config.BasicAuth))
+		unaryInterceptors = append(unaryInterceptors, BasicAuth(s.config.BasicAuth))
+		streamInterceptors = append(streamInterceptors, BasicAuthStream(s.config.BasicAuth))
 	}
 
-	opts = append(opts, s.Recovery())
+	unaryInterceptors = append(unaryInterceptors, s.Recovery())
+	streamInterceptors = append(streamInterceptors, s.StreamRecovery())
 
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(opts...))
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(unaryInterceptors...),
+		grpc.ChainStreamInterceptor(streamInterceptors...),
+	)
 
 	blockchainServer := newBlockchainServer(s)
 	transactionServer := newTransactionServer(s)
@@ -93,6 +101,8 @@ func (s *Server) startListening(listener net.Listener) error {
 		pactus.RegisterWalletServer(grpcServer, walletServer)
 	}
 
+	s.registerHealthServer(grpcServer)
+
 	s.listener = listener
 	s.address = listener.Addr().String()
 	s.server = grpcServer
@@ -105,6 +115,27 @@ func (s *Server) startListening(listener net.Listener) error {
 	}()
 
 	return nil
+}
+
+func (s *Server) registerHealthServer(grpcServer *grpc.Server) {
+	healthServer := health.NewServer()
+
+	serviceNames := []string{
+		"",
+		pactus.Blockchain_ServiceDesc.ServiceName,
+		pactus.Transaction_ServiceDesc.ServiceName,
+		pactus.Network_ServiceDesc.ServiceName,
+		pactus.Utils_ServiceDesc.ServiceName,
+	}
+	if s.config.EnableWallet {
+		serviceNames = append(serviceNames, pactus.Wallet_ServiceDesc.ServiceName)
+	}
+
+	for _, serviceName := range serviceNames {
+		healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
+	}
+
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
 }
 
 func (s *Server) StopServer() {


### PR DESCRIPTION
/claim #944

## Summary
- Register the standard `grpc.health.v1.Health` service on the Pactus gRPC server.
- Report `SERVING` for the overall server and registered Pactus services, including wallet when enabled.
- Add matching stream auth/recovery interceptors so `Watch` follows the same middleware path as unary RPCs.
- Add bufconn coverage for health `Check`, `Watch`, wallet registration, and BasicAuth behavior.

## Tests
- `go test ./www/grpc`
- `go test ./www/...`

## Proof
The new bufconn tests exercise the health service end-to-end without requiring a running node process.