### PR TITLE
chore(deps): update gotk4 dependency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -197,10 +197,6 @@ linters:
         - td *testData
         - ma multiaddr.Multiaddr
         - db *leveldb.DB
-    gomoddirectives:
-      # List of allowed `replace` directives.
-      replace-allow-list:
-        - github.com/diamondburned/gotk4/pkg
   exclusions:
     generated: lax
     rules:

--- a/cmd/gtk/app/run.go
+++ b/cmd/gtk/app/run.go
@@ -162,8 +162,7 @@ func createTray(mwView *view.MainWindowView, gtkApp *gtk.Application) *systray.S
 	})
 
 	trayIcon.
-		SetIcon(assets.ImagePactusTrayLight32Data).
-		SetDarkModeIcon(assets.ImagePactusTrayDark32Data).
+		SetIcon(assets.ImagePactusTrayDark32Data).
 		SetTooltip("Pactus GUI").
 		SetMenu(menu).
 		OnClick(func() {

--- a/go.mod
+++ b/go.mod
@@ -192,6 +192,3 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.52.0 // indirect
 )
-
-//nolint:gomoddirectives // acceptable for this version
-replace github.com/diamondburned/gotk4/pkg => github.com/pactus-project/gotk4/pkg v0.0.0-20260626172655-14e3591aac91

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 h1:5RVFMOWjMyRy8cARdy79nAmgYw3hK/4HUq48LQ6Wwqo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/diamondburned/gotk4/pkg v0.3.1 h1:uhkXSUPUsCyz3yujdvl7DSN8jiLS2BgNTQE95hk6ygg=
+github.com/diamondburned/gotk4/pkg v0.3.1/go.mod h1:DqeOW+MxSZFg9OO+esk4JgQk0TiUJJUBfMltKhG+ub4=
 github.com/dunglas/httpsfv v1.1.0 h1:Jw76nAyKWKZKFrpMMcL76y35tOpYHqQPzHQiwDvpe54=
 github.com/dunglas/httpsfv v1.1.0/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -337,8 +339,6 @@ github.com/pactus-project/gopkg/signal v0.0.0-20260625084706-612d6d2bb21d h1:P3j
 github.com/pactus-project/gopkg/signal v0.0.0-20260625084706-612d6d2bb21d/go.mod h1:HJJqOD4Peyxe52q8tqcU8LIfi4+SiSFmlJSZj1X4M9M=
 github.com/pactus-project/gopkg/testsuite v0.0.0-20260625084706-612d6d2bb21d h1:c/yXVwkzjTShwVltu4Db0erxH0xPSVRHkNRJx/Pievg=
 github.com/pactus-project/gopkg/testsuite v0.0.0-20260625084706-612d6d2bb21d/go.mod h1:F6x48WnRd0IHjm4fgNzqiPerp2uqa7TPsBxei7i12lg=
-github.com/pactus-project/gotk4/pkg v0.0.0-20260626172655-14e3591aac91 h1:4hssg/QyaxV3bxkBXWqXuTQeVuFwFl8dqTHkJqrdZtk=
-github.com/pactus-project/gotk4/pkg v0.0.0-20260626172655-14e3591aac91/go.mod h1:O9K8+PGNFGJpAu8+u5D2Sn5Wae4hxWzHB+AeZNbV/2Q=
 github.com/pacviewer/jrpc-gateway v0.6.0 h1:h4btj93+Fyaq74rIz9oODTVE1GiuC/aswKzt4u4exrg=
 github.com/pacviewer/jrpc-gateway v0.6.0/go.mod h1:e5x4eyPeACtG4nP9oj3uRYDVOiODh55YdP5iB045WQ0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=


### PR DESCRIPTION
## Description

Switch `gotk4/pkg` from the forked `pactus-project/gotk4/pkg` to upstream `diamondburned/gotk4/pkg v0.3.1`.

- Remove the `replace` directive in `go.mod`
- Update `go.sum` with the upstream module hash
- Adapt tray icon code to upstream API (`SetDarkModeIcon` removed, only `SetIcon` needed)
- Remove the now-unnecessary `gomoddirectives` linter exception in `.golangci.yml`