### PR TITLE
fix(sync): remove extra checks from signed block

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -526,17 +526,6 @@ func (sync *synchronizer) tryCommitBlocks() {
 			}
 		}
 
-		if err := blk.BasicCheck(); err != nil {
-			onError(height, err)
-
-			return
-		}
-		if err := cert.BasicCheck(); err != nil {
-			onError(height, err)
-
-			return
-		}
-
 		sync.logger.Trace("committing block", "height", height, "block", blk)
 		if err := sync.state.CommitBlock(blk, cert); err != nil {
 			onError(height, err)


### PR DESCRIPTION
## Description

Once a block has a valid signature from a majority of validators, it should be considered a valid block, and we can skip some extra checks during syncing.
