### PR TITLE
test(util): handle max <= min in RandAmountRange

### DIFF
--- a/util/testsuite/testsuite.go
+++ b/util/testsuite/testsuite.go
@@ -161,6 +161,11 @@ func (ts *TestSuite) RandAmount(max ...amount.Amount) amount.Amount {
 
 // RandAmountRange returns a random amount between [min, max).
 func (ts *TestSuite) RandAmountRange(min, max amount.Amount) amount.Amount {
+	if max <= min {
+		// If max <= min, it returns min to avoid invalid range.
+		return min
+	}
+
 	return amount.Amount(ts.RandInt64(testsuite.WithMin(min.ToNanoPAC()), testsuite.WithMax(max.ToNanoPAC())))
 }
 


### PR DESCRIPTION
## Description

When callers pass `max <= min` to `RandAmountRange`, the underlying `RandInt64` receives an invalid range (`WithMin` > `WithMax`), causing a panic or undefined behavior.

## Fix

Add a guard that returns `min` directly when `max <= min` — the range `[min, max)` is empty/invalid in this case.

## Related Issue

N/A