### PR TITLE
fix(wallet): enforce 32-validator limit when creating validator addresses

### DIFF
--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pactus-project/pactus/wallet/types"
 )
 
+const MaxValidators = 32
+
 type addresses struct {
 	storage  storage.WalletStorage
 	provider provider.WalletProvider
@@ -248,6 +250,9 @@ func (a *addresses) NewAddress(addressType crypto.AddressType, label string, opt
 	case crypto.AddressTypeTreasury:
 		return nil, ErrInvalidAddressType
 	case crypto.AddressTypeValidator:
+		if vault.Purposes.PurposeBLS.NextValidatorIndex >= MaxValidators {
+			return nil, ErrMaxValidatorReached
+		}
 		info, err = vault.NewValidatorAddress(label)
 	case crypto.AddressTypeBLSAccount:
 		info, err = vault.NewBLSAccountAddress(label)

--- a/wallet/addresses_test.go
+++ b/wallet/addresses_test.go
@@ -115,6 +115,16 @@ func TestNewValidatorAddress(t *testing.T) {
 	assert.Equal(t, pub.ValidatorAddress().String(), addressInfo.Address)
 }
 
+func TestNewValidatorAddressMaxReached(t *testing.T) {
+	td := setup(t)
+
+	// Set NextValidatorIndex to 32 to simulate max validators reached
+	td.testVault.Purposes.PurposeBLS.NextValidatorIndex = MaxValidators
+
+	_, err := td.wallet.NewValidatorAddress("extra-validator")
+	require.ErrorIs(t, err, ErrMaxValidatorReached)
+}
+
 func TestNewBLSAccountAddress(t *testing.T) {
 	td := setup(t)
 

--- a/wallet/errors.go
+++ b/wallet/errors.go
@@ -15,6 +15,9 @@ var (
 
 	// ErrTransactionExists indicates the transaction already exists in the wallet.
 	ErrTransactionExists = errors.New("transaction already exists")
+
+	// ErrMaxValidatorReached indicates the maximum number of validator addresses (32) has been reached.
+	ErrMaxValidatorReached = errors.New("maximum number of validator addresses (32) reached")
 )
 
 // ExitsError describes an error in which a wallet exists in the

--- a/wallet/storage/sqlitestorage/sql.go
+++ b/wallet/storage/sqlitestorage/sql.go
@@ -126,5 +126,5 @@ const (
 		no, tx_id, sender, receiver, direction, amount, fee, memo, status, block_height, payload_type,
 		data, comment, created_at, updated_at
 		FROM transactions WHERE status = ?
-		ORDER BY created_at DESC`
+		ORDER BY no DESC`
 )

--- a/wallet/storage/sqlitestorage/storage.go
+++ b/wallet/storage/sqlitestorage/storage.go
@@ -534,7 +534,7 @@ func (s *Storage) QueryTransactions(params storage.QueryParams) ([]*wtypes.Trans
 		queryBuilder.WriteString(where)
 		queryBuilder.WriteString("\n")
 	}
-	queryBuilder.WriteString(`ORDER BY created_at DESC
+	queryBuilder.WriteString(`ORDER BY no DESC
 		LIMIT ? OFFSET ?`)
 
 	query := queryBuilder.String()


### PR DESCRIPTION
## Summary

Two wallet/storage fixes:

1. **Enforce 32-validator limit** — The init command enforces a 32-validator limit, but the wallet allowed creating unlimited validator addresses. This adds the same limit to the wallet's NewAddress method.

2. **Order transactions by no instead of created_at** — Using ORDER BY no ensures consistent ordering even when multiple transactions share the same created_at timestamp.