### PR TITLE
fix(sync): remove entropy delay from block announcement broadcast

### DIFF
--- a/sync/handler_blocks_response_test.go
+++ b/sync/handler_blocks_response_test.go
@@ -181,8 +181,6 @@ func makeAliceAndBobNetworks(t *testing.T) *networkAliceBob {
 	networkAlice := network.MockingNetwork(ts, ts.RandPeerID())
 	networkBob := network.MockingNetwork(ts, ts.RandPeerID())
 
-	stateAlice.StateParams.BlockIntervalInSecond = 1
-	stateBob.StateParams.BlockIntervalInSecond = 1
 	stateAlice.LastHeight = 0
 	stateBob.LastHeight = 0
 	stateAlice.EXPECT().UpdateValidatorProtocolVersion(gomock.Any(), gomock.Any()).AnyTimes()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -188,14 +188,6 @@ func (sync *synchronizer) broadcast(msg message.Message) {
 	if msg.Type() == message.TypeBlockAnnounce {
 		ann := msg.(*message.BlockAnnounceMessage)
 
-		// Add entropy (random delay) before broadcasting the block announcement.
-		// Most committee members reach consensus at roughly the same time.
-		// By waiting a different amount of time, some nodes will receive
-		// announcements from peers first and skip their own broadcast,
-		// reducing redundant network traffic.
-		entropyDelay := sync.blockAnnouncementEntropyDelay(ann)
-		time.Sleep(time.Duration(entropyDelay) * time.Second)
-
 		if sync.cache.HasBlockInCache(ann.Height()) {
 			// We have received the block announcement from other peers before,
 			// so we can simply ignore broadcasting it again.
@@ -214,21 +206,6 @@ func (sync *synchronizer) broadcast(msg message.Message) {
 	sync.peerSet.UpdateSentMetric(nil, msg.Type(), int64(len(data)))
 
 	sync.logger.Debug("bundle broadcasted", "bundle", bdl)
-}
-
-// blockAnnouncementEntropyDelay returns a randomized delay for block announcement
-// broadcast. Returns 0 for future or stale blocks.
-func (sync *synchronizer) blockAnnouncementEntropyDelay(msg *message.BlockAnnounceMessage) int {
-	blockInterval := sync.state.Params().BlockIntervalInSecond
-	nextBlockTime := msg.Block.Header().Time().Add(time.Duration(blockInterval) * time.Second)
-	maxDelay := int(time.Until(nextBlockTime).Seconds())
-	if maxDelay > blockInterval || maxDelay <= 0 {
-		return 0
-	}
-
-	randDelay := util.RandUint32(uint32(maxDelay))
-
-	return int(randDelay)
 }
 
 func (sync *synchronizer) SelfID() peer.ID {
@@ -418,8 +395,8 @@ func (sync *synchronizer) updateBlockchain() {
 	diff := curTime.Sub(lastBlockTime)
 	numOfBlocks := uint32(diff.Seconds() / blockInterval.Seconds())
 
-	if numOfBlocks <= 1 {
-		// We are sync
+	if numOfBlocks == 0 {
+		// We are synced: last block was committed within the current block slot
 		return
 	}
 

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -69,7 +69,6 @@ func setup(t *testing.T, config *Config) *testData {
 	consV2Mgr := manager.NewFakeConsensusManager(ts)
 
 	state := state.NewFakeState(ts, nil)
-	state.StateParams.BlockIntervalInSecond = 1
 	state.CommitTestBlocks(100)
 
 	consV1Mgr.EXPECT().IsDeprecated().Return(false).AnyTimes()
@@ -439,39 +438,5 @@ func TestCommitMissedBlock(t *testing.T) {
 
 		newHeight := td.state.LastBlockHeight()
 		assert.Equal(t, lastHeight+2, newHeight)
-	})
-}
-
-func TestBlockAnnouncementEntropyDelay(t *testing.T) {
-	td := setup(t, nil)
-
-	td.state.StateParams.BlockIntervalInSecond = 10
-
-	t.Run("recent block returns delay within block interval", func(t *testing.T) {
-		blk, cert := td.GenerateTestBlock(td.RandHeight(),
-			testsuite.BlockWithTime(time.Now()))
-		msg := message.NewBlockAnnounceMessage(blk, cert, nil)
-
-		delay := td.sync.blockAnnouncementEntropyDelay(msg)
-		assert.GreaterOrEqual(t, delay, 0)
-		assert.LessOrEqual(t, delay, 10)
-	})
-
-	t.Run("future block returns zero delay", func(t *testing.T) {
-		blk, cert := td.GenerateTestBlock(td.RandHeight(),
-			testsuite.BlockWithTime(time.Now().Add(time.Minute)))
-		msg := message.NewBlockAnnounceMessage(blk, cert, nil)
-
-		delay := td.sync.blockAnnouncementEntropyDelay(msg)
-		assert.Zero(t, delay)
-	})
-
-	t.Run("stale block returns zero delay", func(t *testing.T) {
-		blk, cert := td.GenerateTestBlock(td.RandHeight(),
-			testsuite.BlockWithTime(time.Now().Add(-time.Minute)))
-		msg := message.NewBlockAnnounceMessage(blk, cert, nil)
-
-		delay := td.sync.blockAnnouncementEntropyDelay(msg)
-		assert.Zero(t, delay)
 	})
 }


### PR DESCRIPTION
## Description

This PR reverts the entropy delay added in #2329 and fixes the sync check for nodes that are one block behind.

### Changes

1. **Removed entropy delay** (`sync/sync.go`): The `time.Sleep` and `blockAnnouncementEntropyDelay()` function are removed. The cache-based skip is retained: if another peer's BlockAnnounce is already in cache, we skip broadcasting.

2. **Fixed `numOfBlocks <= 1` → `numOfBlocks == 0`** (`sync/sync.go`): Nodes that are exactly one block behind now trigger a block download instead of incorrectly treating themselves as synced.

### Why

- **Pipeline blocking**: The sleep ran on the single broadcast pipeline goroutine, blocking all outgoing consensus messages (proposals, votes) and causing round timeouts on small testnets.

- **Redundant with gossipsub**: All validators produce byte-for-byte identical BlockAnnounce bundles. Gossipsub deduplicates them automatically via `MessageIDFunc` (hashes bundle bytes) + `WithSeenMessagesTTL(60s)`.

- **1-block-behind stuck**: `numOfBlocks <= 1` prevented download when exactly one block behind. Nodes receive BlockAnnounce for H+1, cannot commit it (missing H), and refuse to download.

## Related Issue

Fixes #2332