### PR TITLE
refactor(state): move syncing fields to ChainInfo

### DIFF
--- a/state/interface.go
+++ b/state/interface.go
@@ -37,6 +37,10 @@ type ChainInfo struct {
 
 	IsPruned      bool
 	PruningHeight types.Height
+
+	ChainType    genesis.ChainType
+	SyncProgress float64
+	BlocksLeft   int64
 }
 
 // CommitteeInfo holds committee validators, protocol versions, and total power.

--- a/state/state.go
+++ b/state/state.go
@@ -787,6 +787,18 @@ func (st *state) ChainInfo() *ChainInfo {
 	st.lk.RLock()
 	defer st.lk.RUnlock()
 
+	genDoc := st.Genesis()
+	nowSec := time.Now().Unix()
+	lastBlockTimeSec := st.lastInfo.BlockTime().Unix()
+	genTimeSec := genDoc.GenesisTime().Unix()
+
+	// Sync progress: fraction of expected blocks that have been synced, clamped to [0, 1].
+	syncProgress := float64(lastBlockTimeSec-genTimeSec) / float64(nowSec-genTimeSec)
+
+	// Blocks remaining to reach the latest block.
+	blockInterval := int64(st.Params().BlockIntervalInSecond)
+	blocksLeft := (nowSec - lastBlockTimeSec) / blockInterval
+
 	return &ChainInfo{
 		LastBlockHeight:  st.lastInfo.BlockHeight(),
 		LastBlockHash:    st.lastInfo.BlockHash(),
@@ -800,6 +812,9 @@ func (st *state) ChainInfo() *ChainInfo {
 		AverageScore:     st.calculateAverageScore(),
 		IsPruned:         st.store.IsPruned(),
 		PruningHeight:    st.store.PruningHeight(),
+		ChainType:        genDoc.ChainType(),
+		SyncProgress:     syncProgress,
+		BlocksLeft:       blocksLeft,
 	}
 }
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -822,51 +822,19 @@ func TestBlockVersionUpgrade(t *testing.T) {
 	assert.Equal(t, protocol.ProtocolVersionLatest, td2.state.Params().BlockVersion)
 }
 
-// func TestProposeBlockVersionUpgradeToV4(t *testing.T) {
-// 	// When BlockVersion is already V4, proposeBlockVersion returns V4 directly.
-// 	td := setupWithVersion(t, protocol.ProtocolVersion4)
+func TestChainInfo(t *testing.T) {
+	td := setup(t)
 
-// 	assert.Equal(t, protocol.ProtocolVersion4, td.state.proposeBlockVersion())
+	td.state.genDoc = genesis.MainnetGenesis()
+	td.state.lastInfo.UpdateBlockTime(time.Now().Add(-1 * time.Second))
+	chainInfo := td.state.ChainInfo()
 
-// 	td.mockTxPool.EXPECT().PrepareBlockTransactions().Return(block.Txs{}).AnyTimes()
-// 	valKey := td.proposerKey(t, 0)
-// 	blk, err := td.state.ProposeBlock(valKey, td.RandAccAddress())
-// 	require.NoError(t, err)
-// 	assert.Equal(t, protocol.ProtocolVersion4, blk.Header().Version())
-// }
-
-// func TestProposeBlockVersionStaysAtV3(t *testing.T) {
-// 	// When BlockVersion is V3 and committee validators don't support V4 yet,
-// 	// proposeBlockVersion should return V3.
-// 	td := setupWithVersion(t, protocol.ProtocolVersion3)
-
-// 	assert.Equal(t, protocol.ProtocolVersion3, td.state.proposeBlockVersion())
-
-// 	td.mockTxPool.EXPECT().PrepareBlockTransactions().Return(block.Txs{}).AnyTimes()
-// 	valKey := td.proposerKey(t, 0)
-// 	blk, err := td.state.ProposeBlock(valKey, td.RandAccAddress())
-// 	require.NoError(t, err)
-// 	assert.Equal(t, protocol.ProtocolVersion3, blk.Header().Version())
-// }
-
-// func TestRewardHalvingWithV4(t *testing.T) {
-// 	// Setup with V4 block version
-// 	td := setupWithVersion(t, protocol.ProtocolVersion4)
-
-// 	// At the test height (7), the coefficient is 1.0 since 7 <= 8,000,000.
-// 	// So reward should be the same as pre-V4: 1 PAC.
-// 	proposerAddr := td.state.Proposer(0).Address()
-// 	trx := td.state.createSubsidyTx(proposerAddr, td.RandAccAddress(), 0, protocol.ProtocolVersion4)
-// 	batchTrx := trx.Payload().(*payload.BatchTransferPayload)
-
-// 	// Foundation reward should be 0.3 * 1.0 = 0.3 PAC
-// 	assert.Equal(t, amount.Amount(0.3e9), batchTrx.Recipients[0].Amount)
-// 	// Validator reward should be 1.0 - 0.3 = 0.7 PAC
-// 	assert.Equal(t, amount.Amount(0.7e9), batchTrx.Recipients[1].Amount)
-
-// 	// With V3, the same height gives the same result.
-// 	trxV3 := td.state.createSubsidyTx(proposerAddr, td.RandAccAddress(), 0, protocol.ProtocolVersion3)
-// 	batchTrxV3 := trxV3.Payload().(*payload.BatchTransferPayload)
-// 	assert.Equal(t, batchTrx.Recipients[0].Amount, batchTrxV3.Recipients[0].Amount)
-// 	assert.Equal(t, batchTrx.Recipients[1].Amount, batchTrxV3.Recipients[1].Amount)
-// }
+	assert.Equal(t, int32(4), chainInfo.ActiveValidators)
+	assert.Equal(t, int32(4), chainInfo.TotalValidators)
+	assert.Equal(t, int64(4), chainInfo.TotalPower)
+	assert.False(t, chainInfo.IsPruned)
+	assert.Equal(t, types.Height(0), chainInfo.PruningHeight)
+	assert.Equal(t, genesis.Mainnet, chainInfo.ChainType)
+	assert.InEpsilon(t, 1, chainInfo.SyncProgress, 0.0001)
+	assert.Equal(t, int64(0), chainInfo.BlocksLeft)
+}

--- a/www/grpc/blockchain.go
+++ b/www/grpc/blockchain.go
@@ -3,8 +3,6 @@ package grpc
 import (
 	"context"
 	"encoding/hex"
-	"math"
-	"time"
 
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/hash"
@@ -44,24 +42,6 @@ func (s *blockchainServer) GetBlockchainInfo(_ context.Context,
 		}
 	}
 
-	// Map genesis chain type to the protobuf enum.
-	genDoc := s.state.Genesis()
-	chainType := pactus.ChainType(genDoc.ChainType())
-
-	blockInterval := int64(s.state.Params().BlockIntervalInSecond)
-	genesisTime := genDoc.GenesisTime()
-	expectedBlocks := (time.Now().Unix() - genesisTime.Unix()) / blockInterval
-
-	// Sync progress: fraction of expected blocks that have been synced, clamped to [0, 1].
-	syncProgress := float64(chainInfo.LastBlockHeight) / float64(expectedBlocks)
-	syncProgress = math.Min(math.Max(syncProgress, 0), 1)
-
-	// Blocks remaining to reach the latest block.
-	blocksLeft := expectedBlocks - int64(chainInfo.LastBlockHeight)
-	if blocksLeft < 0 {
-		blocksLeft = 0
-	}
-
 	return &pactus.GetBlockchainInfoResponse{
 		LastBlockHeight:  uint32(chainInfo.LastBlockHeight),
 		LastBlockHash:    chainInfo.LastBlockHash.String(),
@@ -76,9 +56,9 @@ func (s *blockchainServer) GetBlockchainInfo(_ context.Context,
 		IsPruned:         chainInfo.IsPruned,
 		PruningHeight:    uint32(chainInfo.PruningHeight),
 		InCommittee:      inCommittee,
-		ChainType:        chainType,
-		SyncProgress:     syncProgress,
-		BlocksLeft:       blocksLeft,
+		ChainType:        pactus.ChainType(chainInfo.ChainType),
+		SyncProgress:     chainInfo.SyncProgress,
+		BlocksLeft:       chainInfo.BlocksLeft,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

This PR refactors the `ChainInfo` to hold the syncing information.
