### PR TITLE
fix(wallet): use hardened path for Secp256k1

### DIFF
--- a/cmd/gtk/controller/wallet_create_address_dialog_controller.go
+++ b/cmd/gtk/controller/wallet_create_address_dialog_controller.go
@@ -42,7 +42,8 @@ func (c *WalletCreateAddressDialogController) Run() {
 		}
 
 		password := ""
-		if typ == crypto.AddressTypeEd25519Account {
+		if typ == crypto.AddressTypeEd25519Account ||
+			typ == crypto.AddressTypeSecp256k1Account {
 			pwd, ok := PasswordProvider(c.model)
 			if !ok {
 				return

--- a/cmd/wallet/address.go
+++ b/cmd/wallet/address.go
@@ -101,8 +101,9 @@ func buildAddressNewCmd(parentCmd *cobra.Command) {
 		terminal.FatalErrorCheck(err)
 
 		password := ""
-		if typ == crypto.AddressTypeEd25519Account && wlt.IsEncrypted() {
-			password = prompt.PromptPassword("Password", false)
+		if typ == crypto.AddressTypeEd25519Account ||
+			typ == crypto.AddressTypeSecp256k1Account {
+			password = getPassword(wlt, "")
 		}
 
 		addressInfo, err = wlt.NewAddress(typ, *label, wallet.WithPassword(password))

--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -47,27 +47,21 @@ func WithAddressTypes(addressTypes []crypto.AddressType) ListAddressOption {
 
 // WithAddressType filters addresses by the specified type.
 func WithAddressType(addressType crypto.AddressType) ListAddressOption {
-	return func(cfg *listAddressConfig) {
-		cfg.addressTypes = []crypto.AddressType{addressType}
-	}
+	return WithAddressTypes([]crypto.AddressType{addressType})
 }
 
 // OnlyValidatorAddresses filters to show only validator addresses.
 func OnlyValidatorAddresses() ListAddressOption {
-	return func(cfg *listAddressConfig) {
-		cfg.addressTypes = []crypto.AddressType{crypto.AddressTypeValidator}
-	}
+	return WithAddressType(crypto.AddressTypeValidator)
 }
 
 // OnlyAccountAddresses filters to show only account addresses (BLS and Ed25519).
 func OnlyAccountAddresses() ListAddressOption {
-	return func(cfg *listAddressConfig) {
-		cfg.addressTypes = []crypto.AddressType{
-			crypto.AddressTypeBLSAccount,
-			crypto.AddressTypeEd25519Account,
-			crypto.AddressTypeSecp256k1Account,
-		}
-	}
+	return WithAddressTypes([]crypto.AddressType{
+		crypto.AddressTypeBLSAccount,
+		crypto.AddressTypeEd25519Account,
+		crypto.AddressTypeSecp256k1Account,
+	})
 }
 
 func (a *addresses) ListAddresses(opts ...ListAddressOption) []types.AddressInfo {
@@ -252,7 +246,7 @@ func (a *addresses) NewAddress(addressType crypto.AddressType, label string, opt
 	case crypto.AddressTypeEd25519Account:
 		info, err = vault.NewEd25519AccountAddress(label, cfg.password)
 	case crypto.AddressTypeSecp256k1Account:
-		info, err = vault.NewSecp256k1AccountAddress(label)
+		info, err = vault.NewSecp256k1AccountAddress(label, cfg.password)
 
 	default:
 		return nil, ErrInvalidAddressType

--- a/wallet/addresses_test.go
+++ b/wallet/addresses_test.go
@@ -166,7 +166,7 @@ func TestNewSecp256k1AccountAddress(t *testing.T) {
 	assert.NotEmpty(t, addressInfo.Address)
 	assert.NotEmpty(t, addressInfo.PublicKey)
 	assert.Equal(t, label, addressInfo.Label)
-	assert.Equal(t, "m/44'/21888'/4'/0", addressInfo.Path)
+	assert.Equal(t, "m/44'/21888'/4'/0'", addressInfo.Path)
 
 	pub, _ := secp256k1.PublicKeyFromString(addressInfo.PublicKey)
 	assert.Equal(t, pub.AccountAddress().String(), addressInfo.Address)

--- a/wallet/vault/vault.go
+++ b/wallet/vault/vault.go
@@ -501,26 +501,36 @@ func (v *Vault) deriveEd25519AccountAddressAt(masterKey *ed25519hdkeychain.Exten
 	return &info, nil
 }
 
-func (v *Vault) NewSecp256k1AccountAddress(label string) (*types.AddressInfo, error) {
-	ext, err := secp256k1hdkeychain.NewKeyFromString(v.Purposes.PurposeBIP44.XPubSecp256K1)
-	if err != nil {
-		return nil, err
-	}
-	index := v.Purposes.PurposeBIP44.NextSexp256k1Index
-	info, err := v.deriveSecp256k1AccountAddressAt(ext, index, label)
+func (v *Vault) NewSecp256k1AccountAddress(label, password string) (*types.AddressInfo, error) {
+	seed, err := v.MnemonicSeed(password)
 	if err != nil {
 		return nil, err
 	}
 
+	masterKey, err := secp256k1hdkeychain.NewMaster(seed)
+	if err != nil {
+		return nil, err
+	}
+
+	index := v.Purposes.PurposeBIP44.NextSexp256k1Index
+	info, err := v.deriveSecp256k1AccountAddressAt(masterKey, index, label)
+	if err != nil {
+		return nil, err
+	}
 	v.Purposes.PurposeBIP44.NextSexp256k1Index++
 
 	return info, nil
 }
 
-func (*Vault) deriveSecp256k1AccountAddressAt(ext *secp256k1hdkeychain.ExtendedKey,
+func (v *Vault) deriveSecp256k1AccountAddressAt(masterKey *secp256k1hdkeychain.ExtendedKey,
 	index uint32, label string,
 ) (*types.AddressInfo, error) {
-	ext, err := ext.DerivePath([]uint32{index})
+	ext, err := masterKey.DerivePath([]uint32{
+		addresspath.Harden(addresspath.PurposeBIP44),
+		addresspath.Harden(v.CoinType),
+		addresspath.Harden(crypto.AddressTypeSecp256k1Account),
+		addresspath.Harden(index),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/vault/vault_test.go
+++ b/wallet/vault/vault_test.go
@@ -44,7 +44,7 @@ func setup(t *testing.T) *testData {
 	require.NoError(t, err)
 	addr2, err := vault.NewEd25519AccountAddress("ed25519-account-address", "")
 	require.NoError(t, err)
-	addr4, err := vault.NewSecp256k1AccountAddress("secp256k1-account-address")
+	addr4, err := vault.NewSecp256k1AccountAddress("secp256k1-account-address", "")
 	require.NoError(t, err)
 
 	_, importedBLSPrv := ts.RandBLSKeyPair()
@@ -106,7 +106,7 @@ func TestCreateVaultFromMnemonic(t *testing.T) {
 		require.NoError(t, err)
 		_, err = recovered.NewEd25519AccountAddress("ed25519-account-address", "")
 		require.NoError(t, err)
-		_, err = recovered.NewSecp256k1AccountAddress("secp256k1-account-address")
+		_, err = recovered.NewSecp256k1AccountAddress("secp256k1-account-address", "")
 		require.NoError(t, err)
 
 		assert.Equal(t, recovered.Purposes, td.vault.Purposes)


### PR DESCRIPTION
## Description

This PR uses a hardened path for the Secp256k1 derivation path.
