### PR TITLE
feat(grpc): add health check service

### DIFF
--- a/www/grpc/health_test.go
+++ b/www/grpc/health_test.go
@@ -1,0 +1,24 @@
+package grpc
+
+import (
+	"testing"
+
+	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
+	"github.com/stretchr/testify/require"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestHealthCheck(t *testing.T) {
+	td := setup(t, nil)
+	client := td.healthClient(t)
+
+	response, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, response.Status)
+
+	response, err = client.Check(t.Context(), &healthpb.HealthCheckRequest{
+		Service: pactus.Blockchain_ServiceDesc.ServiceName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, response.Status)
+}

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -86,11 +88,19 @@ func (s *Server) startListening(listener net.Listener) error {
 	pactus.RegisterTransactionServer(grpcServer, transactionServer)
 	pactus.RegisterNetworkServer(grpcServer, networkServer)
 	pactus.RegisterUtilsServer(grpcServer, utilServer)
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pactus.Blockchain_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pactus.Transaction_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pactus.Network_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pactus.Utils_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
 
 	if s.config.EnableWallet {
 		walletServer := newWalletServer(s, s.walletMgr)
 
 		pactus.RegisterWalletServer(grpcServer, walletServer)
+		healthServer.SetServingStatus(pactus.Wallet_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
 	}
 
 	s.listener = listener

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -143,4 +144,10 @@ func (td *testData) utilClient(t *testing.T) pactus.UtilsClient {
 	t.Helper()
 
 	return pactus.NewUtilsClient(td.newClient(t))
+}
+
+func (td *testData) healthClient(t *testing.T) healthpb.HealthClient {
+	t.Helper()
+
+	return healthpb.NewHealthClient(td.newClient(t))
 }


### PR DESCRIPTION
## Summary
- register the standard gRPC health check service on the Pactus gRPC server
- report SERVING for the default service and each registered Pactus gRPC service
- add a bufconn-based health check test

Closes #944.

## Tests
- `go test ./www/grpc -run TestHealthCheck -count=1 -timeout=60s -v`
- `go test ./www/grpc -count=1 -timeout=180s`