### PR TITLE
feat(util): add Options pattern to DecompressBuffer

### DIFF
--- a/util/slice.go
+++ b/util/slice.go
@@ -11,34 +11,6 @@ import (
 	"slices"
 )
 
-// DefaultMaxDecompressedSize bounds how many bytes DecompressBuffer will
-// produce by default.
-//
-// This guards against decompression-bomb DoS attacks (CWE-409): a tiny,
-// highly compressible gzip stream can expand by ~1000x, so without a cap an
-// attacker-controlled compressed payload received over the P2P layer can be
-// inflated into a multi-gigabyte single allocation and crash the node with a
-// fatal out-of-memory error.
-const DefaultMaxDecompressedSize = 8 << 20 // 8 MB
-
-// ErrDecompressedSizeExceedsLimit is returned by DecompressBuffer when the
-// decompressed output exceeds the configured (or default) size limit.
-var ErrDecompressedSizeExceedsLimit = errors.New("decompressed size exceeds limit")
-
-// DecompressOption configures DecompressBuffer behavior.
-type DecompressOption func(*decompressConfig)
-
-type decompressConfig struct {
-	maxSize int
-}
-
-// WithMaxDecompressedSize sets the decompressed output size limit (bytes).
-func WithMaxDecompressedSize(size int) DecompressOption {
-	return func(c *decompressConfig) {
-		c.maxSize = size
-	}
-}
-
 func Uint16ToBytesLE(n uint16) []byte {
 	bs := make([]byte, 2)
 	binary.LittleEndian.PutUint16(bs, n)
@@ -114,6 +86,34 @@ func CompressBuffer(data []byte) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// DefaultMaxDecompressedSize bounds how many bytes DecompressBuffer will
+// produce by default.
+//
+// This guards against decompression-bomb DoS attacks (CWE-409): a tiny,
+// highly compressible gzip stream can expand by ~1000x, so without a cap an
+// attacker-controlled compressed payload received over the P2P layer can be
+// inflated into a multi-gigabyte single allocation and crash the node with a
+// fatal out-of-memory error.
+const DefaultMaxDecompressedSize = 8 << 20 // 8 MB
+
+// ErrDecompressedSizeExceedsLimit is returned by DecompressBuffer when the
+// decompressed output exceeds the configured (or default) size limit.
+var ErrDecompressedSizeExceedsLimit = errors.New("decompressed size exceeds limit")
+
+// DecompressOption configures DecompressBuffer behavior.
+type DecompressOption func(*decompressConfig)
+
+type decompressConfig struct {
+	maxSize int
+}
+
+// WithMaxDecompressedSize sets the decompressed output size limit (bytes).
+func WithMaxDecompressedSize(size int) DecompressOption {
+	return func(c *decompressConfig) {
+		c.maxSize = size
+	}
 }
 
 func DecompressBuffer(compressed []byte, opts ...DecompressOption) ([]byte, error) {

--- a/util/slice.go
+++ b/util/slice.go
@@ -11,18 +11,33 @@ import (
 	"slices"
 )
 
-// MaxDecompressedSize bounds how many bytes DecompressBuffer will produce.
+// DefaultMaxDecompressedSize bounds how many bytes DecompressBuffer will
+// produce by default.
 //
 // This guards against decompression-bomb DoS attacks (CWE-409): a tiny,
 // highly compressible gzip stream can expand by ~1000x, so without a cap an
 // attacker-controlled compressed payload received over the P2P layer can be
 // inflated into a multi-gigabyte single allocation and crash the node with a
 // fatal out-of-memory error.
-const MaxDecompressedSize = 8 << 20 // 8 MB
+const DefaultMaxDecompressedSize = 8 << 20 // 8 MB
 
 // ErrDecompressedSizeExceedsLimit is returned by DecompressBuffer when the
-// decompressed output would exceed MaxDecompressedSize.
+// decompressed output exceeds the configured (or default) size limit.
 var ErrDecompressedSizeExceedsLimit = errors.New("decompressed size exceeds limit")
+
+// DecompressOption configures DecompressBuffer behavior.
+type DecompressOption func(*decompressConfig)
+
+type decompressConfig struct {
+	maxSize int
+}
+
+// WithMaxDecompressedSize sets the decompressed output size limit (bytes).
+func WithMaxDecompressedSize(size int) DecompressOption {
+	return func(c *decompressConfig) {
+		c.maxSize = size
+	}
+}
 
 func Uint16ToBytesLE(n uint16) []byte {
 	bs := make([]byte, 2)
@@ -101,26 +116,33 @@ func CompressBuffer(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func DecompressBuffer(s []byte) ([]byte, error) {
-	buf := bytes.NewBuffer(s)
+func DecompressBuffer(compressed []byte, opts ...DecompressOption) ([]byte, error) {
+	cfg := &decompressConfig{
+		maxSize: DefaultMaxDecompressedSize,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	buf := bytes.NewBuffer(compressed)
 	reader, err := gzip.NewReader(buf)
 	if err != nil {
 		return nil, err
 	}
 
 	// Bound the decompressed output to prevent decompression-bomb DoS attacks
-	// (CWE-409). Read up to MaxDecompressedSize+1 bytes: if the limited reader
-	// yields more than MaxDecompressedSize, the stream is over the cap and we
-	// reject it instead of silently truncating. The LimitReader stops reading
-	// at the cap, so no unbounded allocation occurs.
-	limited := io.LimitReader(reader, MaxDecompressedSize+1)
+	// (CWE-409). Read up to maxSize+1 bytes: if the limited reader yields
+	// more than maxSize, the stream is over the cap and we reject it instead
+	// of silently truncating. The LimitReader stops reading at the cap, so no
+	// unbounded allocation occurs.
+	limited := io.LimitReader(reader, int64(cfg.maxSize+1))
 
 	var res bytes.Buffer
 	if _, err = res.ReadFrom(limited); err != nil {
 		return nil, err
 	}
 
-	if res.Len() > MaxDecompressedSize {
+	if res.Len() > cfg.maxSize {
 		return nil, ErrDecompressedSizeExceedsLimit
 	}
 

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -112,18 +112,13 @@ func TestDecompress(t *testing.T) {
 }
 
 func TestDecompressionBomb(t *testing.T) {
-	// Build a small synthetic gzip stream whose decompressed length is just
-	// one byte over the cap. The slice of zeros compresses to a few KB, so
-	// the test never allocates anywhere near MaxDecompressedSize of output:
-	// DecompressBuffer must stop at the cap and return an error rather than
-	// inflating the full bomb.
-	oversized := make([]byte, MaxDecompressedSize+1)
+	// DecompressBuffer must stop at the configured cap and return an error
+	// rather than inflating the full output.
+	oversized := make([]byte, 200)
 	c, err := CompressBuffer(oversized)
 	require.NoError(t, err)
-	require.Less(t, len(c), MaxDecompressedSize,
-		"compressed bomb must stay small so the test itself uses little memory")
 
-	out, err := DecompressBuffer(c)
+	out, err := DecompressBuffer(c, WithMaxDecompressedSize(100))
 	require.ErrorIs(t, err, ErrDecompressedSizeExceedsLimit)
 	assert.Nil(t, out)
 }

--- a/util/slice_test.go
+++ b/util/slice_test.go
@@ -114,7 +114,7 @@ func TestDecompress(t *testing.T) {
 func TestDecompressionBomb(t *testing.T) {
 	// DecompressBuffer must stop at the configured cap and return an error
 	// rather than inflating the full output.
-	oversized := make([]byte, 200)
+	oversized := make([]byte, 101)
 	c, err := CompressBuffer(oversized)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Description

Adds the Go functional-options pattern to `DecompressBuffer` so callers can configure the decompressed size limit at the call site instead of relying on a single global constant.

Changes:
- Add `DecompressOption` type, `decompressConfig` struct, and `WithMaxDecompressedSize` constructor
- Rename `MaxDecompressedSize` to `DefaultMaxDecompressedSize` (still 8 MB)
- `DecompressBuffer` now accepts variadic `...DecompressOption`
- Existing callers work unchanged — no options means the default 8 MB cap applies

## Motivation

The `BlocksResponseMessage` investigation in #2309 showed compression provides negligible benefit for block data. `CompressBuffer` and `DecompressBuffer` remain in `util/slice.go` as general-purpose utilities. Making the decompress limit configurable adds flexibility for callers that may need a different cap.