### PR TITLE
fix(types): set maximum allowed value to 1e6 for batch transafer

### DIFF
--- a/types/tx/payload/batch_transfer.go
+++ b/types/tx/payload/batch_transfer.go
@@ -29,7 +29,7 @@ func (tr *BatchRecipient) BasicCheck() error {
 		}
 	}
 
-	if tr.Amount > amount.MaxNanoPAC {
+	if tr.Amount > 1e6*amount.NanoPACPerPAC {
 		return BasicCheckError{
 			Reason: fmt.Sprintf("amount must be must not exceed maximum allowed value: %d", tr.Amount),
 		}

--- a/types/tx/payload/batch_transfer_test.go
+++ b/types/tx/payload/batch_transfer_test.go
@@ -204,10 +204,10 @@ func TestBatchTransferBasicCheck(t *testing.T) {
 				From: ts.RandAccAddress(),
 				Recipients: []payload.BatchRecipient{
 					{To: ts.RandAccAddress(), Amount: ts.RandAmount()},
-					{To: ts.RandAccAddress(), Amount: amount.Amount(util.MaxInt64)},
+					{To: ts.RandAccAddress(), Amount: amount.Amount(1e6*amount.NanoPACPerPAC) + 1},
 				},
 			},
-			err: "amount must be must not exceed maximum allowed value: 9223372036854775807",
+			err: "amount must be must not exceed maximum allowed value: 1000000000000001",
 		},
 		{
 			pld: payload.BatchTransferPayload{


### PR DESCRIPTION
## Description

This PR sets the maximum batch transfer amount to one million PAC.