### PR TITLE
feat(grpc): register health check service

### DIFF
--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -81,11 +83,14 @@ func (s *Server) startListening(listener net.Listener) error {
 	transactionServer := newTransactionServer(s)
 	networkServer := newNetworkServer(s)
 	utilServer := newUtilsServer(s)
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 
 	pactus.RegisterBlockchainServer(grpcServer, blockchainServer)
 	pactus.RegisterTransactionServer(grpcServer, transactionServer)
 	pactus.RegisterNetworkServer(grpcServer, networkServer)
 	pactus.RegisterUtilsServer(grpcServer, utilServer)
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
 
 	if s.config.EnableWallet {
 		walletServer := newWalletServer(s, s.walletMgr)

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/test/bufconn"
 )
 
@@ -143,4 +144,19 @@ func (td *testData) utilClient(t *testing.T) pactus.UtilsClient {
 	t.Helper()
 
 	return pactus.NewUtilsClient(td.newClient(t))
+}
+
+func (td *testData) healthClient(t *testing.T) healthpb.HealthClient {
+	t.Helper()
+
+	return healthpb.NewHealthClient(td.newClient(t))
+}
+
+func TestHealthCheck(t *testing.T) {
+	td := setup(t, nil)
+	client := td.healthClient(t)
+
+	res, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, res.GetStatus())
 }


### PR DESCRIPTION
Fixes #944.

This PR registers the standard gRPC health checking service for the Pactus gRPC server using `google.golang.org/grpc/health`.

Changes:
- registers `grpc.health.v1.Health` alongside the existing Pactus gRPC services
- explicitly sets the default health status to `SERVING`
- adds a bufconn test for `Health/Check`

Verification:
- `go test ./www/grpc`
- `make unit_test`