### PR TITLE
Add gRPC health check service

### DIFF
--- a/www/grpc/middleware.go
+++ b/www/grpc/middleware.go
@@ -15,12 +15,7 @@ func BasicAuth(storedCredential string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (
 		any, error,
 	) {
-		user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
-		if err != nil {
-			return nil, status.Error(codes.Unauthenticated, "failed to extract basic auth from header")
-		}
-
-		if err := htpasswd.CompareBasicAuth(storedCredential, user, password); err != nil {
+		if err := checkBasicAuth(ctx, storedCredential); err != nil {
 			return nil, status.Error(codes.Unauthenticated, "username or password is invalid")
 		}
 
@@ -28,7 +23,34 @@ func BasicAuth(storedCredential string) grpc.UnaryServerInterceptor {
 	}
 }
 
+func BasicAuthStream(storedCredential string) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := checkBasicAuth(ss.Context(), storedCredential); err != nil {
+			return status.Error(codes.Unauthenticated, "username or password is invalid")
+		}
+
+		return handler(srv, ss)
+	}
+}
+
+func checkBasicAuth(ctx context.Context, storedCredential string) error {
+	user, password, err := htpasswd.ExtractBasicAuthFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return htpasswd.CompareBasicAuth(storedCredential, user, password)
+}
+
 func (s *Server) Recovery() grpc.UnaryServerInterceptor {
+	return rec.UnaryServerInterceptor(s.recoveryOptions()...)
+}
+
+func (s *Server) RecoveryStream() grpc.StreamServerInterceptor {
+	return rec.StreamServerInterceptor(s.recoveryOptions()...)
+}
+
+func (s *Server) recoveryOptions() []rec.Option {
 	recovery := func(p any) (err error) {
 		err = status.Errorf(codes.Unknown, "%v", p)
 		stackTrace := debug.Stack()
@@ -40,9 +62,8 @@ func (s *Server) Recovery() grpc.UnaryServerInterceptor {
 
 		return err
 	}
-	opts := []rec.Option{
+
+	return []rec.Option{
 		rec.WithRecoveryHandler(recovery),
 	}
-
-	return rec.UnaryServerInterceptor(opts...)
 }

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -67,15 +69,21 @@ func (s *Server) StartServer() error {
 }
 
 func (s *Server) startListening(listener net.Listener) error {
-	opts := make([]grpc.UnaryServerInterceptor, 0)
+	unaryOpts := make([]grpc.UnaryServerInterceptor, 0)
+	streamOpts := make([]grpc.StreamServerInterceptor, 0)
 
 	if s.config.BasicAuth != "" {
-		opts = append(opts, BasicAuth(s.config.BasicAuth))
+		unaryOpts = append(unaryOpts, BasicAuth(s.config.BasicAuth))
+		streamOpts = append(streamOpts, BasicAuthStream(s.config.BasicAuth))
 	}
 
-	opts = append(opts, s.Recovery())
+	unaryOpts = append(unaryOpts, s.Recovery())
+	streamOpts = append(streamOpts, s.RecoveryStream())
 
-	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(opts...))
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(unaryOpts...),
+		grpc.ChainStreamInterceptor(streamOpts...),
+	)
 
 	blockchainServer := newBlockchainServer(s)
 	transactionServer := newTransactionServer(s)
@@ -87,10 +95,19 @@ func (s *Server) startListening(listener net.Listener) error {
 	pactus.RegisterNetworkServer(grpcServer, networkServer)
 	pactus.RegisterUtilsServer(grpcServer, utilServer)
 
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pactus.Blockchain_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pactus.Transaction_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pactus.Network_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(pactus.Utils_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
+
 	if s.config.EnableWallet {
 		walletServer := newWalletServer(s, s.walletMgr)
 
 		pactus.RegisterWalletServer(grpcServer, walletServer)
+		healthServer.SetServingStatus(pactus.Wallet_ServiceDesc.ServiceName, healthpb.HealthCheckResponse_SERVING)
 	}
 
 	s.listener = listener

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/pactus-project/pactus/www/zmq"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -143,4 +146,44 @@ func (td *testData) utilClient(t *testing.T) pactus.UtilsClient {
 	t.Helper()
 
 	return pactus.NewUtilsClient(td.newClient(t))
+}
+
+func (td *testData) healthClient(t *testing.T) healthpb.HealthClient {
+	t.Helper()
+
+	return healthpb.NewHealthClient(td.newClient(t))
+}
+
+func TestHealthCheck(t *testing.T) {
+	td := setup(t, nil)
+	client := td.healthClient(t)
+
+	serviceNames := []string{
+		"",
+		pactus.Blockchain_ServiceDesc.ServiceName,
+		pactus.Transaction_ServiceDesc.ServiceName,
+		pactus.Network_ServiceDesc.ServiceName,
+		pactus.Utils_ServiceDesc.ServiceName,
+	}
+
+	for _, serviceName := range serviceNames {
+		resp, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{
+			Service: serviceName,
+		})
+		require.NoError(t, err)
+		require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+	}
+}
+
+func TestHealthWatchRequiresBasicAuth(t *testing.T) {
+	conf := testConfig()
+	conf.BasicAuth = "user:$2y$10$5Kjd955BDWLouqckHzBjKuCF6hFOUD61lhm8QpjDVHTUwMIrYUdq2"
+	td := setup(t, conf)
+
+	stream, err := td.healthClient(t).Watch(t.Context(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
 }


### PR DESCRIPTION
/claim #944

## Summary
- register the standard `grpc.health.v1.Health` service on the Pactus gRPC server
- report the default server and registered Pactus services as `SERVING`
- apply BasicAuth and recovery middleware to both unary and streaming RPCs, including `Health/Watch`
- add bufconn coverage for health `Check` and stream auth behavior

Fixes #944.

## Demo
This API-only change is exercised by the new bufconn tests, which call the health service directly.

## Tests
- `go test ./www/grpc`