### PR TITLE
fix(state): revert to genesis committee for block 7406821

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -439,6 +439,13 @@ func (st *state) CommitBlock(blk *block.Block, cert *certificate.Certificate) er
 		return nil
 	}
 
+	if height == 7406821 {
+		st.committee, _ = committee.NewCommittee(
+			st.genDoc.Validators(),
+			st.genDoc.Params().CommitteeSize,
+			st.genDoc.Validators()[0].Address())
+	}
+
 	err := st.validateCurCertificate(cert, blk.Hash())
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Use Genesis committee to produce blocks for block height `7406821`.
