### PR TITLE
Add standard gRPC health checks

### DIFF
--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -21,6 +23,7 @@ type Server struct {
 	config        *Config
 	listener      net.Listener
 	server        *grpc.Server
+	healthServer  *health.Server
 	address       string
 	state         state.Facade
 	net           network.Network
@@ -76,6 +79,8 @@ func (s *Server) startListening(listener net.Listener) error {
 	opts = append(opts, s.Recovery())
 
 	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(opts...))
+	healthServer := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
 
 	blockchainServer := newBlockchainServer(s)
 	transactionServer := newTransactionServer(s)
@@ -87,15 +92,30 @@ func (s *Server) startListening(listener net.Listener) error {
 	pactus.RegisterNetworkServer(grpcServer, networkServer)
 	pactus.RegisterUtilsServer(grpcServer, utilServer)
 
+	for _, serviceName := range []string{
+		"",
+		pactus.Blockchain_ServiceDesc.ServiceName,
+		pactus.Transaction_ServiceDesc.ServiceName,
+		pactus.Network_ServiceDesc.ServiceName,
+		pactus.Utils_ServiceDesc.ServiceName,
+	} {
+		healthServer.SetServingStatus(serviceName, grpc_health_v1.HealthCheckResponse_SERVING)
+	}
+
 	if s.config.EnableWallet {
 		walletServer := newWalletServer(s, s.walletMgr)
 
 		pactus.RegisterWalletServer(grpcServer, walletServer)
+		healthServer.SetServingStatus(
+			pactus.Wallet_ServiceDesc.ServiceName,
+			grpc_health_v1.HealthCheckResponse_SERVING,
+		)
 	}
 
 	s.listener = listener
 	s.address = listener.Addr().String()
 	s.server = grpcServer
+	s.healthServer = healthServer
 
 	go func() {
 		s.logger.Info("gRPC server start listening", "address", listener.Addr())
@@ -109,6 +129,9 @@ func (s *Server) startListening(listener net.Listener) error {
 
 func (s *Server) StopServer() {
 	if s.server != nil {
+		if s.healthServer != nil {
+			s.healthServer.Shutdown()
+		}
 		s.server.Stop()
 		_ = s.listener.Close()
 	}

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -143,4 +144,45 @@ func (td *testData) utilClient(t *testing.T) pactus.UtilsClient {
 	t.Helper()
 
 	return pactus.NewUtilsClient(td.newClient(t))
+}
+
+func (td *testData) healthClient(t *testing.T) grpc_health_v1.HealthClient {
+	t.Helper()
+
+	return grpc_health_v1.NewHealthClient(td.newClient(t))
+}
+
+func TestHealthCheckReportsServing(t *testing.T) {
+	td := setup(t, nil)
+	client := td.healthClient(t)
+
+	for _, service := range []string{
+		"",
+		pactus.Blockchain_ServiceDesc.ServiceName,
+		pactus.Transaction_ServiceDesc.ServiceName,
+		pactus.Network_ServiceDesc.ServiceName,
+		pactus.Utils_ServiceDesc.ServiceName,
+	} {
+		resp, err := client.Check(
+			t.Context(),
+			&grpc_health_v1.HealthCheckRequest{Service: service},
+		)
+		require.NoError(t, err)
+		require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+	}
+}
+
+func TestHealthCheckReportsWalletServingWhenEnabled(t *testing.T) {
+	conf := testConfig()
+	conf.EnableWallet = true
+
+	td := setup(t, conf)
+	client := td.healthClient(t)
+
+	resp, err := client.Check(
+		t.Context(),
+		&grpc_health_v1.HealthCheckRequest{Service: pactus.Wallet_ServiceDesc.ServiceName},
+	)
+	require.NoError(t, err)
+	require.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
 }


### PR DESCRIPTION
## Summary

This adds standard gRPC health checking support to the Pactus gRPC server
using `grpc.health.v1.Health` instead of introducing a custom RPC.

## What Changed

- register the standard gRPC health service during server startup
- mark the root service and all registered Pactus gRPC services as `SERVING`
- include wallet health status when wallet RPC support is enabled
- add tests covering health checks for the default services and wallet service

## Notes

- health checks follow the existing unary interceptor chain, so if gRPC basic auth
  is enabled, health requests are authenticated the same way as other unary RPCs
- no proto changes were needed because this uses the standard gRPC health service

## Testing

```bash
../../tools/go/bin/go test ./www/grpc/...
```

Closes #944
