### PR TITLE
chore(grpc): mark GetValidatorAddresses as deprecated

### DIFF
--- a/www/grpc/gen/dart/blockchain.pb.dart
+++ b/www/grpc/gen/dart/blockchain.pb.dart
@@ -2503,6 +2503,7 @@ class BlockchainApi {
           'GetValidatorByNumber', request, GetValidatorResponse());
 
   /// GetValidatorAddresses retrieves a list of all validator addresses.
+  /// deprecated: It will be removed in a future version.
   $async.Future<GetValidatorAddressesResponse> getValidatorAddresses(
           $pb.ClientContext? ctx, GetValidatorAddressesRequest request) =>
       _client.invoke<GetValidatorAddressesResponse>(ctx, 'Blockchain',

--- a/www/grpc/gen/docs/grpc.md
+++ b/www/grpc/gen/docs/grpc.md
@@ -2700,7 +2700,8 @@ Request Message has no fields.
 
 #### GetValidatorAddresses <span id="pactus.Blockchain.GetValidatorAddresses" class="rpc-badge"></span>
 
-<p>GetValidatorAddresses retrieves a list of all validator addresses.</p>
+<p>GetValidatorAddresses retrieves a list of all validator addresses.
+deprecated: It will be removed in a future version.</p>
 
 <h4>GetValidatorAddressesRequest <span class="badge text-bg-info fs-6 align-top">Request</span></h4>
 Request Message has no fields.

--- a/www/grpc/gen/docs/json-rpc.md
+++ b/www/grpc/gen/docs/json-rpc.md
@@ -2731,7 +2731,8 @@ Parameters has no fields.
 
 #### pactus.blockchain.get_validator_addresses <span id="pactus.blockchain.get_validator_addresses" class="rpc-badge"></span>
 
-<p>GetValidatorAddresses retrieves a list of all validator addresses.</p>
+<p>GetValidatorAddresses retrieves a list of all validator addresses.
+deprecated: It will be removed in a future version.</p>
 
 <h4>Parameters</h4>
 Parameters has no fields.

--- a/www/grpc/gen/go/blockchain.cobra.pb.go
+++ b/www/grpc/gen/go/blockchain.cobra.pb.go
@@ -415,7 +415,7 @@ func _BlockchainGetValidatorAddressesCommand(cfg *client.Config) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:   cfg.CommandNamer("GetValidatorAddresses"),
 		Short: "GetValidatorAddresses RPC client",
-		Long:  "GetValidatorAddresses retrieves a list of all validator addresses.",
+		Long:  "GetValidatorAddresses retrieves a list of all validator addresses.\n deprecated: It will be removed in a future version.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cfg.UseEnvVars {
 				if err := flag.SetFlagsFromEnv(cmd.Parent().PersistentFlags(), true, cfg.EnvVarNamer, cfg.EnvVarPrefix, "Blockchain"); err != nil {

--- a/www/grpc/gen/go/blockchain_grpc.pb.go
+++ b/www/grpc/gen/go/blockchain_grpc.pb.go
@@ -58,6 +58,7 @@ type BlockchainClient interface {
 	// GetValidatorByNumber retrieves information about a validator based on the provided number.
 	GetValidatorByNumber(ctx context.Context, in *GetValidatorByNumberRequest, opts ...grpc.CallOption) (*GetValidatorResponse, error)
 	// GetValidatorAddresses retrieves a list of all validator addresses.
+	// deprecated: It will be removed in a future version.
 	GetValidatorAddresses(ctx context.Context, in *GetValidatorAddressesRequest, opts ...grpc.CallOption) (*GetValidatorAddressesResponse, error)
 	// GetPublicKey retrieves the public key of an account based on the provided address.
 	GetPublicKey(ctx context.Context, in *GetPublicKeyRequest, opts ...grpc.CallOption) (*GetPublicKeyResponse, error)
@@ -218,6 +219,7 @@ type BlockchainServer interface {
 	// GetValidatorByNumber retrieves information about a validator based on the provided number.
 	GetValidatorByNumber(context.Context, *GetValidatorByNumberRequest) (*GetValidatorResponse, error)
 	// GetValidatorAddresses retrieves a list of all validator addresses.
+	// deprecated: It will be removed in a future version.
 	GetValidatorAddresses(context.Context, *GetValidatorAddressesRequest) (*GetValidatorAddressesResponse, error)
 	// GetPublicKey retrieves the public key of an account based on the provided address.
 	GetPublicKey(context.Context, *GetPublicKeyRequest) (*GetPublicKeyResponse, error)

--- a/www/grpc/gen/java/pactus/BlockchainGrpc.java
+++ b/www/grpc/gen/java/pactus/BlockchainGrpc.java
@@ -546,6 +546,7 @@ public final class BlockchainGrpc {
     /**
      * <pre>
      * GetValidatorAddresses retrieves a list of all validator addresses.
+     * deprecated: It will be removed in a future version.
      * </pre>
      */
     default void getValidatorAddresses(pactus.BlockchainOuterClass.GetValidatorAddressesRequest request,
@@ -709,6 +710,7 @@ public final class BlockchainGrpc {
     /**
      * <pre>
      * GetValidatorAddresses retrieves a list of all validator addresses.
+     * deprecated: It will be removed in a future version.
      * </pre>
      */
     public void getValidatorAddresses(pactus.BlockchainOuterClass.GetValidatorAddressesRequest request,
@@ -852,6 +854,7 @@ public final class BlockchainGrpc {
     /**
      * <pre>
      * GetValidatorAddresses retrieves a list of all validator addresses.
+     * deprecated: It will be removed in a future version.
      * </pre>
      */
     public pactus.BlockchainOuterClass.GetValidatorAddressesResponse getValidatorAddresses(pactus.BlockchainOuterClass.GetValidatorAddressesRequest request) throws io.grpc.StatusException {
@@ -992,6 +995,7 @@ public final class BlockchainGrpc {
     /**
      * <pre>
      * GetValidatorAddresses retrieves a list of all validator addresses.
+     * deprecated: It will be removed in a future version.
      * </pre>
      */
     public pactus.BlockchainOuterClass.GetValidatorAddressesResponse getValidatorAddresses(pactus.BlockchainOuterClass.GetValidatorAddressesRequest request) {
@@ -1141,6 +1145,7 @@ public final class BlockchainGrpc {
     /**
      * <pre>
      * GetValidatorAddresses retrieves a list of all validator addresses.
+     * deprecated: It will be removed in a future version.
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<pactus.BlockchainOuterClass.GetValidatorAddressesResponse> getValidatorAddresses(

--- a/www/grpc/gen/js/blockchain_grpc_pb.js
+++ b/www/grpc/gen/js/blockchain_grpc_pb.js
@@ -370,6 +370,7 @@ getValidatorByNumber: {
     responseDeserialize: deserialize_pactus_GetValidatorResponse,
   },
   // GetValidatorAddresses retrieves a list of all validator addresses.
+// deprecated: It will be removed in a future version.
 getValidatorAddresses: {
     path: '/pactus.Blockchain/GetValidatorAddresses',
     requestStream: false,

--- a/www/grpc/gen/open-rpc/pactus-openrpc.json
+++ b/www/grpc/gen/open-rpc/pactus-openrpc.json
@@ -571,7 +571,7 @@
         }
       },{
       "name": "pactus.blockchain.get_validator_addresses",
-      "description": "GetValidatorAddresses retrieves a list of all validator addresses.",
+      "description": "GetValidatorAddresses retrieves a list of all validator addresses. deprecated: It will be removed in a future version.",
       "tags": [{ "name": "blockchain"}],
       "paramStructure": "by-name",
       "params": [],

--- a/www/grpc/gen/python/blockchain_pb2_grpc.py
+++ b/www/grpc/gen/python/blockchain_pb2_grpc.py
@@ -146,6 +146,7 @@ class BlockchainServicer:
 
     def GetValidatorAddresses(self, request, context):
         """GetValidatorAddresses retrieves a list of all validator addresses.
+        deprecated: It will be removed in a future version.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/www/grpc/proto/blockchain.proto
+++ b/www/grpc/proto/blockchain.proto
@@ -36,6 +36,7 @@ service Blockchain {
   rpc GetValidatorByNumber(GetValidatorByNumberRequest) returns (GetValidatorResponse);
 
   // GetValidatorAddresses retrieves a list of all validator addresses.
+  // deprecated: It will be removed in a future version.
   rpc GetValidatorAddresses(GetValidatorAddressesRequest) returns (GetValidatorAddressesResponse);
 
   // GetPublicKey retrieves the public key of an account based on the provided address.

--- a/www/http/swagger-ui/pactus.swagger.json
+++ b/www/http/swagger-ui/pactus.swagger.json
@@ -498,7 +498,7 @@
     },
     "/pactus/blockchain/get_validator_addresses": {
       "get": {
-        "summary": "GetValidatorAddresses retrieves a list of all validator addresses.",
+        "summary": "GetValidatorAddresses retrieves a list of all validator addresses.\ndeprecated: It will be removed in a future version.",
         "operationId": "Blockchain_GetValidatorAddresses",
         "responses": {
           "200": {


### PR DESCRIPTION
## Description

This PR marks the `GetValidatorAddresses` method as deprecated and will be removed in future versions.
