### PR TITLE
fix(types): reject transactions exceeding max allowed amount

### DIFF
--- a/types/tx/payload/batch_transfer.go
+++ b/types/tx/payload/batch_transfer.go
@@ -29,6 +29,12 @@ func (tr *BatchRecipient) BasicCheck() error {
 		}
 	}
 
+	if tr.Amount > amount.MaxNanoPAC {
+		return BasicCheckError{
+			Reason: fmt.Sprintf("amount must be must not exceed maximum allowed value: %d", tr.Amount),
+		}
+	}
+
 	return nil
 }
 

--- a/types/tx/payload/batch_transfer_test.go
+++ b/types/tx/payload/batch_transfer_test.go
@@ -202,6 +202,16 @@ func TestBatchTransferBasicCheck(t *testing.T) {
 			pld: payload.BatchTransferPayload{
 				From: ts.RandAccAddress(),
 				Recipients: []payload.BatchRecipient{
+					{To: ts.RandAccAddress(), Amount: ts.RandAmount()},
+					{To: ts.RandAccAddress(), Amount: amount.Amount(util.MaxInt64)},
+				},
+			},
+			err: "amount must be must not exceed maximum allowed value: 9223372036854775807",
+		},
+		{
+			pld: payload.BatchTransferPayload{
+				From: ts.RandAccAddress(),
+				Recipients: []payload.BatchRecipient{
 					{To: ts.RandValAddress(), Amount: ts.RandAmount()},
 					{To: ts.RandAccAddress(), Amount: ts.RandAmount()},
 				},


### PR DESCRIPTION
## Description

Check the maximum value for the batch transactions.