### PR TITLE
fix(gtk): skip file lock when connecting to remote node

### DIFF
--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -164,35 +164,35 @@ func main() {
 			}
 
 			go func() {
-				// Define the lock file path
-				lockFilePath := filepath.Join(workingDir, ".pactus.lock")
-				fileLock = flock.New(lockFilePath)
-
-				locked, err := fileLock.TryLock()
-				if err != nil {
-					gtkutil.ShowErrorDialog(splash.Window(),
-						fmt.Sprintf("Aborted! Unable to acquire file lock. %v", err),
-						func(_ gtk.ResponseType) {
-							splash.Destroy()
-						})
-
-					return
-				}
-
-				if !locked {
-					gtkutil.ShowErrorDialog(splash.Window(),
-						fmt.Sprintf("Could not lock '%s', another instance is running?", lockFilePath),
-						func(_ gtk.ResponseType) {
-							splash.Destroy()
-						})
-
-					return
-				}
-
 				var grpcAddr string
 				var grpcInsecure bool
 
 				if *grpcAddrOpt == "" {
+					// Define the lock file path
+					lockFilePath := filepath.Join(workingDir, ".pactus.lock")
+					fileLock = flock.New(lockFilePath)
+
+					locked, err := fileLock.TryLock()
+					if err != nil {
+						gtkutil.ShowErrorDialog(splash.Window(),
+							fmt.Sprintf("Aborted! Unable to acquire file lock. %v", err),
+							func(_ gtk.ResponseType) {
+								splash.Destroy()
+							})
+
+						return
+					}
+
+					if !locked {
+						gtkutil.ShowErrorDialog(splash.Window(),
+							fmt.Sprintf("Could not lock '%s', another instance is running?", lockFilePath),
+							func(_ gtk.ResponseType) {
+								splash.Destroy()
+							})
+
+						return
+					}
+
 					reportStatus(notify, "Starting local node...")
 					time.Sleep(1 * time.Second)
 


### PR DESCRIPTION
## Description

The GTK GUI attempts to acquire a file lock (`.pactus.lock`) unconditionally during startup. When the `--grpc-addr` flag is provided (connecting to a remote node), acquiring the lock file is unnecessary and blocks the connection if another local instance is already running.

This PR moves the lock file acquisition inside the `if *grpcAddrOpt == ""` block so it only runs when starting a local node.

## Related Issue

Fixes #2299