### PR TITLE
feat(grpc): add health check service

### DIFF
--- a/www/grpc/middleware.go
+++ b/www/grpc/middleware.go
@@ -15,34 +15,63 @@ func BasicAuth(storedCredential string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (
 		any, error,
 	) {
-		user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
-		if err != nil {
-			return nil, status.Error(codes.Unauthenticated, "failed to extract basic auth from header")
-		}
-
-		if err := htpasswd.CompareBasicAuth(storedCredential, user, password); err != nil {
-			return nil, status.Error(codes.Unauthenticated, "username or password is invalid")
+		if err := checkBasicAuth(ctx, storedCredential); err != nil {
+			return nil, err
 		}
 
 		return handler(ctx, req)
 	}
 }
 
-func (s *Server) Recovery() grpc.UnaryServerInterceptor {
-	recovery := func(p any) (err error) {
-		err = status.Errorf(codes.Unknown, "%v", p)
-		stackTrace := debug.Stack()
-		s.logger.Error(
-			"recovery panic triggered in grpc server",
-			"error", err,
-			"stacktrace", string(stackTrace),
-		)
+func BasicAuthStream(storedCredential string) grpc.StreamServerInterceptor {
+	return func(
+		srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler,
+	) error {
+		if err := checkBasicAuth(stream.Context(), storedCredential); err != nil {
+			return err
+		}
 
-		return err
+		return handler(srv, stream)
 	}
+}
+
+func checkBasicAuth(ctx context.Context, storedCredential string) error {
+	user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
+	if err != nil {
+		return status.Error(codes.Unauthenticated, "failed to extract basic auth from header")
+	}
+
+	if err := htpasswd.CompareBasicAuth(storedCredential, user, password); err != nil {
+		return status.Error(codes.Unauthenticated, "username or password is invalid")
+	}
+
+	return nil
+}
+
+func (s *Server) Recovery() grpc.UnaryServerInterceptor {
 	opts := []rec.Option{
-		rec.WithRecoveryHandler(recovery),
+		rec.WithRecoveryHandler(s.recoverGRPCPanic),
 	}
 
 	return rec.UnaryServerInterceptor(opts...)
+}
+
+func (s *Server) RecoveryStream() grpc.StreamServerInterceptor {
+	opts := []rec.Option{
+		rec.WithRecoveryHandler(s.recoverGRPCPanic),
+	}
+
+	return rec.StreamServerInterceptor(opts...)
+}
+
+func (s *Server) recoverGRPCPanic(p any) (err error) {
+	err = status.Errorf(codes.Unknown, "%v", p)
+	stackTrace := debug.Stack()
+	s.logger.Error(
+		"recovery panic triggered in grpc server",
+		"error", err,
+		"stacktrace", string(stackTrace),
+	)
+
+	return err
 }

--- a/www/grpc/middleware_test.go
+++ b/www/grpc/middleware_test.go
@@ -21,6 +21,24 @@ func mockUnaryPanicHandler(_ context.Context, _ any) (any, error) {
 	panic("panic happen!!!")
 }
 
+type mockServerStream struct {
+	grpc.ServerStream
+
+	ctx context.Context
+}
+
+func (stream mockServerStream) Context() context.Context {
+	return stream.ctx
+}
+
+func mockStreamHandler(_ any, _ grpc.ServerStream) error {
+	return nil
+}
+
+func mockStreamPanicHandler(_ any, _ grpc.ServerStream) error {
+	panic("panic happen!!!")
+}
+
 func TestBasicAuth(t *testing.T) {
 	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:password"))
 	invalidAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("invalid:invalid"))
@@ -71,11 +89,72 @@ func TestBasicAuth(t *testing.T) {
 	}
 }
 
+func TestBasicAuthStream(t *testing.T) {
+	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:password"))
+	invalidAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("invalid:invalid"))
+	malformedAuth := "Malformed"
+
+	tests := []struct {
+		name          string
+		authHeader    string
+		expectedError codes.Code
+	}{
+		{
+			name:          "ValidCredentials",
+			authHeader:    auth,
+			expectedError: codes.OK,
+		},
+		{
+			name:          "InvalidCredentials",
+			authHeader:    invalidAuth,
+			expectedError: codes.Unauthenticated,
+		},
+		{
+			name:          "NoMetadata",
+			authHeader:    "",
+			expectedError: codes.Unauthenticated,
+		},
+		{
+			name:          "MalformedAuthHeader",
+			authHeader:    malformedAuth,
+			expectedError: codes.Unauthenticated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tt.authHeader != "" {
+				md := metadata.New(map[string]string{"authorization": tt.authHeader})
+				ctx = metadata.NewIncomingContext(ctx, md)
+			}
+
+			interceptor := BasicAuthStream(
+				"user:$2y$10$5Kjd955BDWLouqckHzBjKuCF6hFOUD61lhm8QpjDVHTUwMIrYUdq2",
+			)
+
+			err := interceptor(nil, mockServerStream{ctx: ctx}, &grpc.StreamServerInfo{}, mockStreamHandler)
+
+			got, want := status.Code(err), tt.expectedError
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
 func TestGrpcRecovery(t *testing.T) {
 	s := setup(t, nil)
 
 	interceptor := s.server.Recovery()
 
 	_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{}, mockUnaryPanicHandler)
+	assert.Equal(t, codes.Unknown, status.Code(err))
+}
+
+func TestGrpcRecoveryStream(t *testing.T) {
+	s := setup(t, nil)
+
+	interceptor := s.server.RecoveryStream()
+
+	err := interceptor(nil, mockServerStream{ctx: t.Context()}, &grpc.StreamServerInfo{}, mockStreamPanicHandler)
 	assert.Equal(t, codes.Unknown, status.Code(err))
 }

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -67,15 +69,21 @@ func (s *Server) StartServer() error {
 }
 
 func (s *Server) startListening(listener net.Listener) error {
-	opts := make([]grpc.UnaryServerInterceptor, 0)
+	unaryOpts := make([]grpc.UnaryServerInterceptor, 0)
+	streamOpts := make([]grpc.StreamServerInterceptor, 0)
 
 	if s.config.BasicAuth != "" {
-		opts = append(opts, BasicAuth(s.config.BasicAuth))
+		unaryOpts = append(unaryOpts, BasicAuth(s.config.BasicAuth))
+		streamOpts = append(streamOpts, BasicAuthStream(s.config.BasicAuth))
 	}
 
-	opts = append(opts, s.Recovery())
+	unaryOpts = append(unaryOpts, s.Recovery())
+	streamOpts = append(streamOpts, s.RecoveryStream())
 
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(opts...))
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(unaryOpts...),
+		grpc.ChainStreamInterceptor(streamOpts...),
+	)
 
 	blockchainServer := newBlockchainServer(s)
 	transactionServer := newTransactionServer(s)
@@ -87,10 +95,21 @@ func (s *Server) startListening(listener net.Listener) error {
 	pactus.RegisterNetworkServer(grpcServer, networkServer)
 	pactus.RegisterUtilsServer(grpcServer, utilServer)
 
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	setServiceServingStatus(healthServer,
+		pactus.Blockchain_ServiceDesc,
+		pactus.Transaction_ServiceDesc,
+		pactus.Network_ServiceDesc,
+		pactus.Utils_ServiceDesc,
+	)
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
+
 	if s.config.EnableWallet {
 		walletServer := newWalletServer(s, s.walletMgr)
 
 		pactus.RegisterWalletServer(grpcServer, walletServer)
+		setServiceServingStatus(healthServer, pactus.Wallet_ServiceDesc)
 	}
 
 	s.listener = listener
@@ -111,5 +130,14 @@ func (s *Server) StopServer() {
 	if s.server != nil {
 		s.server.Stop()
 		_ = s.listener.Close()
+	}
+}
+
+func setServiceServingStatus(healthServer *health.Server, services ...grpc.ServiceDesc) {
+	for _, service := range services {
+		healthServer.SetServingStatus(
+			service.ServiceName,
+			healthpb.HealthCheckResponse_SERVING,
+		)
 	}
 }

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"encoding/base64"
 	"net"
 	"testing"
 
@@ -14,9 +15,14 @@ import (
 	wltmgr "github.com/pactus-project/pactus/wallet/manager"
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -143,4 +149,109 @@ func (td *testData) utilClient(t *testing.T) pactus.UtilsClient {
 	t.Helper()
 
 	return pactus.NewUtilsClient(td.newClient(t))
+}
+
+func (td *testData) healthClient(t *testing.T) healthpb.HealthClient {
+	t.Helper()
+
+	return healthpb.NewHealthClient(td.newClient(t))
+}
+
+func TestHealthCheck(t *testing.T) {
+	td := setup(t, nil)
+	client := td.healthClient(t)
+
+	services := []struct {
+		name string
+		id   string
+	}{
+		{name: "Aggregate"},
+		{name: "Blockchain", id: pactus.Blockchain_ServiceDesc.ServiceName},
+		{name: "Transaction", id: pactus.Transaction_ServiceDesc.ServiceName},
+		{name: "Network", id: pactus.Network_ServiceDesc.ServiceName},
+		{name: "Utils", id: pactus.Utils_ServiceDesc.ServiceName},
+	}
+
+	for _, service := range services {
+		t.Run(service.name, func(t *testing.T) {
+			response, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{
+				Service: service.id,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, healthpb.HealthCheckResponse_SERVING, response.Status)
+		})
+	}
+
+	_, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{
+		Service: pactus.Wallet_ServiceDesc.ServiceName,
+	})
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestHealthWatch(t *testing.T) {
+	td := setup(t, nil)
+	client := td.healthClient(t)
+
+	stream, err := client.Watch(t.Context(), &healthpb.HealthCheckRequest{
+		Service: pactus.Blockchain_ServiceDesc.ServiceName,
+	})
+	require.NoError(t, err)
+
+	response, err := stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(t, healthpb.HealthCheckResponse_SERVING, response.Status)
+}
+
+func TestHealthCheckWithWallet(t *testing.T) {
+	conf := testConfig()
+	conf.EnableWallet = true
+	td := setup(t, conf)
+	client := td.healthClient(t)
+
+	response, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{
+		Service: pactus.Wallet_ServiceDesc.ServiceName,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, healthpb.HealthCheckResponse_SERVING, response.Status)
+}
+
+func TestHealthCheckBasicAuth(t *testing.T) {
+	conf := testConfig()
+	conf.BasicAuth = "user:$2y$10$5Kjd955BDWLouqckHzBjKuCF6hFOUD61lhm8QpjDVHTUwMIrYUdq2"
+	td := setup(t, conf)
+	client := td.healthClient(t)
+
+	_, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	ctx := contextWithBasicAuth(t.Context(), "user", "password")
+	response, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, healthpb.HealthCheckResponse_SERVING, response.Status)
+}
+
+func TestHealthWatchBasicAuth(t *testing.T) {
+	conf := testConfig()
+	conf.BasicAuth = "user:$2y$10$5Kjd955BDWLouqckHzBjKuCF6hFOUD61lhm8QpjDVHTUwMIrYUdq2"
+	td := setup(t, conf)
+	client := td.healthClient(t)
+
+	stream, err := client.Watch(t.Context(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	_, err = stream.Recv()
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	ctx := contextWithBasicAuth(t.Context(), "user", "password")
+	stream, err = client.Watch(ctx, &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	response, err := stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(t, healthpb.HealthCheckResponse_SERVING, response.Status)
+}
+
+func contextWithBasicAuth(ctx context.Context, user, password string) context.Context {
+	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+password))
+
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", auth))
 }


### PR DESCRIPTION
## Summary
- Register the standard gRPC health service for Pactus gRPC servers
- Mark the aggregate service and registered Pactus services as SERVING, including Wallet only when enabled
- Add stream BasicAuth and recovery interceptors so health Watch uses the same middleware coverage as unary calls
- Add tests for health Check, health Watch, wallet status, and BasicAuth-protected health calls

Fixes #944
/claim #944

## Verification
- go test ./www/grpc
- go test ./node

## Demo notes
- `TestHealthCheck` covers the aggregate, Blockchain, Transaction, Network, and Utils health services
- `TestHealthCheckWithWallet` verifies the Wallet health service is only SERVING when Wallet is enabled
- `TestHealthWatchBasicAuth` verifies unauthenticated Watch calls fail and authenticated Watch calls receive SERVING
