### PR TITLE
chore(crypto): simplify IsAccountAddress using IsValidatorAddress

### DIFF
--- a/crypto/address.go
+++ b/crypto/address.go
@@ -154,10 +154,7 @@ func (addr Address) IsTreasuryAddress() bool {
 }
 
 func (addr Address) IsAccountAddress() bool {
-	return addr.Type() == AddressTypeTreasury ||
-		addr.Type() == AddressTypeBLSAccount ||
-		addr.Type() == AddressTypeEd25519Account ||
-		addr.Type() == AddressTypeSecp256k1Account
+	return !addr.IsValidatorAddress()
 }
 
 func (addr Address) IsValidatorAddress() bool {


### PR DESCRIPTION
Refactors `IsAccountAddress()` to use `!addr.IsValidatorAddress()` instead of enumerating each account address type individually. This makes the logic symmetrical with `IsValidatorAddress()` and automatically covers any future account types.