### PR TITLE
feat(grpc): add health check service

### DIFF
--- a/www/grpc/middleware.go
+++ b/www/grpc/middleware.go
@@ -15,17 +15,35 @@ func BasicAuth(storedCredential string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (
 		any, error,
 	) {
-		user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
-		if err != nil {
-			return nil, status.Error(codes.Unauthenticated, "failed to extract basic auth from header")
-		}
-
-		if err := htpasswd.CompareBasicAuth(storedCredential, user, password); err != nil {
-			return nil, status.Error(codes.Unauthenticated, "username or password is invalid")
+		if err := checkBasicAuth(ctx, storedCredential); err != nil {
+			return nil, err
 		}
 
 		return handler(ctx, req)
 	}
+}
+
+func BasicAuthStream(storedCredential string) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := checkBasicAuth(ss.Context(), storedCredential); err != nil {
+			return err
+		}
+
+		return handler(srv, ss)
+	}
+}
+
+func checkBasicAuth(ctx context.Context, storedCredential string) error {
+	user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
+	if err != nil {
+		return status.Error(codes.Unauthenticated, "failed to extract basic auth from header")
+	}
+
+	if err := htpasswd.CompareBasicAuth(storedCredential, user, password); err != nil {
+		return status.Error(codes.Unauthenticated, "username or password is invalid")
+	}
+
+	return nil
 }
 
 func (s *Server) Recovery() grpc.UnaryServerInterceptor {
@@ -45,4 +63,23 @@ func (s *Server) Recovery() grpc.UnaryServerInterceptor {
 	}
 
 	return rec.UnaryServerInterceptor(opts...)
+}
+
+func (s *Server) RecoveryStream() grpc.StreamServerInterceptor {
+	recovery := func(p any) (err error) {
+		err = status.Errorf(codes.Unknown, "%v", p)
+		stackTrace := debug.Stack()
+		s.logger.Error(
+			"recovery panic triggered in grpc server stream",
+			"error", err,
+			"stacktrace", string(stackTrace),
+		)
+
+		return err
+	}
+	opts := []rec.Option{
+		rec.WithRecoveryHandler(recovery),
+	}
+
+	return rec.StreamServerInterceptor(opts...)
 }

--- a/www/grpc/middleware_test.go
+++ b/www/grpc/middleware_test.go
@@ -21,6 +21,19 @@ func mockUnaryPanicHandler(_ context.Context, _ any) (any, error) {
 	panic("panic happen!!!")
 }
 
+type mockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s mockServerStream) Context() context.Context {
+	return s.ctx
+}
+
+func mockStreamHandler(any, grpc.ServerStream) error {
+	return nil
+}
+
 func TestBasicAuth(t *testing.T) {
 	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:password"))
 	invalidAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("invalid:invalid"))
@@ -64,6 +77,55 @@ func TestBasicAuth(t *testing.T) {
 			interceptor := BasicAuth("user:$2y$10$5Kjd955BDWLouqckHzBjKuCF6hFOUD61lhm8QpjDVHTUwMIrYUdq2")
 
 			_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, mockUnaryHandler)
