### PR TITLE
feat(grpc): register health check service

### DIFF
--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -86,6 +88,10 @@ func (s *Server) startListening(listener net.Listener) error {
 	pactus.RegisterTransactionServer(grpcServer, transactionServer)
 	pactus.RegisterNetworkServer(grpcServer, networkServer)
 	pactus.RegisterUtilsServer(grpcServer, utilServer)
+
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
 
 	if s.config.EnableWallet {
 		walletServer := newWalletServer(s, s.walletMgr)

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -143,4 +144,18 @@ func (td *testData) utilClient(t *testing.T) pactus.UtilsClient {
 	t.Helper()
 
 	return pactus.NewUtilsClient(td.newClient(t))
+}
+
+func (td *testData) healthClient(t *testing.T) healthpb.HealthClient {
+	t.Helper()
+
+	return healthpb.NewHealthClient(td.newClient(t))
+}
+
+func TestHealthCheck(t *testing.T) {
+	td := setup(t, nil)
+
+	res, err := td.healthClient(t).Check(t.Context(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, res.GetStatus())
 }


### PR DESCRIPTION
## Summary

- register the standard gRPC health checking service on the Pactus gRPC server
- report the default service as `SERVING`
- add a bufconn regression test that verifies `Health/Check` returns `SERVING`

## Why

This lets operators and tooling probe the Pactus gRPC server using the standard `grpc.health.v1.Health` API instead of relying on project-specific RPC calls.

## Validation

- `git diff --check`

I could not run `go test` locally because this environment does not have `go`/`gofmt` installed.

/claim #944