### PR TITLE
fix(gtk): refactor widget layout structure

### DIFF
--- a/cmd/gtk/app/run.go
+++ b/cmd/gtk/app/run.go
@@ -107,7 +107,7 @@ func Run(ctx context.Context, conn grpc.ClientConnInterface,
 
 		mwView.BoxNode.Append(nodeView.Box)
 		mwView.BoxWallet.Append(walletView.Box)
-		mwView.BoxValidators.Append(validatorView.Box)
+		mwView.BoxValidators.Append(validatorView.BoxValidators)
 		mwView.BoxCommittee.Append(committeeView.Box)
 		mwView.BoxNetwork.Append(networkView.Box)
 

--- a/cmd/gtk/assets/ui/widget_committee.ui
+++ b/cmd/gtk/assets/ui/widget_committee.ui
@@ -10,9 +10,8 @@
       <object class="GtkNotebook">
         <property name="tab-pos">left</property>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
+          <object class="GtkBox" id="id_box_committee_info">
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkGrid">
                 <property name="column-spacing">8</property>
@@ -111,14 +110,19 @@
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
+          <object class="GtkBox" id="id_box_committee_members">
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkColumnView" id="id_columnview_committee_members">
+              <object class="GtkScrolledWindow">
                 <property name="hexpand">True</property>
-                <property name="single-click-activate">True</property>
                 <property name="vexpand">True</property>
+                <child>
+                  <object class="GtkColumnView" id="id_columnview_committee_members">
+                    <property name="hexpand">True</property>
+                    <property name="single-click-activate">True</property>
+                    <property name="vexpand">True</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/cmd/gtk/assets/ui/widget_network.ui
+++ b/cmd/gtk/assets/ui/widget_network.ui
@@ -10,9 +10,8 @@
       <object class="GtkNotebook">
         <property name="tab-pos">left</property>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
+          <object class="GtkBox" id="id_box_network_info">
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkGrid">
                 <property name="css-classes">widget-grid</property>
@@ -69,12 +68,17 @@
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
+          <object class="GtkBox" id="id_box_network_peers">
+            <property name="orientation">vertical</property>
             <child>
-              <object class="GtkColumnView" id="id_columnview_peers">
+              <object class="GtkScrolledWindow">
+                <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
+                <child>
+                  <object class="GtkColumnView" id="id_columnview_peers">
+                    <property name="vexpand">True</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/cmd/gtk/assets/ui/widget_node.ui
+++ b/cmd/gtk/assets/ui/widget_node.ui
@@ -7,381 +7,377 @@
     <property name="baseline-position">top</property>
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkScrolledWindow">
+      <object class="GtkGrid">
+        <property name="css-classes">widget-grid</property>
+        <property name="column-spacing">8</property>
+        <property name="hexpand">True</property>
+        <property name="row-spacing">8</property>
+        <property name="vexpand">True</property>
         <child>
-          <object class="GtkGrid">
-            <property name="css-classes">widget-grid</property>
-            <property name="column-spacing">8</property>
-            <property name="hexpand">True</property>
-            <property name="row-spacing">8</property>
-            <property name="vexpand">True</property>
-            <child>
-              <object class="GtkLabel" id="id_label_connection_type">
-                <property name="halign">start</property>
-                <property name="label"/>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">0</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_connection_value">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">0</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">🌐 Network:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">1</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_network">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">1</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">🧾 Network ID:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">2</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_network_id">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">2</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">🤖 Node Agent:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">3</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_agent">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">3</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">⏰ Clock Offset:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">4</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_clock_offset">
-                <property name="halign">start</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">4</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">📡 Connections:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">5</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_num_connections">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">5</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">🔰 Moniker:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">6</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_moniker">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">6</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">🔍 Reachability:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">7</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_reachability">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">7</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">✂️ Pruned:</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">8</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_is_prune">
-                <property name="halign">start</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">8</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">✅ Active Validators:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">9</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_active_validators">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">9</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">✨ Total Power:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">10</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_total_power">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">10</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">📈 Average Score:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">11</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_average_score">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">11</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">💎 In Committee Now:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">12</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_in_committee">
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">12</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">⛓️ Last Block Height:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">13</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_last_block_height">
-                <property name="halign">start</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">13</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">🕔 Last Block Time:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">14</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_last_block_time">
-                <property name="halign">start</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">14</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">📦 Remaining Blocks:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">15</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="id_label_blocks_left">
-                <property name="halign">start</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">15</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="halign">start</property>
-                <property name="label">🔄 Syncing Progress:</property>
-                <property name="valign">start</property>
-                <layout>
-                  <property name="column">0</property>
-                  <property name="row">16</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="GtkProgressBar" id="id_progress_synced">
-                <property name="pulse-step">0.01</property>
-                <property name="show-text">True</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="row">16</property>
-                </layout>
-              </object>
-            </child>
+          <object class="GtkLabel" id="id_label_connection_type">
+            <property name="halign">start</property>
+            <property name="label"/>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">0</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_connection_value">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">0</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">🌐 Network:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">1</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_network">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">1</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">🧾 Network ID:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">2</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_network_id">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">2</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">🤖 Node Agent:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">3</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_agent">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">3</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">⏰ Clock Offset:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">4</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_clock_offset">
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">4</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">📡 Connections:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">5</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_num_connections">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">5</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">🔰 Moniker:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">6</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_moniker">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">6</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">🔍 Reachability:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">7</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_reachability">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">7</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">✂️ Pruned:</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">8</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_is_prune">
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">8</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">✅ Active Validators:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">9</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_active_validators">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">9</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">✨ Total Power:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">10</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_total_power">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">10</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">📈 Average Score:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">11</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_average_score">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">11</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">💎 In Committee Now:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">12</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_in_committee">
+            <property name="halign">start</property>
+            <property name="selectable">True</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">12</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">⛓️ Last Block Height:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">13</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_last_block_height">
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">13</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">🕔 Last Block Time:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">14</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_last_block_time">
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">14</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">📦 Remaining Blocks:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">15</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="id_label_blocks_left">
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">15</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="halign">start</property>
+            <property name="label">🔄 Syncing Progress:</property>
+            <property name="valign">start</property>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">16</property>
+            </layout>
+          </object>
+        </child>
+        <child>
+          <object class="GtkProgressBar" id="id_progress_synced">
+            <property name="pulse-step">0.01</property>
+            <property name="show-text">True</property>
+            <layout>
+              <property name="column">1</property>
+              <property name="row">16</property>
+            </layout>
           </object>
         </child>
       </object>

--- a/cmd/gtk/assets/ui/widget_wallet.ui
+++ b/cmd/gtk/assets/ui/widget_wallet.ui
@@ -11,9 +11,8 @@
       <object class="GtkNotebook">
         <property name="tab-pos">left</property>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
+          <object class="GtkBox" id="id_box_wallet_info">
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkGrid">
                 <property name="column-spacing">8</property>
@@ -201,13 +200,12 @@
         </child>
         <child type="tab">
           <object class="GtkLabel">
-            <property name="label">Overview</property>
+            <property name="label">Info</property>
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
+          <object class="GtkBox" id="id_box_wallet_addresses">
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
                 <property name="orientation">vertical</property>
@@ -250,9 +248,8 @@
           </object>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
+          <object class="GtkBox" id="id_box_wallet_transactions">
+            <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
                 <property name="orientation">vertical</property>

--- a/cmd/gtk/controller/committee_widget_controller.go
+++ b/cmd/gtk/controller/committee_widget_controller.go
@@ -73,7 +73,6 @@ func (c *CommitteeWidgetController) BuildView(ctx context.Context) error {
 
 	scheduler.Every(refreshCommitteeInterval).Do(ctx, func(ctx context.Context) {
 		if gtkutil.IsWidgetShowing(&c.view.Box.Widget) {
-			gtkutil.Logf("refreshing committee")
 			c.refresh(ctx)
 		}
 	})
@@ -84,6 +83,8 @@ func (c *CommitteeWidgetController) BuildView(ctx context.Context) error {
 }
 
 func (c *CommitteeWidgetController) refresh(_ context.Context) {
+	gtkutil.Logf("refreshing committee")
+
 	res, err := c.model.GetCommitteeInfo()
 	if err != nil {
 		return

--- a/cmd/gtk/controller/network_widget_controller.go
+++ b/cmd/gtk/controller/network_widget_controller.go
@@ -80,13 +80,11 @@ func (c *NetworkWidgetController) BuildView(ctx context.Context) error {
 	})
 
 	scheduler.Every(refreshNetworkInterval).Do(ctx, func(ctx context.Context) {
-		if gtkutil.IsWidgetShowing(&c.view.LabelConnectedPeers.Widget) {
-			gtkutil.Logf("refreshing network info")
+		if gtkutil.IsWidgetShowing(&c.view.BoxInfo.Widget) {
 			c.refreshInfo(ctx)
 		}
 
-		if gtkutil.IsWidgetShowing(&c.view.ColViewPeers.Widget) {
-			gtkutil.Logf("refreshing peer list")
+		if gtkutil.IsWidgetShowing(&c.view.BoxPeers.Widget) {
 			c.refreshList(ctx)
 		}
 	})
@@ -98,6 +96,8 @@ func (c *NetworkWidgetController) BuildView(ctx context.Context) error {
 }
 
 func (c *NetworkWidgetController) refreshInfo(_ context.Context) {
+	gtkutil.Logf("refreshing network info")
+
 	netInfo, err := c.model.GetNetworkInfo()
 	if err != nil {
 		return
@@ -110,6 +110,8 @@ func (c *NetworkWidgetController) refreshInfo(_ context.Context) {
 }
 
 func (c *NetworkWidgetController) refreshList(_ context.Context) {
+	gtkutil.Logf("refreshing network peer list")
+
 	peersRes, err := c.model.ListPeers(false) // active peers only
 	if err != nil {
 		return

--- a/cmd/gtk/controller/validator_widget_controller.go
+++ b/cmd/gtk/controller/validator_widget_controller.go
@@ -67,8 +67,7 @@ func (c *ValidatorWidgetController) BuildView(ctx context.Context) error {
 	})
 
 	scheduler.Every(refreshValidatorsInterval).Do(ctx, func(ctx context.Context) {
-		if gtkutil.IsWidgetShowing(&c.view.ColViewValidators.Widget) {
-			gtkutil.Logf("refreshing validators")
+		if gtkutil.IsWidgetShowing(&c.view.BoxValidators.Widget) {
 			c.refresh(ctx)
 		}
 	})
@@ -79,6 +78,8 @@ func (c *ValidatorWidgetController) BuildView(ctx context.Context) error {
 }
 
 func (c *ValidatorWidgetController) refresh(_ context.Context) {
+	gtkutil.Logf("refreshing validators")
+
 	vals, err := c.model.Validators()
 	if err != nil {
 		return

--- a/cmd/gtk/controller/wallet_widget_controller.go
+++ b/cmd/gtk/controller/wallet_widget_controller.go
@@ -137,24 +137,17 @@ func (c *WalletWidgetController) BuildView(ctx context.Context, nav *Navigator) 
 		gtkutil.CaptureDoubleClick(&c.view.ColViewAddresses.Widget, c.ShowAddressDetails)
 	})
 
-	totalBalance1, _ := c.model.TotalBalance()
 	scheduler.Every(refreshWalletInterval).Do(ctx, func(context.Context) {
-		totalBalance2, _ := c.model.TotalBalance()
-
-		if totalBalance1 != totalBalance2 {
+		if gtkutil.IsWidgetShowing(&c.view.BoxInfo.Widget) {
 			c.RefreshInfo()
+		}
 
-			if gtkutil.IsWidgetShowing(&c.view.ColViewAddresses.Widget) {
-				gtkutil.Logf("refreshing addresses")
-				c.RefreshAddresses()
-			}
+		if gtkutil.IsWidgetShowing(&c.view.BoxAddresses.Widget) {
+			c.RefreshAddresses()
+		}
 
-			if gtkutil.IsWidgetShowing(&c.view.ColViewTransactions.Widget) {
-				gtkutil.Logf("refreshing transactions")
-				c.RefreshTransactions()
-			}
-
-			totalBalance1 = totalBalance2
+		if gtkutil.IsWidgetShowing(&c.view.BoxTransactions.Widget) {
+			c.RefreshTransactions()
 		}
 	})
 
@@ -197,6 +190,8 @@ func getDirectionTextWithIcon(dir types.TxDirection) string {
 }
 
 func (c *WalletWidgetController) RefreshInfo() {
+	gtkutil.Logf("refreshing wallet info")
+
 	balance, _ := c.model.TotalBalance()
 	stake, _ := c.model.TotalStake()
 	balanceStr := balance.String()
@@ -218,6 +213,8 @@ func (c *WalletWidgetController) RefreshInfo() {
 
 // RefreshAddresses updates the address list from the model.
 func (c *WalletWidgetController) RefreshAddresses() {
+	gtkutil.Logf("refreshing wallet addresses")
+
 	infos, err := c.model.ListAddresses()
 	if err != nil {
 		return
@@ -234,6 +231,8 @@ func (c *WalletWidgetController) RefreshAddresses() {
 
 // RefreshTransactions updates the transaction list.
 func (c *WalletWidgetController) RefreshTransactions() {
+	gtkutil.Logf("refreshing wallet transactions: count: %v, skip:%v", c.txCount, c.txSkip)
+
 	infos, err := c.model.Transactions(c.txCount, c.txSkip)
 	if err != nil {
 		return

--- a/cmd/gtk/gtkutil/gtkutil.go
+++ b/cmd/gtk/gtkutil/gtkutil.go
@@ -366,34 +366,8 @@ func CaptureDoubleClick(widget *gtk.Widget, action func()) {
 	widget.AddController(gesture)
 }
 
-// ClearListModel removes all items from a gioutil ListModel.
-func ClearListModel[T any](listModel *gioutil.ListModel[T]) {
-	for i := int(listModel.NItems()); i > 0; i-- {
-		listModel.Remove(i - 1)
-	}
-}
-
-// SyncListModel updates a gioutil ListModel with new data, reusing existing
-// items to avoid GObject allocation churn. Items are updated in-place where
-// possible; excess items are removed and new items are appended.
 func SyncListModel[T any](listModel *gioutil.ListModel[T], data []T) {
-	oldLen := int(listModel.NItems())
-	newLen := len(data)
-
-	// Update existing items in-place.
-	for i := 0; i < min(oldLen, newLen); i++ {
-		listModel.Update(i, data[i])
-	}
-
-	// Remove excess items.
-	for i := oldLen - 1; i >= newLen; i-- {
-		listModel.Remove(i)
-	}
-
-	// Append new items.
-	for i := oldLen; i < newLen; i++ {
-		listModel.Append(data[i])
-	}
+	listModel.Splice(0, int(listModel.NItems()), data...)
 }
 
 func IsWidgetShowing(widget *gtk.Widget) bool {

--- a/cmd/gtk/view/committee_widget_view.go
+++ b/cmd/gtk/view/committee_widget_view.go
@@ -11,7 +11,9 @@ import (
 type CommitteeWidgetView struct {
 	ViewBuilder
 
-	Box *gtk.Box
+	Box        *gtk.Box
+	BoxInfo    *gtk.Box
+	BoxMembers *gtk.Box
 
 	LabelCommitteeSize    *gtk.Label
 	LabelCommitteePower   *gtk.Label
@@ -24,8 +26,11 @@ func NewCommitteeWidgetView() *CommitteeWidgetView {
 	builder := NewViewBuilder(assets.CommitteeWidgetUI)
 
 	view := &CommitteeWidgetView{
-		ViewBuilder:           builder,
-		Box:                   builder.GetBoxObj("id_box_committee"),
+		ViewBuilder: builder,
+		Box:         builder.GetBoxObj("id_box_committee"),
+		BoxInfo:     builder.GetBoxObj("id_box_committee_info"),
+		BoxMembers:  builder.GetBoxObj("id_box_committee_members"),
+
 		LabelCommitteeSize:    builder.GetLabelObj("id_label_committee_size"),
 		LabelCommitteePower:   builder.GetLabelObj("id_label_committee_power"),
 		LabelTotalPower:       builder.GetLabelObj("id_label_total_power"),

--- a/cmd/gtk/view/network_widget_view.go
+++ b/cmd/gtk/view/network_widget_view.go
@@ -11,7 +11,9 @@ import (
 type NetworkWidgetView struct {
 	ViewBuilder
 
-	Box *gtk.Box
+	Box      *gtk.Box
+	BoxInfo  *gtk.Box
+	BoxPeers *gtk.Box
 
 	LabelNetworkName    *gtk.Label
 	LabelConnectedPeers *gtk.Label
@@ -23,8 +25,11 @@ func NewNetworkWidgetView() *NetworkWidgetView {
 	builder := NewViewBuilder(assets.NetworkWidgetUI)
 
 	view := &NetworkWidgetView{
-		ViewBuilder:         builder,
-		Box:                 builder.GetBoxObj("id_box_network"),
+		ViewBuilder: builder,
+		Box:         builder.GetBoxObj("id_box_network"),
+		BoxInfo:     builder.GetBoxObj("id_box_network_info"),
+		BoxPeers:    builder.GetBoxObj("id_box_network_peers"),
+
 		LabelNetworkName:    builder.GetLabelObj("id_label_network_name"),
 		LabelConnectedPeers: builder.GetLabelObj("id_label_connected_peers"),
 		ColViewPeers:        builder.GetColumnViewObj("id_columnview_peers"),

--- a/cmd/gtk/view/validator_widget_view.go
+++ b/cmd/gtk/view/validator_widget_view.go
@@ -11,7 +11,7 @@ import (
 type ValidatorWidgetView struct {
 	ViewBuilder
 
-	Box *gtk.Box
+	BoxValidators *gtk.Box
 
 	ColViewValidators *gtk.ColumnView
 }
@@ -20,8 +20,9 @@ func NewValidatorWidgetView() *ValidatorWidgetView {
 	builder := NewViewBuilder(assets.ValidatorWidgetUI)
 
 	view := &ValidatorWidgetView{
-		ViewBuilder:       builder,
-		Box:               builder.GetBoxObj("id_box_validator"),
+		ViewBuilder:   builder,
+		BoxValidators: builder.GetBoxObj("id_box_validator"),
+
 		ColViewValidators: builder.GetColumnViewObj("id_columnview_validators"),
 	}
 

--- a/cmd/gtk/view/wallet_widget_view.go
+++ b/cmd/gtk/view/wallet_widget_view.go
@@ -11,7 +11,10 @@ import (
 type WalletWidgetView struct {
 	ViewBuilder
 
-	Box *gtk.Box
+	Box             *gtk.Box
+	BoxInfo         *gtk.Box
+	BoxAddresses    *gtk.Box
+	BoxTransactions *gtk.Box
 
 	ColViewAddresses    *gtk.ColumnView
 	ColViewTransactions *gtk.ColumnView
@@ -38,8 +41,11 @@ func NewWalletWidgetView() *WalletWidgetView {
 	builder := NewViewBuilder(assets.WalletWidgetUI)
 
 	view := &WalletWidgetView{
-		ViewBuilder: builder,
-		Box:         builder.GetBoxObj("id_box_wallet"),
+		ViewBuilder:     builder,
+		Box:             builder.GetBoxObj("id_box_wallet"),
+		BoxInfo:         builder.GetBoxObj("id_box_wallet_info"),
+		BoxAddresses:    builder.GetBoxObj("id_box_wallet_addresses"),
+		BoxTransactions: builder.GetBoxObj("id_box_wallet_transactions"),
 
 		ColViewAddresses:    builder.GetColumnViewObj("id_columnview_addresses"),
 		ColViewTransactions: builder.GetColumnViewObj("id_columnview_transactions"),


### PR DESCRIPTION
## Summary

Refactors GTK widget layout structure across all widget views:

- Replace outer GtkScrolledWindow wrappers with GtkBox containers for better layout control
- Wrap GtkColumnView inside GtkScrolledWindow for proper scrolling behavior
- Update Box field references in views and controllers (Box -> BoxValidators, BoxCommittee, etc.)
- Remove redundant ScrolledWindow from widget_node.ui grid