### PR TITLE
fix(sync): remove gzip compression from blocks response

### DIFF
--- a/sync/bundle/bundle.go
+++ b/sync/bundle/bundle.go
@@ -59,10 +59,6 @@ func (b *Bundle) LogString() string {
 	return fmt.Sprintf("%s%s", b.Message.Type(), b.Message.LogString())
 }
 
-func (b *Bundle) CompressIt() {
-	b.Flags = util.SetFlag(b.Flags, BundleFlagCompressed)
-}
-
 type _Bundle struct {
 	Flags           int          `cbor:"1,keyasint"`
 	MessageType     message.Type `cbor:"2,keyasint"`
@@ -74,14 +70,6 @@ func (b *Bundle) Encode() ([]byte, error) {
 	data, err := cbor.Marshal(b.Message)
 	if err != nil {
 		return nil, err
-	}
-
-	if util.IsFlagSet(b.Flags, BundleFlagCompressed) {
-		c, err := util.CompressBuffer(data)
-		if err != nil {
-			return nil, err
-		}
-		data = c
 	}
 
 	msg := &_Bundle{

--- a/sync/bundle/bundle_test.go
+++ b/sync/bundle/bundle_test.go
@@ -3,7 +3,6 @@ package bundle
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"testing"
 
 	"github.com/pactus-project/pactus/sync/bundle/message"
@@ -27,7 +26,7 @@ func TestInvalidCBOR(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMessageCompress(t *testing.T) {
+func TestEncodeDecodeBlocksResponse(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 
 	blocksData := [][]byte{}
@@ -38,32 +37,17 @@ func TestMessageCompress(t *testing.T) {
 	}
 	msg := message.NewBlocksResponseMessage(message.ResponseCodeOK, message.ResponseCodeOK.String(),
 		ts.RandInt(), ts.RandHeight(), blocksData, nil)
-	bdl1 := NewBundle(msg)
-	require.NoError(t, bdl1.BasicCheck())
-	bs0, err := bdl1.Encode()
+	bdl := NewBundle(msg)
+	require.NoError(t, bdl.BasicCheck())
+	encData, err := bdl.Encode()
 	require.NoError(t, err)
-	assert.False(t, util.IsFlagSet(bdl1.Flags, BundleFlagCompressed))
-
-	bdl1.CompressIt()
-	bs1, err := bdl1.Encode()
-	require.NoError(t, err)
-	assert.True(t, util.IsFlagSet(bdl1.Flags, BundleFlagCompressed))
-
-	t.Logf("Compressed :%v%%\n", 100-len(bs1)*100/len(bs0))
-	t.Logf("Uncompressed len :%v\n", len(bs0))
-	t.Logf("Compressed len :%v\n", len(bs1))
+	assert.False(t, util.IsFlagSet(bdl.Flags, BundleFlagCompressed))
 
 	bdl2 := new(Bundle)
-	bytesRead1, err := bdl2.Decode(bytes.NewReader(bs0))
+	bytesRead, err := bdl2.Decode(bytes.NewReader(encData))
 	require.NoError(t, err)
-	assert.Equal(t, len(bs0), bytesRead1)
+	assert.Equal(t, len(encData), bytesRead)
 	require.NoError(t, bdl2.BasicCheck())
-
-	bdl3 := new(Bundle)
-	bytesRead2, err := bdl3.Decode(bytes.NewReader(bs1))
-	require.NoError(t, err)
-	assert.Equal(t, len(bs1), bytesRead2)
-	require.NoError(t, bdl3.BasicCheck())
 }
 
 func TestDecodeVoteMessage(t *testing.T) {
@@ -72,14 +56,9 @@ func TestDecodeVoteMessage(t *testing.T) {
 	v, _ := ts.GenerateTestPrecommitVote(88, 0)
 	msg := message.NewVoteMessage(v)
 	bdl := NewBundle(msg)
-	bs0, err := bdl.Encode()
+	bs, err := bdl.Encode()
 	require.NoError(t, err)
-	bdl.CompressIt()
-	bs1, err := bdl.Encode()
-	require.NoError(t, err)
-	fmt.Printf("Compressed :%v%%\n", 100-len(bs1)*100/len(bs0))
-	fmt.Printf("Uncompressed len :%v\n", len(bs0))
-	fmt.Printf("Compressed len :%v\n", len(bs1))
+	t.Logf("Encoded vote message len: %v", len(bs))
 }
 
 func TestDecodeVoteCBOR(t *testing.T) {

--- a/sync/handler_blocks_response.go
+++ b/sync/handler_blocks_response.go
@@ -49,10 +49,7 @@ func (handler *blocksResponseHandler) ParseMessage(m message.Message, pid peer.I
 }
 
 func (*blocksResponseHandler) PrepareBundle(m message.Message) *bundle.Bundle {
-	bdl := bundle.NewBundle(m)
-	bdl.CompressIt()
-
-	return bdl
+	return bundle.NewBundle(m)
 }
 
 func (handler *blocksResponseHandler) updateSession(sid int, code message.ResponseCode) {


### PR DESCRIPTION
## Description

Removes gzip compression from `BlocksResponseMessage` bundles. Investigation showed only ~3% size reduction (80,752 → 78,228 bytes for 60 blocks). Block data is already compact CBOR-encoded binary — cryptographic fields like hashes and signatures are incompressible. The CPU cost of gzip compress/decompress outweighs the negligible bandwidth savings.

This also mitigates compression bomb concerns.

The decompression path in `Decode()` is preserved for backward compatibility with older peers that still send compressed bundles.

## Related Issue

Fixes #2305