### PR TITLE
fix(wallet): order transactions by no instead of created_at

### DIFF
--- a/wallet/storage/sqlitestorage/sql.go
+++ b/wallet/storage/sqlitestorage/sql.go
@@ -126,5 +126,5 @@ const (
 		no, tx_id, sender, receiver, direction, amount, fee, memo, status, block_height, payload_type,
 		data, comment, created_at, updated_at
 		FROM transactions WHERE status = ?
-		ORDER BY created_at DESC`
+		ORDER BY no DESC`
 )

--- a/wallet/storage/sqlitestorage/storage.go
+++ b/wallet/storage/sqlitestorage/storage.go
@@ -534,7 +534,7 @@ func (s *Storage) QueryTransactions(params storage.QueryParams) ([]*wtypes.Trans
 		queryBuilder.WriteString(where)
 		queryBuilder.WriteString("\n")
 	}
-	queryBuilder.WriteString(`ORDER BY created_at DESC
+	queryBuilder.WriteString(`ORDER BY no DESC
 		LIMIT ? OFFSET ?`)
 
 	query := queryBuilder.String()


### PR DESCRIPTION
Use ORDER BY no to ensure consistent ordering even when multiple transactions share the same created_at timestamp.