### PR TITLE
fix(state): use Power() instead of Stake() in sortition evaluation

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -541,7 +541,7 @@ func (st *state) evaluateSortition() bool {
 		}
 
 		ok, proof := sortition.EvaluateSortition(st.lastInfo.SortitionSeed(),
-			key.PrivateKey(), st.totalPower, int64(val.Stake()))
+			key.PrivateKey(), st.totalPower, val.Power())
 		if ok {
 			trx := tx.NewSortitionTx(st.lastInfo.BlockHeight(), val.Address(), proof)
 			sig := key.Sign(trx.SignBytes())


### PR DESCRIPTION
## Description

The sortition evaluation in `evaluateSortition()` was incorrectly using `int64(val.Stake())` instead of `val.Power()`. This could cause sortition to select validators incorrectly since a validator's `Power()` is the value that should be used for sortition probability calculation, not the raw `Stake()` value.

This fix replaces `int64(val.Stake())` with `val.Power()` in the `EvaluateSortition` call.

## Related Issue

Fixes #2321