### PR TITLE
test(network): ensure connect signal hits on CloseStream test

### DIFF
--- a/network/stream_test.go
+++ b/network/stream_test.go
@@ -28,14 +28,14 @@ func TestCloseStream(t *testing.T) {
 				confA.DefaultPort, networkA.SelfID().String())))
 		networkB = makeTestNetwork(t, confB, nil)
 
-		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.Eventually(t, func() bool {
 			e := <-networkA.networkPipe.UnsafeGetChannel()
-			assert.Equal(collect, EventTypeConnect, e.Type())
+			return EventTypeConnect == e.Type()
 		}, 5*time.Second, 100*time.Millisecond)
 
-		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.Eventually(t, func() bool {
 			e := <-networkB.networkPipe.UnsafeGetChannel()
-			assert.Equal(collect, EventTypeConnect, e.Type())
+			return EventTypeConnect == e.Type()
 		}, 5*time.Second, 100*time.Millisecond)
 
 		return networkA, networkB

--- a/network/stream_test.go
+++ b/network/stream_test.go
@@ -30,11 +30,13 @@ func TestCloseStream(t *testing.T) {
 
 		assert.Eventually(t, func() bool {
 			e := <-networkA.networkPipe.UnsafeGetChannel()
+
 			return EventTypeConnect == e.Type()
 		}, 5*time.Second, 100*time.Millisecond)
 
 		assert.Eventually(t, func() bool {
 			e := <-networkB.networkPipe.UnsafeGetChannel()
+
 			return EventTypeConnect == e.Type()
 		}, 5*time.Second, 100*time.Millisecond)
 


### PR DESCRIPTION
## Description

In rare cases, `EventTypeProtocols` can occur before `EventTypeConnect`, causing `TestCloseStream` to fail. This PR fixes that issue.
