### PR TITLE
feat(execution): allow secp256k1 transactions

### DIFF
--- a/execution/executor/batch_transfer.go
+++ b/execution/executor/batch_transfer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pactus-project/pactus/sandbox"
 	"github.com/pactus-project/pactus/types/account"
 	"github.com/pactus-project/pactus/types/amount"
+	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 )
@@ -32,7 +33,8 @@ func newBatchTransferExecutor(trx *tx.Tx, sbx sandbox.Sandbox) (*BatchTransferEx
 
 	recipients := make([]batchRecipient, len(pld.Recipients))
 	for i, r := range pld.Recipients {
-		if r.To.Type() == crypto.AddressTypeSecp256k1Account {
+		if r.To.Type() == crypto.AddressTypeSecp256k1Account &&
+			sbx.Params().BlockVersion <= protocol.ProtocolVersion3 {
 			return nil, ErrSecp256k1AccountNotSupported
 		}
 

--- a/execution/executor/batch_transfer_test.go
+++ b/execution/executor/batch_transfer_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"testing"
 
+	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 	"github.com/stretchr/testify/assert"
@@ -103,6 +104,12 @@ func TestBatchTransferSecp256k1(t *testing.T) {
 		{To: td.RandAccAddressSecp256k1(), Amount: amt},
 	}
 	trx := tx.NewBatchTransferTx(lockTime, senderAddr, recipients, fee)
+
+	td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion3
 	td.check(t, trx, true, ErrSecp256k1AccountNotSupported)
 	td.check(t, trx, false, ErrSecp256k1AccountNotSupported)
+
+	td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion4
+	td.check(t, trx, true, nil)
+	td.check(t, trx, false, nil)
 }

--- a/execution/executor/transfer.go
+++ b/execution/executor/transfer.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pactus-project/pactus/sandbox"
 	"github.com/pactus-project/pactus/types/account"
 	"github.com/pactus-project/pactus/types/amount"
+	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 )
@@ -19,7 +20,8 @@ type TransferExecutor struct {
 func newTransferExecutor(trx *tx.Tx, sbx sandbox.Sandbox) (*TransferExecutor, error) {
 	pld := trx.Payload().(*payload.TransferPayload)
 
-	if pld.To.Type() == crypto.AddressTypeSecp256k1Account {
+	if pld.To.Type() == crypto.AddressTypeSecp256k1Account &&
+		sbx.Params().BlockVersion <= protocol.ProtocolVersion3 {
 		return nil, ErrSecp256k1AccountNotSupported
 	}
 

--- a/execution/executor/transfer_test.go
+++ b/execution/executor/transfer_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"testing"
 
+	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/stretchr/testify/assert"
 )
@@ -76,6 +77,12 @@ func TestTransferSecp256k1(t *testing.T) {
 	lockTime := td.sbx.CurrentHeight()
 
 	trx := tx.NewTransferTx(lockTime, senderAddr, td.RandAccAddressSecp256k1(), amt, fee)
+
+	td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion3
 	td.check(t, trx, true, ErrSecp256k1AccountNotSupported)
 	td.check(t, trx, false, ErrSecp256k1AccountNotSupported)
+
+	td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion4
+	td.check(t, trx, true, nil)
+	td.check(t, trx, false, nil)
 }

--- a/execution/executor/withdraw.go
+++ b/execution/executor/withdraw.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pactus-project/pactus/sandbox"
 	"github.com/pactus-project/pactus/types/account"
 	"github.com/pactus-project/pactus/types/amount"
+	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 	"github.com/pactus-project/pactus/types/validator"
@@ -20,7 +21,8 @@ type WithdrawExecutor struct {
 func newWithdrawExecutor(trx *tx.Tx, sbx sandbox.Sandbox) (*WithdrawExecutor, error) {
 	pld := trx.Payload().(*payload.WithdrawPayload)
 
-	if pld.To.Type() == crypto.AddressTypeSecp256k1Account {
+	if pld.To.Type() == crypto.AddressTypeSecp256k1Account &&
+		sbx.Params().BlockVersion <= protocol.ProtocolVersion3 {
 		return nil, ErrSecp256k1AccountNotSupported
 	}
 

--- a/execution/executor/withdraw_test.go
+++ b/execution/executor/withdraw_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pactus-project/pactus/types/amount"
+	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/stretchr/testify/assert"
 )
@@ -116,7 +117,12 @@ func TestWithdrawSecp256k1(t *testing.T) {
 	t.Run("Should fail, secp256k1 account is not supported yet", func(t *testing.T) {
 		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr, amt, fee)
 
+		td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion3
 		td.check(t, trx, true, ErrSecp256k1AccountNotSupported)
 		td.check(t, trx, false, ErrSecp256k1AccountNotSupported)
+
+		td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion4
+		td.check(t, trx, true, ErrValidatorBonded)
+		td.check(t, trx, false, ErrValidatorBonded)
 	})
 }


### PR DESCRIPTION
## Description

Remove the `ErrSecp256k1AccountNotSupported` restriction that previously blocked transferring, withdrawing, and batch transferring to secp256k1 account addresses. This allows secp256k1 accounts as valid recipients in all transfer-related operations.

## Related Issue

Fixes #2342