### PR TITLE
fix(committee): align protocol upgrade threshold with PIP-51

### DIFF
--- a/committee/committee.go
+++ b/committee/committee.go
@@ -238,8 +238,8 @@ func (c *committee) ProtocolVersions() map[protocol.Version]float64 {
 	return percentages
 }
 
-// SupportProtocolVersion checks if more than 70% of committee members
-// support the given protocol version.
+// SupportProtocolVersion checks if more than 75% of the committee's total power
+// supports the given protocol version.
 func (c *committee) SupportProtocolVersion(version protocol.Version) bool {
 	versions := c.ProtocolVersions()
 	supported := float64(0)
@@ -250,5 +250,5 @@ func (c *committee) SupportProtocolVersion(version protocol.Version) bool {
 		}
 	}
 
-	return supported > 70.0
+	return supported > 75.0
 }

--- a/committee/committee_test.go
+++ b/committee/committee_test.go
@@ -416,7 +416,7 @@ func TestSupportProtocolVersion(t *testing.T) {
 	val1 := ts.GenerateTestValidator(testsuite.ValidatorWithStake(1000))
 	val2 := ts.GenerateTestValidator(testsuite.ValidatorWithStake(1000))
 	val3 := ts.GenerateTestValidator(testsuite.ValidatorWithStake(500))
-	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithStake(500))
+	val4 := ts.GenerateTestValidator(testsuite.ValidatorWithStake(501))
 	val5 := ts.GenerateTestValidator(testsuite.ValidatorWithStake(1000))
 
 	val2.UpdateProtocolVersion(protocol.ProtocolVersion1)


### PR DESCRIPTION
## Description

Align the `SupportProtocolVersion` activation threshold from `> 70%` to `> 75%` as specified in PIP-51.

### Changes

**`committee/committee.go`**: Changed `return supported > 70.0` → `return supported > 75.0` and updated the comment.

**`committee/committee_test.go`**: Adjusted `val4` stake from 500 to 501. With the old values, 3000/4000 = 75% exactly, which does NOT satisfy `> 75%`. The new values produce 3001/4001 ≈ 75.006% > 75%, so `supportVer1` correctly passes while `supportVer2` (2001/4001 ≈ 50%) still fails.

### Verification

- `make fmt`: clean
- `go test ./committee/...`: all pass
- `make check`: 0 lint issues

## Related Issue

Fixes #2334