### PR TITLE
fix(sync): set limit for decompress buffer

### DIFF
--- a/util/slice.go
+++ b/util/slice.go
@@ -5,9 +5,24 @@ import (
 	"compress/gzip"
 	"crypto/subtle"
 	"encoding/binary"
+	"errors"
+	"io"
 	"math/rand"
 	"slices"
 )
+
+// MaxDecompressedSize bounds how many bytes DecompressBuffer will produce.
+//
+// This guards against decompression-bomb DoS attacks (CWE-409): a tiny,
+// highly compressible gzip stream can expand by ~1000x, so without a cap an
+// attacker-controlled compressed payload received over the P2P layer can be
+// inflated into a multi-gigabyte single allocation and crash the node with a
+// fatal out-of-memory error.
+const MaxDecompressedSize = 8 << 20 // 8 MB
+
+// ErrDecompressedSizeExceedsLimit is returned by DecompressBuffer when the
+// decompressed output would exceed MaxDecompressedSize.
+var ErrDecompressedSizeExceedsLimit = errors.New("decompressed size exceeds limit")
 
 func Uint16ToBytesLE(n uint16) []byte {
 	bs := make([]byte, 2)
@@ -93,9 +108,20 @@ func DecompressBuffer(s []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	// Bound the decompressed output to prevent decompression-bomb DoS attacks
+	// (CWE-409). Read up to MaxDecompressedSize+1 bytes: if the limited reader
+	// yields more than MaxDecompressedSize, the stream is over the cap and we
+	// reject it instead of silently truncating. The LimitReader stops reading
+	// at the cap, so no unbounded allocation occurs.
+	limited := io.LimitReader(reader, MaxDecompressedSize+1)
+
 	var res bytes.Buffer
-	if _, err = res.ReadFrom(reader); err != nil {
+	if _, err = res.ReadFrom(limited); err != nil {
 		return nil, err
+	}
+
+	if res.Len() > MaxDecompressedSize {
+		return nil, ErrDecompressedSizeExceedsLimit
 	}
 
 	return res.Bytes(), nil

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -111,6 +111,23 @@ func TestDecompress(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDecompressionBomb(t *testing.T) {
+	// Build a small synthetic gzip stream whose decompressed length is just
+	// one byte over the cap. The slice of zeros compresses to a few KB, so
+	// the test never allocates anywhere near MaxDecompressedSize of output:
+	// DecompressBuffer must stop at the cap and return an error rather than
+	// inflating the full bomb.
+	oversized := make([]byte, MaxDecompressedSize+1)
+	c, err := CompressBuffer(oversized)
+	require.NoError(t, err)
+	require.Less(t, len(c), MaxDecompressedSize,
+		"compressed bomb must stay small so the test itself uses little memory")
+
+	out, err := DecompressBuffer(c)
+	require.ErrorIs(t, err, ErrDecompressedSizeExceedsLimit)
+	assert.Nil(t, out)
+}
+
 func TestSubtractAndSubset(t *testing.T) {
 	t.Run("Case 1", func(t *testing.T) {
 		s1 := []int32{1, 2, 3, 4}


### PR DESCRIPTION
## Description

Set limit for decompress buffer and prevent decompress bomb attack.