### PR TITLE
fix(wallet): recalculate CRC for V6 JSON wallets

### DIFF
--- a/wallet/storage/jsonstorage/testdata/wallet_version_6
+++ b/wallet/storage/jsonstorage/testdata/wallet_version_6
@@ -3,7 +3,7 @@
   "uuid": "44156117-268a-49f0-a906-400659b7a051",
   "created_at": "2024-08-27T16:45:08Z",
   "network": 0,
-  "crc": 3037999230,
+  "crc": 3456918530,
   "default_fee": 20000000,
   "vault": {
     "type": 1,
@@ -27,7 +27,8 @@
       },
       "purpose_bip44": {
         "next_ed25519_index": 1,
-        "next_secp256k1_index": 1
+        "next_secp256k1_index": 1,
+        "xpub_secp256k1": ""
       }
     }
   },

--- a/wallet/storage/jsonstorage/upgrader.go
+++ b/wallet/storage/jsonstorage/upgrader.go
@@ -102,8 +102,10 @@ func upgrade(path string) error {
 		return store.Save(path)
 
 	case Version6:
-		// Latest version, no need to upgrade.
-		return nil
+		// Recalculate the CRC after removing unused `xpub_secp256k1`, no need to upgrade the version.
+		store.VaultCRC = store.calcVaultCRC()
+
+		return store.Save(path)
 
 	default:
 		return UnsupportedVersionError{


### PR DESCRIPTION
## Description

The `xpub_secp256k1` field was removed from the `purposeBIP44` vault struct, but wallets saved while the field was present still contain it in their JSON. This breaks `ValidateCRC()` because `calcVaultCRC()` now marshals the vault without the field.

**Changes:**
- **Upgrader:** The V6 upgrade case now recalculates the CRC and re-saves the wallet, dropping the stale `xpub_secp256k1` field from the JSON
- **Testdata:** Updated `wallet_version_6` to include `xpub_secp256k1` to simulate affected wallets

## Related Issue

Fixes #2374