### PR TITLE
fix(consensus): prevent double proposal on re-entry to propose state

### DIFF
--- a/consensus/propose.go
+++ b/consensus/propose.go
@@ -18,7 +18,9 @@ func (s *proposeState) decide() {
 	proposer := s.proposer(s.round)
 	if proposer.Address() == s.valKey.Address() {
 		s.logger.Info("our turn to propose", "proposer", proposer.Address())
-		s.createProposal(s.height, s.round)
+		if !s.log.HasRoundProposal(s.round) {
+			s.createProposal(s.height, s.round)
+		}
 	} else {
 		s.logger.Debug("not our turn to propose", "proposer", proposer.Address())
 	}

--- a/consensus/propose_test.go
+++ b/consensus/propose_test.go
@@ -3,6 +3,7 @@ package consensus
 import (
 	"testing"
 
+	"github.com/pactus-project/pactus/sync/bundle/message"
 	"github.com/pactus-project/pactus/types"
 	"github.com/pactus-project/pactus/types/proposal"
 	"github.com/pactus-project/pactus/types/vote"
@@ -17,6 +18,21 @@ func TestProposeBlock(t *testing.T) {
 	td.enterNewHeight(td.consX)
 	p := td.shouldPublishProposal(t, td.consX, 1, 0)
 	assert.Equal(t, td.consX.valKey.Address(), p.Block().Header().ProposerAddress())
+}
+
+func TestProposeDoubleEntry(t *testing.T) {
+	td := setup(t)
+
+	td.consX.MoveToNewHeight()
+	td.newHeightTimeout(td.consX)
+	td.shouldPublishProposal(t, td.consX, 1, 0)
+
+	// Clear accumulated messages to test the double entry independently
+	td.consMessages = nil
+
+	// Double entry to propose state should not publish another proposal
+	td.consX.enterNewState(td.consX.proposeState)
+	td.shouldNotPublish(t, td.consX, message.TypeProposal)
 }
 
 func TestSetProposalInvalidProposer(t *testing.T) {

--- a/consensusv2/propose.go
+++ b/consensusv2/propose.go
@@ -35,7 +35,9 @@ func (s *proposeState) decide() {
 
 	if proposer.Address() == s.valKey.Address() {
 		s.logger.Info("our turn to propose", "proposer", proposer.Address())
-		s.createProposal(s.height, s.round)
+		if !s.log.HasRoundProposal(s.round) {
+			s.createProposal(s.height, s.round)
+		}
 	} else {
 		s.logger.Debug("not our turn to propose", "proposer", proposer.Address())
 	}

--- a/consensusv2/propose_test.go
+++ b/consensusv2/propose_test.go
@@ -3,6 +3,7 @@ package consensusv2
 import (
 	"testing"
 
+	"github.com/pactus-project/pactus/sync/bundle/message"
 	"github.com/pactus-project/pactus/types"
 	"github.com/pactus-project/pactus/types/proposal"
 	"github.com/pactus-project/pactus/types/vote"
@@ -17,6 +18,21 @@ func TestProposePublishProposal(t *testing.T) {
 	td.enterNewHeight(td.consX)
 	p := td.shouldPublishProposal(t, td.consX, 1, 0)
 	assert.Equal(t, td.consX.valKey.Address(), p.Block().Header().ProposerAddress())
+}
+
+func TestProposeDoubleEntry(t *testing.T) {
+	td := setup(t)
+
+	td.consX.MoveToNewHeight()
+	td.newHeightTimeout(td.consX)
+	td.shouldPublishProposal(t, td.consX, 1, 0)
+
+	// Clear accumulated messages to test the double entry independently
+	td.network = nil
+
+	// Double entry to propose state should not publish another proposal
+	td.consX.enterNewState(td.consX.proposeState)
+	td.shouldNotPublish(t, td.consX, message.TypeProposal)
 }
 
 func TestProposeInvalidProposer(t *testing.T) {


### PR DESCRIPTION
## Description

Guard `createProposal` with `HasRoundProposal` check in both v1 and v2 consensus engines. This prevents creating a duplicate proposal when the propose state is re-entered for a round where a proposal already exists.

## Related Issue

Fixes #2301