### PR TITLE
fix(gtk): enable wallet service on starting GUI

### DIFF
--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -295,9 +295,9 @@ func newNode(ctx context.Context, workingDir string, statusCb statusReporter) (*
 	configModifier := func(cfg *config.Config) *config.Config {
 		if !cfg.GRPC.Enable {
 			cfg.GRPC.Enable = true
-			cfg.GRPC.EnableWallet = true
 			cfg.GRPC.Listen = "localhost:0"
 		}
+		cfg.GRPC.EnableWallet = true
 
 		return cfg
 	}


### PR DESCRIPTION
## Description

This PR fixes an issue that opens the empty default_wallet on starting the GUI.
