### PR TITLE
chore(cmd, config): improve CLI UX and localnet config defaults

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -184,7 +184,7 @@ func StartNode(ctx context.Context, workingDir string, passwordFetcher func() (s
 func makeLocalGenesis(wlt *wallet.Wallet) *genesis.Genesis {
 	// Treasury account
 	acc := account.NewAccount(0)
-	acc.AddToBalance(21 * 1e14)
+	acc.AddToBalance(21e15)
 	accs := map[crypto.Address]*account.Account{
 		crypto.TreasuryAddress: acc,
 	}

--- a/cmd/daemon/init.go
+++ b/cmd/daemon/init.go
@@ -64,6 +64,8 @@ func buildInitCmd(parentCmd *cobra.Command) {
 			terminal.PrintLine()
 			confirmed := prompt.PromptConfirm("Have you written down the seed phrase? Continue with initialization")
 			if !confirmed {
+				terminal.PrintWarnMsgf("Operation canceled")
+
 				return
 			}
 		} else {
@@ -90,7 +92,7 @@ func buildInitCmd(parentCmd *cobra.Command) {
 			terminal.PrintInfoMsgf("   • Each validator can stake up to 1,000 coins")
 			terminal.PrintInfoMsgf("   • Choose based on your total stake amount")
 			terminal.PrintLine()
-			valNum = prompt.PromptInputWithRange("Number of Validators", 7, 1, 32)
+			valNum = prompt.PromptInputWithRange("Number of Validators", 32, 1, 32)
 		} else {
 			if *valNumOpt < 1 || *valNumOpt > 32 {
 				terminal.PrintErrorMsgf("%v is not in valid range of validator number, it should be between 1 and 32", *valNumOpt)

--- a/cmd/daemon/prune.go
+++ b/cmd/daemon/prune.go
@@ -63,6 +63,8 @@ func buildPruneCmd(parentCmd *cobra.Command) {
 		terminal.PrintLine()
 		confirmed := prompt.PromptConfirm("Are you sure you want to continue")
 		if !confirmed {
+			terminal.PrintWarnMsgf("Operation canceled")
+
 			return
 		}
 		terminal.PrintLine()

--- a/cmd/wallet/send.go
+++ b/cmd/wallet/send.go
@@ -245,6 +245,8 @@ func signAndPublishTx(wlt *wallet.Wallet, trx *tx.Tx, noConfirm bool, pass strin
 			terminal.PrintLine()
 			confirmed := prompt.PromptConfirm("Do you want to continue")
 			if !confirmed {
+				terminal.PrintWarnMsgf("Operation canceled")
+
 				return
 			}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -227,9 +227,10 @@ func defaultConfigLocalnet() *Config {
 	conf.Network.MaxConns = 16
 	conf.Network.NetworkName = "pactus-localnet"
 	conf.Network.DefaultPort = 0
+	conf.Network.EnableUDP = true
 	conf.Network.ForcePrivateNetwork = true
 	conf.Network.EnableMdns = true
-	conf.Sync.Moniker = "localnet-1"
+	conf.Sync.Moniker = "localnet"
 	conf.GRPC.Enable = true
 	conf.GRPC.EnableWallet = true
 	conf.GRPC.Listen = "[::]:50052"


### PR DESCRIPTION
## Description

- Add "Operation canceled" warning messages when users cancel interactive prompts in daemon init, daemon prune, and wallet send
- Change default validator count from 7 to 32 in daemon init interactive prompt
- Enable UDP in localnet default config
- Change localnet moniker from "localnet-1" to "localnet"

## Related Issue

Fixes #2354