### PR TITLE
fix(execution): check validator expiry for unbond

### DIFF
--- a/execution/executor/errors.go
+++ b/execution/executor/errors.go
@@ -60,6 +60,10 @@ var ErrInvalidDelegation = errors.New("invalid delegation")
 // ErrDelegateExpiryInPast is returned when the delegate expiry is in the past.
 var ErrDelegateExpiryInPast = errors.New("delegate expiry must be in the future")
 
+// ErrDelegationNotExpired indicates that a validator's current
+// delegation is still active and has not yet reached its expiration height.
+var ErrDelegationNotExpired = errors.New("delegation has not expired")
+
 // ErrWithdrawMustGoToStakeOwner is returned when the withdrawal is not going to the stake owner.
 var ErrWithdrawMustGoToStakeOwner = errors.New("delegated validator withdraw must go to stake owner")
 

--- a/execution/executor/unbond.go
+++ b/execution/executor/unbond.go
@@ -38,6 +38,10 @@ func (e *UnbondExecutor) Check(strict bool) error {
 		if e.pld.DelegateOwner != e.validator.DelegateOwner() {
 			return ErrInvalidDelegateOwner
 		}
+
+		if !e.validator.DelegateExpired(e.sbx.CurrentHeight()) {
+			return ErrDelegationNotExpired
+		}
 	} else {
 		// A non-delegated validator can only be unbonded by its own key.
 		// The payload must not be delegated, forcing Signer() == Validator.

--- a/execution/executor/unbond.go
+++ b/execution/executor/unbond.go
@@ -42,12 +42,11 @@ func (e *UnbondExecutor) Check(strict bool) error {
 		if !e.validator.DelegateExpired(e.sbx.CurrentHeight()) {
 			return ErrDelegationNotExpired
 		}
-	} else {
+	} else if e.pld.IsDelegated() {
 		// A non-delegated validator can only be unbonded by its own key.
 		// The payload must not be delegated, forcing Signer() == Validator.
-		if e.pld.IsDelegated() {
-			return ErrInvalidDelegateOwner
-		}
+
+		return ErrInvalidDelegateOwner
 	}
 
 	if strict {

--- a/execution/executor/unbond_test.go
+++ b/execution/executor/unbond_test.go
@@ -105,12 +105,12 @@ func TestExecuteDelegatedUnbondTx(t *testing.T) {
 	val := td.sbx.MakeNewValidator(valPub)
 	val.AddToStake(td.sbx.TestParams.MaximumStake)
 	owner := td.RandAccAddress()
-	val.SetDelegation(owner, amount.Amount(0.2e9), td.sbx.CurrentHeight()+10)
+	expiry := td.sbx.CurrentHeight() + td.RandHeight()
+	val.SetDelegation(owner, amount.Amount(0.2e9), expiry)
 	td.sbx.UpdateValidator(val)
-	lockTime := td.sbx.CurrentHeight()
 
 	t.Run("Should fail, invalid delegate owner", func(t *testing.T) {
-		trx := tx.NewUnbondTx(lockTime, valAddr)
+		trx := tx.NewUnbondTx(td.RandHeight(), valAddr)
 		pld := trx.Payload().(*payload.UnbondPayload)
 		pld.DelegateOwner = td.RandAccAddress()
 
@@ -118,8 +118,19 @@ func TestExecuteDelegatedUnbondTx(t *testing.T) {
 		td.check(t, trx, false, ErrInvalidDelegateOwner)
 	})
 
+	t.Run("Should fail, delegation is not expired", func(t *testing.T) {
+		td.sbx.TestStore.AddTestBlock(expiry - 2)
+		trx := tx.NewUnbondTx(td.RandHeight(), valAddr)
+		pld := trx.Payload().(*payload.UnbondPayload)
+		pld.DelegateOwner = owner
+
+		td.check(t, trx, true, ErrDelegationNotExpired)
+		td.check(t, trx, false, ErrDelegationNotExpired)
+	})
+
 	t.Run("Ok", func(t *testing.T) {
-		trx := tx.NewUnbondTx(lockTime, valAddr)
+		td.sbx.TestStore.AddTestBlock(expiry - 1)
+		trx := tx.NewUnbondTx(td.RandHeight(), valAddr)
 		pld := trx.Payload().(*payload.UnbondPayload)
 		pld.DelegateOwner = owner
 
@@ -129,7 +140,7 @@ func TestExecuteDelegatedUnbondTx(t *testing.T) {
 	})
 
 	updatedVal := td.sbx.Validator(valAddr)
-	assert.Equal(t, lockTime, updatedVal.UnbondingHeight())
+	assert.Equal(t, td.sbx.CurrentHeight(), updatedVal.UnbondingHeight())
 }
 
 // TestUnbondNonDelegatedWithDelegateOwner is a regression test for an


### PR DESCRIPTION
## Description

This PR enforces the expiry time for the delegated validators at unbond time.
