### PR TITLE
feat(sync): add entropy delay to block announcement broadcast

### DIFF
--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -181,6 +181,8 @@ func makeAliceAndBobNetworks(t *testing.T) *networkAliceBob {
 	networkAlice := network.MockingNetwork(ts, ts.RandPeerID())
 	networkBob := network.MockingNetwork(ts, ts.RandPeerID())
 
+	stateAlice.StateParams.BlockIntervalInSecond = 1
+	stateBob.StateParams.BlockIntervalInSecond = 1
 	stateAlice.LastHeight = 0
 	stateBob.LastHeight = 0
 	stateAlice.EXPECT().UpdateValidatorProtocolVersion(gomock.Any(), gomock.Any()).AnyTimes()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -186,11 +186,22 @@ func (sync *synchronizer) sendTo(msg message.Message, pid peer.ID) {
 
 func (sync *synchronizer) broadcast(msg message.Message) {
 	if msg.Type() == message.TypeBlockAnnounce {
-		m := msg.(*message.BlockAnnounceMessage)
-		if sync.cache.HasBlockInCache(m.Height()) {
+		ann := msg.(*message.BlockAnnounceMessage)
+
+		// Add entropy (random delay) before broadcasting the block announcement.
+		// Most committee members reach consensus at roughly the same time.
+		// By waiting a different amount of time, some nodes will receive
+		// announcements from peers first and skip their own broadcast,
+		// reducing redundant network traffic.
+		entropyDelay := sync.blockAnnouncementEntropyDelay(ann)
+		time.Sleep(time.Duration(entropyDelay) * time.Second)
+
+		if sync.cache.HasBlockInCache(ann.Height()) {
 			// We have received the block announcement from other peers before,
 			// so we can simply ignore broadcasting it again.
 			// This helps to reduce the network bandwidth.
+			sync.logger.Info("block announce skipped: already in cache", "height", ann.Height())
+
 			return
 		}
 	}
@@ -203,6 +214,21 @@ func (sync *synchronizer) broadcast(msg message.Message) {
 	sync.peerSet.UpdateSentMetric(nil, msg.Type(), int64(len(data)))
 
 	sync.logger.Debug("bundle broadcasted", "bundle", bdl)
+}
+
+// blockAnnouncementEntropyDelay returns a randomized delay for block announcement
+// broadcast. Returns 0 for future or stale blocks.
+func (sync *synchronizer) blockAnnouncementEntropyDelay(msg *message.BlockAnnounceMessage) int {
+	blockInterval := sync.state.Params().BlockIntervalInSecond
+	nextBlockTime := msg.Block.Header().Time().Add(time.Duration(blockInterval) * time.Second)
+	maxDelay := int(time.Until(nextBlockTime).Seconds())
+	if maxDelay > blockInterval || maxDelay <= 0 {
+		return 0
+	}
+
+	randDelay := util.RandUint32(uint32(maxDelay))
+
+	return int(randDelay)
 }
 
 func (sync *synchronizer) SelfID() peer.ID {

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -442,59 +442,6 @@ func TestCommitMissedBlock(t *testing.T) {
 	})
 }
 
-func TestBlockAnnounceCacheBadAnnounce(t *testing.T) {
-	td := setup(t, nil)
-
-	lastHeight := td.state.LastBlockHeight()
-
-	// Create a block announce where the certificate height does not match
-	// the block height (simulating an invalid/bad announce).
-	blk, _ := td.GenerateTestBlock(lastHeight + 1)
-	badCert := td.GenerateTestCertificate(lastHeight + 2) // wrong height
-
-	badMsg := message.NewBlockAnnounceMessage(blk, badCert, nil)
-	pid := td.RandPeerID()
-	td.receivingNewMessage(td.sync, badMsg, pid)
-
-	// The block is added at height lastHeight+1 (via AddBlock),
-	// and the cert is added at height lastHeight+2 (via AddCertificate).
-	// tryCommitBlocks checks for block+cert at lastHeight+1:
-	// block found but cert NOT found at that height, so commit can't proceed.
-	// The block stays in cache (orphaned).
-	assert.True(t, td.sync.cache.HasBlockInCache(lastHeight+1))
-	assert.NotNil(t, td.sync.cache.GetBlock(lastHeight+1))
-
-	// State should be unchanged since nothing was committed.
-	assert.Equal(t, lastHeight, td.state.LastBlockHeight())
-
-	// Removing the orphaned block from cache should work,
-	// simulating the path tryCommitBlocks takes on error.
-	td.sync.cache.RemoveBlock(lastHeight + 1)
-	assert.False(t, td.sync.cache.HasBlockInCache(lastHeight+1))
-}
-
-func TestBlockAnnounceCacheCommittedBefore(t *testing.T) {
-	td := setup(t, nil)
-
-	// Commit one more block so the node is ahead.
-	td.state.CommitTestBlocks(1)
-	lastHeight := td.state.LastBlockHeight()
-
-	// Now receive a block announce for an already-committed height.
-	blk, cert := td.GenerateTestBlock(lastHeight)
-	msg := message.NewBlockAnnounceMessage(blk, cert, nil)
-	pid := td.RandPeerID()
-	td.receivingNewMessage(td.sync, msg, pid)
-
-	// The block gets added to cache, but tryCommitBlocks starts
-	// at lastHeight+1, so the already-committed block is ignored.
-	// State should remain unchanged.
-	assert.Equal(t, lastHeight, td.state.LastBlockHeight())
-
-	// Block is in cache but doesn't interfere with state.
-	assert.True(t, td.sync.cache.HasBlockInCache(lastHeight))
-}
-
 func TestBlockAnnouncementEntropyDelay(t *testing.T) {
 	td := setup(t, nil)
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -69,6 +69,7 @@ func setup(t *testing.T, config *Config) *testData {
 	consV2Mgr := manager.NewFakeConsensusManager(ts)
 
 	state := state.NewFakeState(ts, nil)
+	state.StateParams.BlockIntervalInSecond = 1
 	state.CommitTestBlocks(100)
 
 	consV1Mgr.EXPECT().IsDeprecated().Return(false).AnyTimes()
@@ -438,5 +439,92 @@ func TestCommitMissedBlock(t *testing.T) {
 
 		newHeight := td.state.LastBlockHeight()
 		assert.Equal(t, lastHeight+2, newHeight)
+	})
+}
+
+func TestBlockAnnounceCacheBadAnnounce(t *testing.T) {
+	td := setup(t, nil)
+
+	lastHeight := td.state.LastBlockHeight()
+
+	// Create a block announce where the certificate height does not match
+	// the block height (simulating an invalid/bad announce).
+	blk, _ := td.GenerateTestBlock(lastHeight + 1)
+	badCert := td.GenerateTestCertificate(lastHeight + 2) // wrong height
+
+	badMsg := message.NewBlockAnnounceMessage(blk, badCert, nil)
+	pid := td.RandPeerID()
+	td.receivingNewMessage(td.sync, badMsg, pid)
+
+	// The block is added at height lastHeight+1 (via AddBlock),
+	// and the cert is added at height lastHeight+2 (via AddCertificate).
+	// tryCommitBlocks checks for block+cert at lastHeight+1:
+	// block found but cert NOT found at that height, so commit can't proceed.
+	// The block stays in cache (orphaned).
+	assert.True(t, td.sync.cache.HasBlockInCache(lastHeight+1))
+	assert.NotNil(t, td.sync.cache.GetBlock(lastHeight+1))
+
+	// State should be unchanged since nothing was committed.
+	assert.Equal(t, lastHeight, td.state.LastBlockHeight())
+
+	// Removing the orphaned block from cache should work,
+	// simulating the path tryCommitBlocks takes on error.
+	td.sync.cache.RemoveBlock(lastHeight + 1)
+	assert.False(t, td.sync.cache.HasBlockInCache(lastHeight+1))
+}
+
+func TestBlockAnnounceCacheCommittedBefore(t *testing.T) {
+	td := setup(t, nil)
+
+	// Commit one more block so the node is ahead.
+	td.state.CommitTestBlocks(1)
+	lastHeight := td.state.LastBlockHeight()
+
+	// Now receive a block announce for an already-committed height.
+	blk, cert := td.GenerateTestBlock(lastHeight)
+	msg := message.NewBlockAnnounceMessage(blk, cert, nil)
+	pid := td.RandPeerID()
+	td.receivingNewMessage(td.sync, msg, pid)
+
+	// The block gets added to cache, but tryCommitBlocks starts
+	// at lastHeight+1, so the already-committed block is ignored.
+	// State should remain unchanged.
+	assert.Equal(t, lastHeight, td.state.LastBlockHeight())
+
+	// Block is in cache but doesn't interfere with state.
+	assert.True(t, td.sync.cache.HasBlockInCache(lastHeight))
+}
+
+func TestBlockAnnouncementEntropyDelay(t *testing.T) {
+	td := setup(t, nil)
+
+	td.state.StateParams.BlockIntervalInSecond = 10
+
+	t.Run("recent block returns delay within block interval", func(t *testing.T) {
+		blk, cert := td.GenerateTestBlock(td.RandHeight(),
+			testsuite.BlockWithTime(time.Now()))
+		msg := message.NewBlockAnnounceMessage(blk, cert, nil)
+
+		delay := td.sync.blockAnnouncementEntropyDelay(msg)
+		assert.GreaterOrEqual(t, delay, 0)
+		assert.LessOrEqual(t, delay, 10)
+	})
+
+	t.Run("future block returns zero delay", func(t *testing.T) {
+		blk, cert := td.GenerateTestBlock(td.RandHeight(),
+			testsuite.BlockWithTime(time.Now().Add(time.Minute)))
+		msg := message.NewBlockAnnounceMessage(blk, cert, nil)
+
+		delay := td.sync.blockAnnouncementEntropyDelay(msg)
+		assert.Zero(t, delay)
+	})
+
+	t.Run("stale block returns zero delay", func(t *testing.T) {
+		blk, cert := td.GenerateTestBlock(td.RandHeight(),
+			testsuite.BlockWithTime(time.Now().Add(-time.Minute)))
+		msg := message.NewBlockAnnounceMessage(blk, cert, nil)
+
+		delay := td.sync.blockAnnouncementEntropyDelay(msg)
+		assert.Zero(t, delay)
 	})
 }


### PR DESCRIPTION
## Description

Add random delay (entropy) before broadcasting block announcements to reduce redundant network traffic. Since committee members reach consensus at roughly the same time, they all try to broadcast simultaneously. By waiting a random amount of time (within the current block window), some nodes will receive announcements from peers first and skip their own broadcast, reducing unnecessary network traffic.

Changes:
- Add `blockAnnouncementEntropyDelay` method that calculates a randomized delay based on time until the next block
- In the `broadcast` method, add entropy delay before block announcement and skip broadcast if block is already in cache
- Add log when block announcement is skipped because the block is already in cache
- Add tests for block announce cache edge cases (bad announce, already committed)
- Add tests for the entropy delay function covering recent, future, and stale blocks

## Related Issue

Fixes #2328