+
+			got, want := status.Code(err), tt.expectedError
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestBasicAuthStream(t *testing.T) {
+	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:password"))
+	invalidAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("invalid:invalid"))
+	malformedAuth := "Malformed"
+
+	tests := []struct {
+		name          string
+		authHeader    string
+		expectedError codes.Code
+	}{
+		{
+			name:          "ValidCredentials",
+			authHeader:    auth,
+			expectedError: codes.OK,
+		},
+		{
+			name:          "InvalidCredentials",
+			authHeader:    invalidAuth,
+			expectedError: codes.Unauthenticated,
+		},
+		{
+			name:          "NoMetadata",
+			authHeader:    "",
+			expectedError: codes.Unauthenticated,
+		},
+		{
+			name:          "MalformedAuthHeader",
+			authHeader:    malformedAuth,
+			expectedError: codes.Unauthenticated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.authHeader != "" {
+				md := metadata.New(map[string]string{"authorization": tt.authHeader})
+				ctx = metadata.NewIncomingContext(ctx, md)
+			}
+
+			interceptor := BasicAuthStream("user:$2y$10$5Kjd955BDWLouqckHzBjKuCF6hFOUD61lhm8QpjDVHTUwMIrYUdq2")
+			err := interceptor(nil, mockServerStream{ctx: ctx}, &grpc.StreamServerInfo{}, mockStreamHandler)
 
 			got, want := status.Code(err), tt.expectedError
 			assert.Equal(t, want, got)

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -67,30 +69,44 @@ func (s *Server) StartServer() error {
 }
 
 func (s *Server) startListening(listener net.Listener) error {
-	opts := make([]grpc.UnaryServerInterceptor, 0)
+	unaryInterceptors := make([]grpc.UnaryServerInterceptor, 0)
+	streamInterceptors := make([]grpc.StreamServerInterceptor, 0)
 
 	if s.config.BasicAuth != "" {
-		opts = append(opts, BasicAuth(s.config.BasicAuth))
+		unaryInterceptors = append(unaryInterceptors, BasicAuth(s.config.BasicAuth))
+		streamInterceptors = append(streamInterceptors, BasicAuthStream(s.config.BasicAuth))
 	}
 
-	opts = append(opts, s.Recovery())
+	unaryInterceptors = append(unaryInterceptors, s.Recovery())
+	streamInterceptors = append(streamInterceptors, s.RecoveryStream())
 
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(opts...))
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(unaryInterceptors...),
+		grpc.ChainStreamInterceptor(streamInterceptors...),
+	)
+	healthServer := health.NewServer()
 
 	blockchainServer := newBlockchainServer(s)
 	transactionServer := newTransactionServer(s)
 	networkServer := newNetworkServer(s)
 	utilServer := newUtilsServer(s)
 
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
 	pactus.RegisterBlockchainServer(grpcServer, blockchainServer)
 	pactus.RegisterTransactionServer(grpcServer, transactionServer)
 	pactus.RegisterNetworkServer(grpcServer, networkServer)
 	pactus.RegisterUtilsServer(grpcServer, utilServer)
+	registerHealthStatus(healthServer, "")
+	registerHealthStatus(healthServer, pactus.Blockchain_ServiceDesc.ServiceName)
+	registerHealthStatus(healthServer, pactus.Transaction_ServiceDesc.ServiceName)
+	registerHealthStatus(healthServer, pactus.Network_ServiceDesc.ServiceName)
+	registerHealthStatus(healthServer, pactus.Utils_ServiceDesc.ServiceName)
 
 	if s.config.EnableWallet {
 		walletServer := newWalletServer(s, s.walletMgr)
 
 		pactus.RegisterWalletServer(grpcServer, walletServer)
+		registerHealthStatus(healthServer, pactus.Wallet_ServiceDesc.ServiceName)
 	}
 
 	s.listener = listener
@@ -105,6 +121,10 @@ func (s *Server) startListening(listener net.Listener) error {
 	}()
 
 	return nil
+}
+
+func registerHealthStatus(healthServer *health.Server, service string) {
+	healthServer.SetServingStatus(service, healthpb.HealthCheckResponse_SERVING)
 }
 
 func (s *Server) StopServer() {

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/pactus-project/pactus/www/zmq"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -143,4 +146,61 @@ func (td *testData) utilClient(t *testing.T) pactus.UtilsClient {
 	t.Helper()
 
 	return pactus.NewUtilsClient(td.newClient(t))
+}
+
+func TestHealthCheck(t *testing.T) {
+	td := setup(t, nil)
+	client := healthpb.NewHealthClient(td.newClient(t))
+
+	services := []string{
+		"",
+		pactus.Blockchain_ServiceDesc.ServiceName,
+		pactus.Transaction_ServiceDesc.ServiceName,
+		pactus.Network_ServiceDesc.ServiceName,
+		pactus.Utils_ServiceDesc.ServiceName,
+	}
+	for _, service := range services {
+		t.Run(service, func(t *testing.T) {
+			resp, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{
+				Service: service,
+			})
+			require.NoError(t, err)
+			require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.Status)
+		})
+	}
+
+	_, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{
+		Service: pactus.Wallet_ServiceDesc.ServiceName,
+	})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestHealthWatch(t *testing.T) {
+	td := setup(t, nil)
+	client := healthpb.NewHealthClient(td.newClient(t))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	stream, err := client.Watch(ctx, &healthpb.HealthCheckRequest{
+		Service: pactus.Blockchain_ServiceDesc.ServiceName,
+	})
+	require.NoError(t, err)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.Status)
+}
+
+func TestHealthCheckWithWallet(t *testing.T) {
+	conf := testConfig()
+	conf.EnableWallet = true
+	td := setup(t, conf)
+	client := healthpb.NewHealthClient(td.newClient(t))
+
+	resp, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{
+		Service: pactus.Wallet_ServiceDesc.ServiceName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.Status)
 }


### PR DESCRIPTION
## Summary
- register the standard `grpc.health.v1.Health` service on the Pactus gRPC server
- report `SERVING` for the default service and registered Pactus services, including Wallet when enabled
- add stream interceptors so `Health/Watch` follows the same BasicAuth and recovery path as unary RPCs
- add bufconn/unit coverage for `Check`, `Watch`, wallet health status, and stream BasicAuth

## Tests
- `go test ./www/grpc`
- `go test ./www/...`

## Proof
The new bufconn tests exercise the health service end-to-end without requiring a running node process. I also ran the broader `www` package suite to cover adjacent HTTP, HTML, basic auth, and ZMQ packages.

/claim #944