### PR TITLE
feat(grpc): add health check service

### DIFF
--- a/www/grpc/middleware.go
+++ b/www/grpc/middleware.go
@@ -15,20 +15,46 @@ func BasicAuth(storedCredential string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (
 		any, error,
 	) {
-		user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
-		if err != nil {
-			return nil, status.Error(codes.Unauthenticated, "failed to extract basic auth from header")
-		}
-
-		if err := htpasswd.CompareBasicAuth(storedCredential, user, password); err != nil {
-			return nil, status.Error(codes.Unauthenticated, "username or password is invalid")
+		if err := authenticateBasicAuth(ctx, storedCredential); err != nil {
+			return nil, err
 		}
 
 		return handler(ctx, req)
 	}
 }
 
+func BasicAuthStream(storedCredential string) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := authenticateBasicAuth(ss.Context(), storedCredential); err != nil {
+			return err
+		}
+
+		return handler(srv, ss)
+	}
+}
+
+func authenticateBasicAuth(ctx context.Context, storedCredential string) error {
+	user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
+	if err != nil {
+		return status.Error(codes.Unauthenticated, "failed to extract basic auth from header")
+	}
+
+	if err := htpasswd.CompareBasicAuth(storedCredential, user, password); err != nil {
+		return status.Error(codes.Unauthenticated, "username or password is invalid")
+	}
+
+	return nil
+}
+
 func (s *Server) Recovery() grpc.UnaryServerInterceptor {
+	return rec.UnaryServerInterceptor(s.recoveryOptions()...)
+}
+
+func (s *Server) RecoveryStream() grpc.StreamServerInterceptor {
+	return rec.StreamServerInterceptor(s.recoveryOptions()...)
+}
+
+func (s *Server) recoveryOptions() []rec.Option {
 	recovery := func(p any) (err error) {
 		err = status.Errorf(codes.Unknown, "%v", p)
 		stackTrace := debug.Stack()
@@ -40,9 +66,7 @@ func (s *Server) Recovery() grpc.UnaryServerInterceptor {
 
 		return err
 	}
-	opts := []rec.Option{
+	return []rec.Option{
 		rec.WithRecoveryHandler(recovery),
 	}
-
-	return rec.UnaryServerInterceptor(opts...)
 }

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	grpcHealthV1 "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -21,6 +23,7 @@ type Server struct {
 	config        *Config
 	listener      net.Listener
 	server        *grpc.Server
+	healthServer  *health.Server
 	address       string
 	state         state.Facade
 	net           network.Network
@@ -81,11 +84,14 @@ func (s *Server) startListening(listener net.Listener) error {
 	transactionServer := newTransactionServer(s)
 	networkServer := newNetworkServer(s)
 	utilServer := newUtilsServer(s)
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpcHealthV1.HealthCheckResponse_SERVING)
 
 	pactus.RegisterBlockchainServer(grpcServer, blockchainServer)
 	pactus.RegisterTransactionServer(grpcServer, transactionServer)
 	pactus.RegisterNetworkServer(grpcServer, networkServer)
 	pactus.RegisterUtilsServer(grpcServer, utilServer)
+	grpcHealthV1.RegisterHealthServer(grpcServer, healthServer)
 
 	if s.config.EnableWallet {
 		walletServer := newWalletServer(s, s.walletMgr)
@@ -96,6 +102,7 @@ func (s *Server) startListening(listener net.Listener) error {
 	s.listener = listener
 	s.address = listener.Addr().String()
 	s.server = grpcServer
+	s.healthServer = healthServer
 
 	go func() {
 		s.logger.Info("gRPC server start listening", "address", listener.Addr())
@@ -109,6 +116,9 @@ func (s *Server) startListening(listener net.Listener) error {
 
 func (s *Server) StopServer() {
 	if s.server != nil {
+		if s.healthServer != nil {
+			s.healthServer.Shutdown()
+		}
 		s.server.Stop()
 		_ = s.listener.Close()
 	}

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -70,22 +70,37 @@ func (s *Server) StartServer() error {
 }
 
 func (s *Server) startListening(listener net.Listener) error {
-	opts := make([]grpc.UnaryServerInterceptor, 0)
+	unaryOpts := make([]grpc.UnaryServerInterceptor, 0)
+	streamOpts := make([]grpc.StreamServerInterceptor, 0)
 
 	if s.config.BasicAuth != "" {
-		opts = append(opts, BasicAuth(s.config.BasicAuth))
+		unaryOpts = append(unaryOpts, BasicAuth(s.config.BasicAuth))
+		streamOpts = append(streamOpts, BasicAuthStream(s.config.BasicAuth))
 	}
 
-	opts = append(opts, s.Recovery())
+	unaryOpts = append(unaryOpts, s.Recovery())
+	streamOpts = append(streamOpts, s.RecoveryStream())
 
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(opts...))
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(unaryOpts...),
+		grpc.ChainStreamInterceptor(streamOpts...),
+	)
 
 	blockchainServer := newBlockchainServer(s)
 	transactionServer := newTransactionServer(s)
 	networkServer := newNetworkServer(s)
 	utilServer := newUtilsServer(s)
 	healthServer := health.NewServer()
-	healthServer.SetServingStatus("", grpcHealthV1.HealthCheckResponse_SERVING)
+	servingStatus := grpcHealthV1.HealthCheckResponse_SERVING
+	for _, service := range []string{
+		"",
+		pactus.Blockchain_ServiceDesc.ServiceName,
+		pactus.Transaction_ServiceDesc.ServiceName,
+		pactus.Network_ServiceDesc.ServiceName,
+		pactus.Utils_ServiceDesc.ServiceName,
+	} {
+		healthServer.SetServingStatus(service, servingStatus)
+	}
 
 	pactus.RegisterBlockchainServer(grpcServer, blockchainServer)
 	pactus.RegisterTransactionServer(grpcServer, transactionServer)
@@ -97,6 +112,7 @@ func (s *Server) startListening(listener net.Listener) error {
 		walletServer := newWalletServer(s, s.walletMgr)
 
 		pactus.RegisterWalletServer(grpcServer, walletServer)
+		healthServer.SetServingStatus(pactus.Wallet_ServiceDesc.ServiceName, servingStatus)
 	}
 
 	s.listener = listener

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	grpcHealthV1 "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -143,4 +144,19 @@ func (td *testData) utilClient(t *testing.T) pactus.UtilsClient {
 	t.Helper()
 
 	return pactus.NewUtilsClient(td.newClient(t))
+}
+
+func (td *testData) healthClient(t *testing.T) grpcHealthV1.HealthClient {
+	t.Helper()
+
+	return grpcHealthV1.NewHealthClient(td.newClient(t))
+}
+
+func TestHealthCheck(t *testing.T) {
+	td := setup(t, nil)
+	client := td.healthClient(t)
+
+	response, err := client.Check(t.Context(), &grpcHealthV1.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, grpcHealthV1.HealthCheckResponse_SERVING, response.Status)
 }

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -12,12 +12,16 @@ import (
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/testsuite"
 	wltmgr "github.com/pactus-project/pactus/wallet/manager"
+	grpcBasicAuth "github.com/pactus-project/pactus/www/grpc/basicauth"
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	grpcHealthV1 "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -100,12 +104,15 @@ func (td *testData) bufDialer(context.Context, string) (net.Conn, error) {
 	return td.listener.Dial()
 }
 
-func (td *testData) newClient(t *testing.T) *grpc.ClientConn {
+func (td *testData) newClient(t *testing.T, opts ...grpc.DialOption) *grpc.ClientConn {
 	t.Helper()
 
-	conn, err := grpc.NewClient("passthrough://bufnet",
+	opts = append([]grpc.DialOption{
 		grpc.WithContextDialer(td.bufDialer),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}, opts...)
+
+	conn, err := grpc.NewClient("passthrough://bufnet", opts...)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -156,7 +163,81 @@ func TestHealthCheck(t *testing.T) {
 	td := setup(t, nil)
 	client := td.healthClient(t)
 
-	response, err := client.Check(t.Context(), &grpcHealthV1.HealthCheckRequest{})
+	services := []string{
+		"",
+		pactus.Blockchain_ServiceDesc.ServiceName,
+		pactus.Transaction_ServiceDesc.ServiceName,
+		pactus.Network_ServiceDesc.ServiceName,
+		pactus.Utils_ServiceDesc.ServiceName,
+	}
+	for _, service := range services {
+		response, err := client.Check(t.Context(), &grpcHealthV1.HealthCheckRequest{
+			Service: service,
+		})
+		require.NoError(t, err)
+		require.Equal(t, grpcHealthV1.HealthCheckResponse_SERVING, response.Status)
+	}
+
+	_, err := client.Check(t.Context(), &grpcHealthV1.HealthCheckRequest{
+		Service: pactus.Wallet_ServiceDesc.ServiceName,
+	})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestHealthCheckWithWallet(t *testing.T) {
+	conf := testConfig()
+	conf.EnableWallet = true
+	td := setup(t, conf)
+	client := td.healthClient(t)
+
+	response, err := client.Check(t.Context(), &grpcHealthV1.HealthCheckRequest{
+		Service: pactus.Wallet_ServiceDesc.ServiceName,
+	})
 	require.NoError(t, err)
 	require.Equal(t, grpcHealthV1.HealthCheckResponse_SERVING, response.Status)
+}
+
+func TestHealthWatch(t *testing.T) {
+	td := setup(t, nil)
+	client := td.healthClient(t)
+
+	stream, err := client.Watch(t.Context(), &grpcHealthV1.HealthCheckRequest{
+		Service: pactus.Blockchain_ServiceDesc.ServiceName,
+	})
+	require.NoError(t, err)
+
+	response, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, grpcHealthV1.HealthCheckResponse_SERVING, response.Status)
+}
+
+func TestHealthRequiresBasicAuth(t *testing.T) {
+	conf := testConfig()
+	conf.BasicAuth = "user:$2y$10$5Kjd955BDWLouqckHzBjKuCF6hFOUD61lhm8QpjDVHTUwMIrYUdq2"
+	td := setup(t, conf)
+	client := td.healthClient(t)
+
+	_, err := client.Check(t.Context(), &grpcHealthV1.HealthCheckRequest{})
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	stream, err := client.Watch(t.Context(), &grpcHealthV1.HealthCheckRequest{})
+	if err == nil {
+		_, err = stream.Recv()
+	}
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	ctx := metadata.NewOutgoingContext(t.Context(), metadata.Pairs(
+		"authorization", grpcBasicAuth.EncodeBasicAuth("user", "password"),
+	))
+
+	checkResponse, err := client.Check(ctx, &grpcHealthV1.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, grpcHealthV1.HealthCheckResponse_SERVING, checkResponse.Status)
+
+	watchStream, err := client.Watch(ctx, &grpcHealthV1.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	watchResponse, err := watchStream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, grpcHealthV1.HealthCheckResponse_SERVING, watchResponse.Status)
 }


### PR DESCRIPTION
## Summary
- register the standard `grpc.health.v1.Health` service on the Pactus gRPC server
- report `SERVING` for the default health target and registered Pactus services, including Wallet only when enabled
- apply BasicAuth and recovery middleware to both unary and stream RPCs so `Check` and `Watch` share the same protection
- add bufconn coverage for health `Check`, `Watch`, wallet status, and BasicAuth failures/successes

## Demo
Short backend demo showing the health tests running and passing:

![pactus-health-demo](https://github.com/user-attachments/assets/d28d4cb6-0f73-41d2-bc96-415bb2731a30)

## Tests
- `CGO_ENABLED=0 ../.toolchains/go/bin/go test ./www/grpc`
- `CGO_ENABLED=0 ../.toolchains/go/bin/go test ./www/...`

## Proof
The new bufconn tests exercise the health service end-to-end without a running node process, including the streaming `Watch` endpoint and BasicAuth behavior.

/claim #944

Closes #944
