### PR TITLE
feat(state): add TotalPower to CommitteeInfo

### DIFF
--- a/state/interface.go
+++ b/state/interface.go
@@ -44,6 +44,7 @@ type CommitteeInfo struct {
 	Validators       []*validator.Validator
 	ProtocolVersions map[protocol.Version]float64
 	CommitteePower   int64
+	TotalPower       int64
 }
 
 type State interface {

--- a/state/state.go
+++ b/state/state.go
@@ -761,6 +761,7 @@ func (st *state) CommitteeInfo() *CommitteeInfo {
 		Validators:       st.committee.Validators(),
 		ProtocolVersions: st.committee.ProtocolVersions(),
 		CommitteePower:   st.committee.Power(),
+		TotalPower:       st.totalPower,
 	}
 }
 

--- a/state/state_fake.go
+++ b/state/state_fake.go
@@ -282,6 +282,7 @@ func NewFakeState(ts *testsuite.TestSuite, committee committee.Committee) *FakeS
 				Validators:       fake.Committee.Validators(),
 				ProtocolVersions: fake.Committee.ProtocolVersions(),
 				CommitteePower:   fake.Committee.Power(),
+				TotalPower:       fake.Committee.Power(),
 			}
 		},
 	).AnyTimes()

--- a/www/grpc/blockchain.go
+++ b/www/grpc/blockchain.go
@@ -63,7 +63,6 @@ func (s *blockchainServer) GetCommitteeInfo(_ context.Context,
 	_ *pactus.GetCommitteeInfoRequest,
 ) (*pactus.GetCommitteeInfoResponse, error) {
 	info := s.state.CommitteeInfo()
-	chainInfo := s.state.ChainInfo()
 	valInfos := make([]*pactus.ValidatorInfo, 0, len(info.Validators))
 	for _, val := range info.Validators {
 		valInfos = append(valInfos, s.validatorToProto(val))
@@ -78,7 +77,7 @@ func (s *blockchainServer) GetCommitteeInfo(_ context.Context,
 		ProtocolVersions: protocolVersions,
 		CommitteePower:   info.CommitteePower,
 		CommitteeSize:    int32(len(info.Validators)),
-		TotalPower:       chainInfo.TotalPower,
+		TotalPower:       info.TotalPower,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

This PR adds `TotalPower` field to the `CommitteeInfo` struct so that `GetCommitteeInfo` gRPC handler no longer needs to call `ChainInfo()` just to retrieve the total power value.

## Changes

- Add `TotalPower` field to `CommitteeInfo` struct in `state/interface.go`
- Populate `TotalPower` from `st.totalPower` in `state.CommitteeInfo()`
- Update `FakeState` mock `CommitteeInfo()` to include `TotalPower`
- Remove `ChainInfo()` call from `GetCommitteeInfo` gRPC handler and use `info.TotalPower` directly

## Related Issue

Fixes #2319