### PR TITLE
feat(grpc): add health check service

### DIFF
--- a/www/grpc/health_test.go
+++ b/www/grpc/health_test.go
@@ -1,0 +1,17 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestHealthCheck(t *testing.T) {
+	td := setup(t, nil)
+	client := healthpb.NewHealthClient(td.newClient(t))
+
+	resp, err := client.Check(t.Context(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.Status)
+}

--- a/www/grpc/server.go
+++ b/www/grpc/server.go
@@ -14,6 +14,8 @@ import (
 	pactus "github.com/pactus-project/pactus/www/grpc/gen/go"
 	"github.com/pactus-project/pactus/www/zmq"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type Server struct {
@@ -76,6 +78,7 @@ func (s *Server) startListening(listener net.Listener) error {
 	opts = append(opts, s.Recovery())
 
 	grpcServer := grpc.NewServer(grpc.ChainUnaryInterceptor(opts...))
+	healthServer := health.NewServer()
 
 	blockchainServer := newBlockchainServer(s)
 	transactionServer := newTransactionServer(s)
@@ -86,6 +89,8 @@ func (s *Server) startListening(listener net.Listener) error {
 	pactus.RegisterTransactionServer(grpcServer, transactionServer)
 	pactus.RegisterNetworkServer(grpcServer, networkServer)
 	pactus.RegisterUtilsServer(grpcServer, utilServer)
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 
 	if s.config.EnableWallet {
 		walletServer := newWalletServer(s, s.walletMgr)


### PR DESCRIPTION
Closes #944

/claim #944

## Summary
- register the standard grpc.health.v1 health service on the existing gRPC server
- report the default service as SERVING once the server is initialized
- add a bufconn test for Health.Check

## Tests
- go test ./www/grpc