### PR TITLE
feat(gtk): modernize the GTK GUI - sidebar, dashboards, light/dark theme

### DIFF
--- a/cmd/gtk/app/run.go
+++ b/cmd/gtk/app/run.go
@@ -133,7 +133,13 @@ func Run(ctx context.Context, conn grpc.ClientConnInterface,
 				themeToggle.SetLabel("☀")
 			}
 		}
+		// Restore the persisted light/dark choice, falling back to the system
+		// theme when the user has not chosen yet.
 		startDark := adw.StyleManagerGetDefault().Dark()
+		if saved, ok := gtkutil.LoadDarkMode(); ok {
+			startDark = saved
+			nav.SetDarkMode(saved)
+		}
 		themeToggle.SetActive(startDark)
 		applyThemeIcon(startDark)
 		themeToggle.ConnectToggled(func() {

--- a/cmd/gtk/app/run.go
+++ b/cmd/gtk/app/run.go
@@ -5,6 +5,7 @@ package app
 import (
 	"context"
 
+	adw "github.com/diamondburned/gotk4-adwaita/pkg/adw"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 	"github.com/gogpu/systray"
 	"github.com/pactus-project/pactus/cmd"
@@ -98,6 +99,47 @@ func Run(ctx context.Context, conn grpc.ClientConnInterface,
 
 	mwView := gtkutil.IdleAddSyncT(func() *view.MainWindowView {
 		mwView := view.NewMainWindowView()
+
+		// Custom title bar: small Pactus logo next to the app name on the left,
+		// and a round light/dark toggle on the right, beside the window buttons.
+		header := gtk.NewHeaderBar()
+
+		brand := gtk.NewBox(gtk.OrientationHorizontal, 8)
+		brand.SetVAlign(gtk.AlignCenter)
+		logo := gtk.NewImageFromPaintable(assets.ImagePactusLogoTexture)
+		logo.SetPixelSize(24)
+		logo.AddCSSClass("app-logo")
+		title := gtk.NewLabel("Pactus GUI")
+		title.AddCSSClass("app-title")
+		brand.Append(logo)
+		brand.Append(title)
+		header.PackStart(brand)
+		// Suppress the centered window title so the brand stays left-aligned.
+		header.SetTitleWidget(gtk.NewLabel(""))
+
+		themeToggle := gtk.NewToggleButton()
+		themeToggle.AddCSSClass("theme-toggle")
+		themeToggle.AddCSSClass("circular")
+		themeToggle.SetVAlign(gtk.AlignCenter)
+		themeToggle.SetTooltipText("Toggle light / dark mode")
+		applyThemeIcon := func(dark bool) {
+			if dark {
+				themeToggle.SetLabel("🌙")
+			} else {
+				themeToggle.SetLabel("☀")
+			}
+		}
+		startDark := adw.StyleManagerGetDefault().Dark()
+		themeToggle.SetActive(startDark)
+		applyThemeIcon(startDark)
+		themeToggle.ConnectToggled(func() {
+			active := themeToggle.Active()
+			nav.SetDarkMode(active)
+			applyThemeIcon(active)
+		})
+		header.PackEnd(themeToggle)
+
+		mwView.Window.SetTitlebar(header)
 
 		walletCtrl.SetupMenu(mwView.Window)
 

--- a/cmd/gtk/app/run.go
+++ b/cmd/gtk/app/run.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	adw "github.com/diamondburned/gotk4-adwaita/pkg/adw"
+	"github.com/diamondburned/gotk4/pkg/glib/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 	"github.com/gogpu/systray"
 	"github.com/pactus-project/pactus/cmd"
@@ -100,6 +101,9 @@ func Run(ctx context.Context, conn grpc.ClientConnInterface,
 	mwView := gtkutil.IdleAddSyncT(func() *view.MainWindowView {
 		mwView := view.NewMainWindowView()
 
+		// Register the main window so dialogs open centered over it.
+		gtkutil.SetMainWindow(&mwView.Window.Window)
+
 		// Custom title bar: small Pactus logo next to the app name on the left,
 		// and a round light/dark toggle on the right, beside the window buttons.
 		header := gtk.NewHeaderBar()
@@ -107,7 +111,7 @@ func Run(ctx context.Context, conn grpc.ClientConnInterface,
 		brand := gtk.NewBox(gtk.OrientationHorizontal, 8)
 		brand.SetVAlign(gtk.AlignCenter)
 		logo := gtk.NewImageFromPaintable(assets.ImagePactusLogoTexture)
-		logo.SetPixelSize(24)
+		logo.SetPixelSize(20)
 		logo.AddCSSClass("app-logo")
 		title := gtk.NewLabel("Pactus GUI")
 		title.AddCSSClass("app-title")
@@ -159,6 +163,14 @@ func Run(ctx context.Context, conn grpc.ClientConnInterface,
 
 		gtkApp.AddWindow(&mwView.Window.Window)
 		mwView.Window.Present()
+
+		// Center the main window on first show; GTK4 cannot position it, so do
+		// it natively once mapped (no-op on Linux/macOS).
+		glib.TimeoutAdd(80, func() bool {
+			gtkutil.CenterActiveWindow()
+
+			return false
+		})
 
 		return mwView
 	})

--- a/cmd/gtk/assets/css/style.css
+++ b/cmd/gtk/assets/css/style.css
@@ -49,6 +49,34 @@ separator {
     min-height: 1px;
 }
 
+/* ---- Header bar (title bar with logo) ----------------------------------- */
+
+headerbar {
+    min-height: 42px;
+    padding: 3px 8px;
+    background-color: @surface;
+    border-bottom: 1px solid @hairline;
+    box-shadow: none;
+}
+
+.app-logo {
+    margin: 0 8px 0 2px;
+}
+
+.app-title {
+    font-weight: 700;
+    font-size: 14px;
+    color: @theme_fg_color;
+}
+
+.theme-toggle {
+    margin-right: 6px;
+    min-width: 28px;
+    min-height: 28px;
+    padding: 0;
+    font-size: 14px;
+}
+
 /* ---- Notebook tabs (main navigation) ------------------------------------ */
 
 notebook > header {
@@ -194,6 +222,45 @@ textview.view {
     padding: 6px;
     border-radius: 8px;
     border: 1px solid @hairline;
+}
+
+/* ---- Progress + controls ------------------------------------------------ */
+
+progressbar > trough {
+    border-radius: 6px;
+    min-height: 8px;
+    background-color: @hover_bg;
+}
+
+progressbar > trough > progress {
+    background-image: none;
+    background-color: @pactus_accent;
+    border-radius: 6px;
+}
+
+progressbar text {
+    color: @muted_fg;
+    font-size: 11px;
+}
+
+/* Brand the interactive controls. */
+spinner {
+    color: @pactus_accent;
+}
+
+check:checked,
+radio:checked {
+    background-image: none;
+    background-color: @pactus_accent;
+    border-color: @pactus_accent;
+}
+
+switch:checked {
+    background-color: @pactus_accent;
+}
+
+scale > trough > highlight {
+    background-color: @pactus_accent;
 }
 
 /* ---- Status colors ------------------------------------------------------ */

--- a/cmd/gtk/assets/css/style.css
+++ b/cmd/gtk/assets/css/style.css
@@ -1,98 +1,263 @@
+/*
+ * Pactus GUI theme foundation.
+ *
+ * Colors are derived from GTK's adaptive named colors (@theme_bg_color,
+ * @theme_fg_color, @theme_base_color ...) so the interface follows the
+ * active light or dark theme automatically. Only the Pactus brand accent
+ * is fixed; it is a mid-tone teal chosen to stay legible on both light
+ * and dark backgrounds.
+ *
+ * Note: GTK CSS variables (@define-color) hold colors only, not lengths,
+ * so radii and spacing are written as literal values kept consistent here.
+ */
+
+/* ---- Brand + token layer ------------------------------------------------ */
+
+@define-color pactus_navy       #002235;
+@define-color pactus_accent     #12909e;
+@define-color pactus_accent_hi  #16a7b8;
+
+/* Route GTK's own accent/selection through the brand teal for cohesion. */
+@define-color accent_color         @pactus_accent;
+@define-color accent_bg_color      @pactus_accent;
+@define-color theme_selected_bg_color @pactus_accent;
+@define-color theme_selected_fg_color #ffffff;
+
+/* Surfaces + lines derived from the active theme (adapts to light/dark). */
+@define-color surface     @theme_bg_color;
+@define-color card_bg     mix(@theme_base_color, @theme_fg_color, 0.03);
+@define-color card_border alpha(@theme_fg_color, 0.10);
+@define-color hairline    alpha(@theme_fg_color, 0.12);
+@define-color muted_fg    alpha(@theme_fg_color, 0.62);
+@define-color hover_bg    alpha(@theme_fg_color, 0.06);
+@define-color danger_fg   #e0483a;
+
+/* ---- Base --------------------------------------------------------------- */
+
+window {
+    background-color: @surface;
+}
+
+label {
+    /* Gentle default; specific labels override below. */
+}
+
+separator {
+    margin: 8px 4px;
+    background-color: @hairline;
+    min-width: 1px;
+    min-height: 1px;
+}
+
+/* ---- Notebook tabs (main navigation) ------------------------------------ */
+
+notebook > header {
+    background-color: @surface;
+    border-bottom: 1px solid @hairline;
+    padding: 2px 4px 0 4px;
+}
+
+notebook > header tab {
+    margin: 0 2px;
+    padding: 8px 16px;
+    border-radius: 8px 8px 0 0;
+    border: none;
+    color: @muted_fg;
+    font-weight: 500;
+    transition: background-color 150ms ease, color 150ms ease;
+}
+
+notebook > header tab:hover {
+    background-color: @hover_bg;
+    color: @theme_fg_color;
+}
+
+notebook > header tab:checked {
+    color: @pactus_accent;
+    box-shadow: inset 0 -2px 0 0 @pactus_accent;
+}
+
+notebook > header tab:checked label {
+    font-weight: 700;
+}
+
+/* ---- Buttons ------------------------------------------------------------ */
+
+button {
+    border-radius: 8px;
+    padding: 6px 14px;
+    transition: background-color 150ms ease, box-shadow 150ms ease;
+}
+
+button:hover {
+    background-color: @hover_bg;
+}
+
+button.suggested-action,
+button.default {
+    background-image: none;
+    background-color: @pactus_accent;
+    color: #ffffff;
+    border: none;
+}
+
+button.suggested-action:hover,
+button.default:hover {
+    background-color: @pactus_accent_hi;
+}
+
+button.destructive-action {
+    background-image: none;
+    background-color: @danger_fg;
+    color: #ffffff;
+    border: none;
+}
+
 .inline_button {
-    padding: 2px;
-    margin-right: 3px;
+    padding: 4px;
+    margin-right: 4px;
+    border-radius: 6px;
+}
+
+/* ---- Entries ------------------------------------------------------------ */
+
+entry {
+    border-radius: 8px;
+    padding: 6px 10px;
+    border: 1px solid @hairline;
+    transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+entry:focus-within {
+    border-color: @pactus_accent;
+    box-shadow: 0 0 0 2px alpha(@pactus_accent, 0.30);
 }
 
 .copyable_entry {
     padding-right: 36px;
 }
 
-.warning {
-    color: red;
+/* ---- Lists + rows ------------------------------------------------------- */
+
+list {
+    padding: 4px;
+    background-color: transparent;
 }
 
+list > row {
+    border-radius: 8px;
+    padding: 6px 8px;
+    margin: 1px 2px;
+    transition: background-color 150ms ease;
+}
 
-separator {
-    margin: 8px;
+list > row:hover {
+    background-color: @hover_bg;
+}
+
+/* ---- Cards / framed sections ------------------------------------------- */
+
+frame {
+    border-radius: 12px;
+    border: 1px solid @card_border;
+    background-color: @card_bg;
+    padding: 4px;
+}
+
+frame > label {
+    font-weight: 600;
+    margin: 2px 6px;
 }
 
 .widget-grid {
-    margin-top: 12px;
-    margin-bottom: 8px;
-    margin-right: 4px;
-    margin-left: 4px;
+    margin: 12px 6px 8px 6px;
 }
 
 .dialog-box {
-    margin-top: 12px;
-    margin-bottom: 8px;
-    margin-right: 4px;
-    margin-left: 4px;
+    margin: 12px 6px 8px 6px;
 }
 
 .dialog-action-bar {
-
+    padding-top: 8px;
 }
 
 .toolbar {
     background-image: none;
     background-color: @theme_bg_color;
     box-shadow: none;
+    border-bottom: 1px solid @hairline;
 }
 
-/*** Styles for Gtk.ListBox ***/
-list {
-    padding: 2px;
-    margin: 2px;
-}
+/* ---- TextView ----------------------------------------------------------- */
 
-/*** Styles for Gtk.TextView ***/
 textview.view {
-    padding: 2px;
-    margin: 2px;
-    border: 1px solid #000000;
+    padding: 6px;
+    border-radius: 8px;
+    border: 1px solid @hairline;
 }
 
-/* Styles for the assistant page */
+/* ---- Status colors ------------------------------------------------------ */
+
+.warning {
+    color: @danger_fg;
+    font-weight: 600;
+}
+
+/* ---- Startup assistant -------------------------------------------------- */
 
 .assistant-frame {
     font-size: 14px;
-    margin: 4px;
-    padding: 4px;
+    margin: 8px;
+    padding: 14px;
+    border-radius: 12px;
+    border: 1px solid @card_border;
+    background-color: @card_bg;
+    transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.assistant-frame:hover {
+    border-color: alpha(@pactus_accent, 0.55);
 }
 
 .assistant-frame-label {
+    font-weight: 700;
     margin-bottom: 12px;
 }
 
 .assistant-frame-desc {
-    font-size: 14px;
+    font-size: 13px;
     font-weight: normal;
+    color: @muted_fg;
     margin-bottom: 12px;
-    margin-left: 8px;
+    margin-left: 4px;
 }
 
+/* ---- Splash screen ------------------------------------------------------ */
+
 .splash {
-    padding: 24px;
+    padding: 28px 32px;
+    background-color: @surface;
+    border-radius: 16px;
 }
 
 .splash-logo {
-    margin-bottom: 8px;
-    padding: 0px;
+    margin-bottom: 10px;
+    padding: 0;
 }
 
 .splash-spinner {
     margin-bottom: 6px;
-    padding: 0px;
+    padding: 0;
 }
 
 .splash-status {
     font-size: 14px;
-    font-weight: 500;
-    margin-bottom: 6px;
+    font-weight: 600;
+    margin-bottom: 4px;
 }
 
 .splash-version {
     font-size: 12px;
-    opacity: 0.7;
+    color: @muted_fg;
+    opacity: 0.8;
 }

--- a/cmd/gtk/assets/css/style.css
+++ b/cmd/gtk/assets/css/style.css
@@ -13,11 +13,13 @@
 
 /* ---- Brand + token layer ------------------------------------------------ */
 
+/* Pactus brand palette, taken from the logo and the site's action buttons. */
 @define-color pactus_navy       #002235;
-@define-color pactus_accent     #12909e;
-@define-color pactus_accent_hi  #16a7b8;
+@define-color pactus_accent     #00a085;   /* green - primary actions/accent */
+@define-color pactus_accent_hi  #12b89a;   /* green hover */
+@define-color pactus_blue       #217aff;   /* blue - navigation */
 
-/* Route GTK's own accent/selection through the brand teal for cohesion. */
+/* Route GTK's own accent/selection through the brand green for cohesion. */
 @define-color accent_color         @pactus_accent;
 @define-color accent_bg_color      @pactus_accent;
 @define-color theme_selected_bg_color @pactus_accent;
@@ -52,29 +54,35 @@ separator {
 /* ---- Header bar (title bar with logo) ----------------------------------- */
 
 headerbar {
-    min-height: 42px;
-    padding: 3px 8px;
+    min-height: 32px;
+    padding: 1px 6px;
     background-color: @surface;
     border-bottom: 1px solid @hairline;
     box-shadow: none;
 }
 
 .app-logo {
-    margin: 0 8px 0 2px;
+    margin: 0 6px 0 2px;
 }
 
 .app-title {
     font-weight: 700;
-    font-size: 14px;
+    font-size: 13px;
     color: @theme_fg_color;
 }
 
 .theme-toggle {
-    margin-right: 6px;
-    min-width: 28px;
-    min-height: 28px;
+    margin-right: 4px;
+    min-width: 24px;
+    min-height: 24px;
     padding: 0;
-    font-size: 14px;
+    font-size: 13px;
+}
+
+headerbar windowcontrols > button {
+    min-height: 24px;
+    min-width: 24px;
+    padding: 0;
 }
 
 /* ---- Notebook tabs (main navigation) ------------------------------------ */
@@ -107,6 +115,50 @@ notebook > header tab:checked {
 
 notebook > header tab:checked label {
     font-weight: 700;
+}
+
+/* ---- Sidebar navigation ------------------------------------------------- */
+
+.sidebar {
+    background-color: mix(@theme_bg_color, @theme_fg_color, 0.03);
+    border-right: 1px solid @hairline;
+    min-width: 210px;
+    padding: 10px 8px;
+}
+
+.sidebar-list {
+    background: transparent;
+}
+
+.sidebar-list > row {
+    border-radius: 8px;
+    margin: 2px;
+    min-height: 0;
+}
+
+.sidebar-list > row:hover {
+    background-color: @hover_bg;
+}
+
+.sidebar-list > row:selected {
+    background-color: alpha(@pactus_blue, 0.16);
+}
+
+.sidebar-list > row:selected .sidebar-label {
+    color: @pactus_blue;
+    font-weight: 700;
+}
+
+.sidebar-row {
+    padding: 10px 12px;
+}
+
+.sidebar-icon {
+    font-size: 15px;
+}
+
+.sidebar-label {
+    font-size: 14px;
 }
 
 /* ---- Buttons ------------------------------------------------------------ */
@@ -149,11 +201,27 @@ button.destructive-action {
 
 /* ---- Entries ------------------------------------------------------------ */
 
+/* Keep all input controls the same height. min-height is only a floor, so the
+   entry padding is kept small and the floor equalizes entries, dropdowns,
+   combo boxes and spin buttons. */
 entry {
     border-radius: 8px;
-    padding: 6px 10px;
+    padding: 3px 10px;
+    min-height: 32px;
     border: 1px solid @hairline;
     transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+spinbutton,
+dropdown > button,
+combobox button {
+    min-height: 32px;
+    border-radius: 8px;
+}
+
+dropdown,
+combobox {
+    min-height: 32px;
 }
 
 entry:focus-within {
@@ -202,11 +270,16 @@ frame > label {
 }
 
 .dialog-box {
-    margin: 12px 6px 8px 6px;
+    margin: 18px 20px 14px 20px;
 }
 
 .dialog-action-bar {
-    padding-top: 8px;
+    padding-top: 14px;
+}
+
+.dialog-action-bar button {
+    min-width: 90px;
+    margin-left: 8px;
 }
 
 .toolbar {
@@ -230,33 +303,29 @@ textview.view {
     margin: 16px;
 }
 
-.card {
-    padding: 14px 16px;
-    min-width: 190px;
+.page-header {
+    margin-bottom: 4px;
 }
 
-.overview-flow > flowboxchild {
-    padding: 0;
+.page-title {
+    font-size: 18px;
+    font-weight: 800;
+}
+
+.card {
+    padding: 16px 18px;
+    min-width: 190px;
+    border-radius: 14px;
+    background-color: @card_bg;
+    border: 1px solid @card_border;
+    box-shadow: 0 1px 3px alpha(@theme_fg_color, 0.06);
 }
 
 .section-title {
     font-weight: 800;
-    font-size: 12px;
+    font-size: 11px;
     color: @muted_fg;
-    margin-bottom: 8px;
-}
-
-.metric {
-    padding: 7px 0;
-    border-bottom: 1px solid @hairline;
-}
-
-.metric-last {
-    border-bottom: none;
-}
-
-.metric-icon {
-    font-size: 15px;
+    margin-bottom: 2px;
 }
 
 .metric-label {
@@ -265,12 +334,46 @@ textview.view {
 }
 
 .metric-value {
-    font-size: 14px;
+    font-size: 15px;
     font-weight: 700;
 }
 
+.metric-mono {
+    font-size: 12px;
+    font-weight: 600;
+    font-family: monospace;
+    background-color: alpha(@theme_fg_color, 0.05);
+    border-radius: 8px;
+    padding: 8px 10px;
+    margin-top: 2px;
+}
+
 .sync-card {
-    padding: 20px 24px;
+    padding: 16px 18px;
+}
+
+.sync-status {
+    font-size: 13px;
+    font-weight: 600;
+    color: @muted_fg;
+    margin-top: 4px;
+}
+
+/* Local Node Info: aligned definition list. */
+.info-key {
+    font-size: 13px;
+    color: @muted_fg;
+}
+
+.info-val {
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.info-mono {
+    font-family: monospace;
+    font-size: 12px;
+    font-weight: 600;
 }
 
 /* ---- Circular sync gauge ------------------------------------------------ */

--- a/cmd/gtk/assets/css/style.css
+++ b/cmd/gtk/assets/css/style.css
@@ -224,6 +224,63 @@ textview.view {
     border: 1px solid @hairline;
 }
 
+/* ---- Node status cards -------------------------------------------------- */
+
+.node-content {
+    margin: 16px;
+}
+
+.card {
+    padding: 14px 16px;
+    min-width: 190px;
+}
+
+.overview-flow > flowboxchild {
+    padding: 0;
+}
+
+.section-title {
+    font-weight: 800;
+    font-size: 12px;
+    color: @muted_fg;
+    margin-bottom: 8px;
+}
+
+.metric {
+    padding: 7px 0;
+    border-bottom: 1px solid @hairline;
+}
+
+.metric-last {
+    border-bottom: none;
+}
+
+.metric-icon {
+    font-size: 15px;
+}
+
+.metric-label {
+    font-size: 11px;
+    color: @muted_fg;
+}
+
+.metric-value {
+    font-size: 14px;
+    font-weight: 700;
+}
+
+.sync-card {
+    padding: 20px 24px;
+}
+
+/* ---- Circular sync gauge ------------------------------------------------ */
+
+.circular-progress-label {
+    font-size: 15px;
+    font-weight: 700;
+    color: @theme_fg_color;
+}
+
 /* ---- Progress + controls ------------------------------------------------ */
 
 progressbar > trough {

--- a/cmd/gtk/assets/css/style.css
+++ b/cmd/gtk/assets/css/style.css
@@ -312,6 +312,11 @@ textview.view {
     font-weight: 800;
 }
 
+.page-subtitle {
+    font-size: 12px;
+    color: @muted_fg;
+}
+
 .card {
     padding: 16px 18px;
     min-width: 190px;
@@ -374,6 +379,86 @@ textview.view {
     font-family: monospace;
     font-size: 12px;
     font-weight: 600;
+}
+
+/* Prominent statistic value used on card headers. */
+.stat-value {
+    font-size: 20px;
+    font-weight: 800;
+}
+
+/* ---- Data table (GtkColumnView) ----------------------------------------- */
+
+.table-card {
+    padding: 16px 18px 12px 18px;
+}
+
+/* Wallet Addresses/Transactions notebook styled as a padded card. */
+notebook.wallet-tabs {
+    background-color: @card_bg;
+    border: 1px solid @card_border;
+    border-radius: 14px;
+    box-shadow: 0 1px 3px alpha(@theme_fg_color, 0.06);
+}
+
+notebook.wallet-tabs > header {
+    background: transparent;
+    border-bottom: 1px solid @hairline;
+    padding: 2px 12px 0 12px;
+}
+
+notebook.wallet-tabs > stack {
+    padding: 16px 20px 18px 20px;
+}
+
+columnview.data-table {
+    background: transparent;
+}
+
+columnview.data-table header button {
+    background: none;
+    border: none;
+    box-shadow: none;
+    min-height: 0;
+    padding: 6px 12px;
+    margin: 0;
+}
+
+columnview.data-table header button label {
+    font-size: 11px;
+    font-weight: 700;
+    color: @muted_fg;
+}
+
+columnview.data-table header {
+    border-bottom: 1px solid @hairline;
+}
+
+columnview.data-table row cell {
+    padding: 9px 12px;
+    border-bottom: 1px solid alpha(@theme_fg_color, 0.06);
+}
+
+columnview.data-table row:hover {
+    background-color: @hover_bg;
+}
+
+columnview.data-table row:selected {
+    background-color: alpha(@pactus_blue, 0.12);
+}
+
+.cell-mono {
+    font-family: monospace;
+    font-size: 12px;
+}
+
+.cell-num {
+    font-size: 13px;
+}
+
+.cell-dim {
+    color: @muted_fg;
+    font-size: 13px;
 }
 
 /* ---- Circular sync gauge ------------------------------------------------ */

--- a/cmd/gtk/assets/icons.go
+++ b/cmd/gtk/assets/icons.go
@@ -56,6 +56,26 @@ var (
 	//go:embed icons/save.svg
 	iconSaveData    []byte
 	IconSaveTexture *gdk.Texture
+
+	//go:embed icons/nav_overview.svg
+	iconNavOverviewData    []byte
+	IconNavOverviewTexture *gdk.Texture
+
+	//go:embed icons/nav_committee.svg
+	iconNavCommitteeData    []byte
+	IconNavCommitteeTexture *gdk.Texture
+
+	//go:embed icons/nav_network.svg
+	iconNavNetworkData    []byte
+	IconNavNetworkTexture *gdk.Texture
+
+	//go:embed icons/nav_validators.svg
+	iconNavValidatorsData    []byte
+	IconNavValidatorsTexture *gdk.Texture
+
+	//go:embed icons/nav_wallet.svg
+	iconNavWalletData    []byte
+	IconNavWalletTexture *gdk.Texture
 )
 
 func initIcons() {
@@ -71,4 +91,9 @@ func initIcons() {
 	IconPrevTexture = TextureFromBytes(iconPrevData)
 	IconNextTexture = TextureFromBytes(iconNextData)
 	IconSaveTexture = TextureFromBytes(iconSaveData)
+	IconNavOverviewTexture = TextureFromBytes(iconNavOverviewData)
+	IconNavCommitteeTexture = TextureFromBytes(iconNavCommitteeData)
+	IconNavNetworkTexture = TextureFromBytes(iconNavNetworkData)
+	IconNavValidatorsTexture = TextureFromBytes(iconNavValidatorsData)
+	IconNavWalletTexture = TextureFromBytes(iconNavWalletData)
 }

--- a/cmd/gtk/assets/icons/nav_committee.svg
+++ b/cmd/gtk/assets/icons/nav_committee.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#217aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
+  <circle cx="9" cy="7" r="4"/>
+  <path d="M22 21v-2a4 4 0 0 0-3-3.87"/>
+  <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+</svg>

--- a/cmd/gtk/assets/icons/nav_network.svg
+++ b/cmd/gtk/assets/icons/nav_network.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#217aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/>
+  <path d="M2 12h20"/>
+</svg>

--- a/cmd/gtk/assets/icons/nav_overview.svg
+++ b/cmd/gtk/assets/icons/nav_overview.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#217aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect width="7" height="9" x="3" y="3" rx="1"/>
+  <rect width="7" height="5" x="14" y="3" rx="1"/>
+  <rect width="7" height="9" x="14" y="12" rx="1"/>
+  <rect width="7" height="5" x="3" y="16" rx="1"/>
+</svg>

--- a/cmd/gtk/assets/icons/nav_validators.svg
+++ b/cmd/gtk/assets/icons/nav_validators.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#217aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/>
+  <path d="m9 12 2 2 4-4"/>
+</svg>

--- a/cmd/gtk/assets/icons/nav_wallet.svg
+++ b/cmd/gtk/assets/icons/nav_wallet.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#217aff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M19 7V4a1 1 0 0 0-1-1H5a2 2 0 0 0 0 4h15a1 1 0 0 1 1 1v4h-3a2 2 0 0 0 0 4h3a1 1 0 0 1-1 1H5a2 2 0 0 1-2-2V5"/>
+</svg>

--- a/cmd/gtk/assets/ui/main_window.ui
+++ b/cmd/gtk/assets/ui/main_window.ui
@@ -1,68 +1,209 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Created with Cambalache 1.0.2 -->
 <interface>
   <!-- interface-name main_window.ui -->
   <requires lib="gio" version="2.0"/>
   <requires lib="gtk" version="4.14"/>
   <object class="GtkApplicationWindow" id="id_main_window">
-    <property name="default-height">640</property>
-    <property name="default-width">920</property>
+    <property name="default-width">1040</property>
     <property name="title">Pactus GUI</property>
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
+        <property name="orientation">horizontal</property>
         <child>
-          <object class="GtkNotebook" id="id_notebook">
+          <object class="GtkBox">
+            <property name="css-classes">sidebar</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkListBox" id="id_sidebar_list">
+                <property name="css-classes">sidebar-list navigation-sidebar</property>
+                <property name="selection-mode">single</property>
+                <property name="vexpand">True</property>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="name">node</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">sidebar-row</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkImage" id="id_icon_overview">
+                            <property name="css-classes">sidebar-icon</property>
+                            <property name="pixel-size">18</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">Node Overview</property>
+                            <property name="css-classes">sidebar-label</property>
+                            <property name="halign">start</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="name">committee</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">sidebar-row</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkImage" id="id_icon_committee">
+                            <property name="css-classes">sidebar-icon</property>
+                            <property name="pixel-size">18</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">Committee</property>
+                            <property name="css-classes">sidebar-label</property>
+                            <property name="halign">start</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="name">network</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">sidebar-row</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkImage" id="id_icon_network">
+                            <property name="css-classes">sidebar-icon</property>
+                            <property name="pixel-size">18</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">Network</property>
+                            <property name="css-classes">sidebar-label</property>
+                            <property name="halign">start</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="name">validators</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">sidebar-row</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkImage" id="id_icon_validators">
+                            <property name="css-classes">sidebar-icon</property>
+                            <property name="pixel-size">18</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">My Validators</property>
+                            <property name="css-classes">sidebar-label</property>
+                            <property name="halign">start</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkListBoxRow">
+                    <property name="name">wallet</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">sidebar-row</property>
+                        <property name="spacing">12</property>
+                        <child>
+                          <object class="GtkImage" id="id_icon_wallet">
+                            <property name="css-classes">sidebar-icon</property>
+                            <property name="pixel-size">18</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">Wallet</property>
+                            <property name="css-classes">sidebar-label</property>
+                            <property name="halign">start</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStack" id="id_main_stack">
+            <property name="hexpand">True</property>
             <property name="vexpand">True</property>
+            <property name="hhomogeneous">False</property>
+            <property name="vhomogeneous">False</property>
+            <property name="transition-type">crossfade</property>
             <child>
-              <object class="GtkBox" id="id_box_node">
-                <property name="homogeneous">True</property>
-              </object>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel">
-                <property name="justify">right</property>
-                <property name="label">Node </property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox" id="id_box_committee">
-                <property name="homogeneous">True</property>
-              </object>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel">
-                <property name="label">Committee</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox" id="id_box_network">
-                <property name="homogeneous">True</property>
-              </object>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel">
-                <property name="label">Network</property>
+              <object class="GtkStackPage">
+                <property name="name">node</property>
+                <property name="child">
+                  <object class="GtkScrolledWindow">
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="propagate-natural-height">True</property>
+                    <property name="propagate-natural-width">True</property>
+                    <property name="child">
+                      <object class="GtkBox" id="id_box_node">
+                        <property name="orientation">vertical</property>
+                      </object>
+                    </property>
+                  </object>
+                </property>
               </object>
             </child>
             <child>
-              <object class="GtkBox" id="id_box_validators">
-                <property name="homogeneous">True</property>
-              </object>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel">
-                <property name="label">My Validators</property>
+              <object class="GtkStackPage">
+                <property name="name">committee</property>
+                <property name="child">
+                  <object class="GtkBox" id="id_box_committee">
+                    <property name="orientation">vertical</property>
+                  </object>
+                </property>
               </object>
             </child>
             <child>
-              <object class="GtkBox" id="id_box_wallet">
-                <property name="homogeneous">True</property>
+              <object class="GtkStackPage">
+                <property name="name">network</property>
+                <property name="child">
+                  <object class="GtkBox" id="id_box_network">
+                    <property name="orientation">vertical</property>
+                  </object>
+                </property>
               </object>
             </child>
-            <child type="tab">
-              <object class="GtkLabel">
-                <property name="label">Wallet</property>
+            <child>
+              <object class="GtkStackPage">
+                <property name="name">validators</property>
+                <property name="child">
+                  <object class="GtkBox" id="id_box_validators">
+                    <property name="orientation">vertical</property>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkStackPage">
+                <property name="name">wallet</property>
+                <property name="child">
+                  <object class="GtkBox" id="id_box_wallet">
+                    <property name="orientation">vertical</property>
+                  </object>
+                </property>
               </object>
             </child>
           </object>

--- a/cmd/gtk/assets/ui/widget_committee.ui
+++ b/cmd/gtk/assets/ui/widget_committee.ui
@@ -1,136 +1,147 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Created with Cambalache 1.0.2 -->
 <interface>
   <!-- interface-name widget_committee.ui -->
   <requires lib="gtk" version="4.14"/>
   <object class="GtkBox" id="id_box_committee">
-    <property name="homogeneous">True</property>
+    <property name="css-classes">node-content</property>
     <property name="orientation">vertical</property>
+    <property name="spacing">12</property>
+
     <child>
-      <object class="GtkNotebook">
-        <property name="tab-pos">left</property>
+      <object class="GtkLabel">
+        <property name="label">Committee</property>
+        <property name="css-classes">page-title</property>
+        <property name="halign">start</property>
+        <property name="xalign">0</property>
+      </object>
+    </child>
+
+    <!-- Info stat cards -->
+    <child>
+      <object class="GtkBox" id="id_box_committee_info">
+        <property name="homogeneous">True</property>
+        <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" id="id_box_committee_info">
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
             <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
             <child>
-              <object class="GtkGrid">
-                <property name="column-spacing">8</property>
-                <property name="css-classes">widget-grid</property>
-                <property name="row-spacing">8</property>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Committee Size:</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_committee_size">
-                    <property name="halign">start</property>
-                    <property name="selectable">True</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Committee Power:</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_committee_power">
-                    <property name="halign">start</property>
-                    <property name="selectable">True</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Total Power:</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">2</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_total_power">
-                    <property name="halign">start</property>
-                    <property name="selectable">True</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">2</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Protocol Versions:</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">3</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_protocol_versions">
-                    <property name="halign">start</property>
-                    <property name="selectable">True</property>
-                    <property name="valign">start</property>
-                    <property name="wrap">True</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">3</property>
-                    </layout>
-                  </object>
-                </child>
+              <object class="GtkLabel">
+                <property name="label">Committee Size</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_committee_size">
+                <property name="css-classes">stat-value</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="selectable">True</property>
               </object>
             </child>
           </object>
         </child>
-        <child type="tab">
-          <object class="GtkLabel">
-            <property name="label">_Info</property>
-            <property name="use-underline">True</property>
+        <child>
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Committee Power</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_committee_power">
+                <property name="css-classes">stat-value</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
+              </object>
+            </child>
           </object>
         </child>
         <child>
-          <object class="GtkBox" id="id_box_committee_members">
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
             <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
             <child>
-              <object class="GtkScrolledWindow">
+              <object class="GtkLabel">
+                <property name="label">Total Power</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_total_power">
+                <property name="css-classes">stat-value</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Protocol Versions</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_protocol_versions">
+                <property name="css-classes">metric-value</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="valign">start</property>
+                <property name="selectable">True</property>
+                <property name="wrap">True</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <!-- Members table -->
+    <child>
+      <object class="GtkBox" id="id_box_committee_members">
+        <property name="css-classes">card table-card</property>
+        <property name="orientation">vertical</property>
+        <property name="vexpand">True</property>
+        <property name="spacing">10</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="label">Members</property>
+            <property name="css-classes">section-title</property>
+            <property name="halign">start</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="hscrollbar-policy">never</property>
+            <child>
+              <object class="GtkColumnView" id="id_columnview_committee_members">
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
-                <child>
-                  <object class="GtkColumnView" id="id_columnview_committee_members">
-                    <property name="hexpand">True</property>
-                    <property name="single-click-activate">True</property>
-                    <property name="vexpand">True</property>
-                  </object>
-                </child>
+                <property name="single-click-activate">True</property>
               </object>
             </child>
-          </object>
-        </child>
-        <child type="tab">
-          <object class="GtkLabel">
-            <property name="label">_Members</property>
-            <property name="use-underline">True</property>
           </object>
         </child>
       </object>

--- a/cmd/gtk/assets/ui/widget_network.ui
+++ b/cmd/gtk/assets/ui/widget_network.ui
@@ -1,92 +1,98 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Created with Cambalache 1.0.2 -->
 <interface>
   <!-- interface-name widget_network.ui -->
-  <requires lib="gtk" version="4.14" />
+  <requires lib="gtk" version="4.14"/>
   <object class="GtkBox" id="id_box_network">
-    <property name="homogeneous">True</property>
+    <property name="css-classes">node-content</property>
     <property name="orientation">vertical</property>
+    <property name="spacing">12</property>
+
     <child>
-      <object class="GtkNotebook">
-        <property name="tab-pos">left</property>
+      <object class="GtkLabel">
+        <property name="label">Network</property>
+        <property name="css-classes">page-title</property>
+        <property name="halign">start</property>
+        <property name="xalign">0</property>
+      </object>
+    </child>
+
+    <child>
+      <object class="GtkBox" id="id_box_network_info">
+        <property name="homogeneous">True</property>
+        <property name="spacing">12</property>
         <child>
-          <object class="GtkBox" id="id_box_network_info">
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
             <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
             <child>
-              <object class="GtkGrid">
-                <property name="css-classes">widget-grid</property>
-                <property name="column-spacing">8</property>
-                <property name="row-spacing">8</property>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Network Name:</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_network_name">
-                    <property name="halign">start</property>
-                    <property name="selectable">True</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Connected Peers:</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_connected_peers">
-                    <property name="halign">start</property>
-                    <property name="selectable">True</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">1</property>
-                    </layout>
-                  </object>
-                </child>
+              <object class="GtkLabel">
+                <property name="label">Network Name</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_network_name">
+                <property name="css-classes">stat-value</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
               </object>
             </child>
           </object>
         </child>
-        <child type="tab">
+        <child>
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Connected Peers</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_connected_peers">
+                <property name="css-classes">stat-value</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="selectable">True</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <child>
+      <object class="GtkBox" id="id_box_network_peers">
+        <property name="css-classes">card table-card</property>
+        <property name="orientation">vertical</property>
+        <property name="vexpand">True</property>
+        <property name="spacing">10</property>
+        <child>
           <object class="GtkLabel">
-            <property name="label">_Info</property>
-            <property name="use-underline">True</property>
+            <property name="label">Peers</property>
+            <property name="css-classes">section-title</property>
+            <property name="halign">start</property>
           </object>
         </child>
         <child>
-          <object class="GtkBox" id="id_box_network_peers">
-            <property name="orientation">vertical</property>
+          <object class="GtkScrolledWindow">
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="hscrollbar-policy">never</property>
             <child>
-              <object class="GtkScrolledWindow">
+              <object class="GtkColumnView" id="id_columnview_peers">
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
-                <child>
-                  <object class="GtkColumnView" id="id_columnview_peers">
-                    <property name="vexpand">True</property>
-                  </object>
-                </child>
+                <property name="single-click-activate">True</property>
               </object>
             </child>
-          </object>
-        </child>
-        <child type="tab">
-          <object class="GtkLabel">
-            <property name="label">_Peers</property>
-            <property name="use-underline">True</property>
           </object>
         </child>
       </object>

--- a/cmd/gtk/assets/ui/widget_node.ui
+++ b/cmd/gtk/assets/ui/widget_node.ui
@@ -3,649 +3,494 @@
   <!-- interface-name widget_node.ui -->
   <requires lib="gtk" version="4.14"/>
   <object class="GtkBox" id="id_box_node">
+    <property name="css-classes">node-content</property>
     <property name="orientation">vertical</property>
+    <property name="spacing">12</property>
+
+    <!-- Page header with quick transaction actions -->
     <child>
-      <object class="GtkScrolledWindow">
+      <object class="GtkBox">
+        <property name="css-classes">page-header</property>
+        <property name="spacing">8</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="label">Node Overview</property>
+            <property name="css-classes">page-title</property>
+            <property name="halign">start</property>
+            <property name="hexpand">True</property>
+            <property name="xalign">0</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton">
+            <property name="label">Transfer</property>
+            <property name="action-name">app.transfer</property>
+            <property name="css-classes">suggested-action</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton">
+            <property name="label">Bond</property>
+            <property name="action-name">app.bond</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton">
+            <property name="label">Unbond</property>
+            <property name="action-name">app.unbond</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton">
+            <property name="label">Withdraw</property>
+            <property name="action-name">app.withdraw</property>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <!-- Three columns that fill the available height -->
+    <child>
+      <object class="GtkBox">
+        <property name="homogeneous">True</property>
         <property name="hexpand">True</property>
-        <property name="vexpand">True</property>
-        <property name="hscrollbar-policy">never</property>
+        <property name="valign">start</property>
+        <property name="spacing">12</property>
+
+        <!-- Network Health -->
         <child>
           <object class="GtkBox">
-            <property name="css-classes">node-content</property>
+            <property name="css-classes">card</property>
             <property name="orientation">vertical</property>
             <property name="spacing">14</property>
-
-            <!-- Metric cards grid (reflows on narrow windows) -->
             <child>
-              <object class="GtkFlowBox">
-                <property name="css-classes">overview-flow</property>
-                <property name="selection-mode">none</property>
-                <property name="homogeneous">True</property>
-                <property name="max-children-per-line">3</property>
-                <property name="min-children-per-line">1</property>
-                <property name="column-spacing">14</property>
-                <property name="row-spacing">14</property>
-
-                <!-- Network Health -->
+              <object class="GtkLabel">
+                <property name="label">Network Health</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox">
-                    <property name="css-classes">card</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">2</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="label">Network Health</property>
-                        <property name="css-classes">section-title</property>
-                        <property name="halign">start</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">⛓️</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Synced Height</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_last_block_height">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">🕔</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Last Block</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_last_block_time">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="wrap">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">📡</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Connections</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_num_connections">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">🔍</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Reachability</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_reachability">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric metric-last</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">⏰</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Clock Offset</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_clock_offset">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                  <object class="GtkLabel">
+                    <property name="label">Synced Height</property>
+                    <property name="css-classes">metric-label</property>
+                    <property name="halign">start</property>
                   </object>
                 </child>
-
-                <!-- Validator Network -->
                 <child>
-                  <object class="GtkBox">
-                    <property name="css-classes">card</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">2</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="label">Validator Network</property>
-                        <property name="css-classes">section-title</property>
-                        <property name="halign">start</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">✅</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Active Validators</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_active_validators">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">✨</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Total Staked Power</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_total_power">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">📈</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Average Score</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_average_score">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric metric-last</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">💎</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">In Committee Now</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_in_committee">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-
-                <!-- Local Node Info -->
-                <child>
-                  <object class="GtkBox">
-                    <property name="css-classes">card</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">2</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="label">Local Node Info</property>
-                        <property name="css-classes">section-title</property>
-                        <property name="halign">start</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">📁</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel" id="id_label_connection_type">
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_connection_value">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap-mode">char</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">🌐</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Network</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_network">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">🧾</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Network ID</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_network_id">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap-mode">char</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">🤖</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Node Agent</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_agent">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                                <property name="wrap">True</property>
-                                <property name="wrap-mode">char</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">🔰</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Moniker</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_moniker">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                                <property name="selectable">True</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric metric-last</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">✂️</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Pruned</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_is_prune">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                  <object class="GtkLabel" id="id_label_last_block_height">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
                   </object>
                 </child>
               </object>
             </child>
-
-            <!-- Synchronization card -->
             <child>
               <object class="GtkBox">
-                <property name="css-classes">card sync-card</property>
-                <property name="spacing">28</property>
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="id_sync_container">
+                  <object class="GtkLabel">
+                    <property name="label">Last Block</property>
+                    <property name="css-classes">metric-label</property>
+                    <property name="halign">start</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="id_label_last_block_time">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                    <property name="ellipsize">end</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Connections</property>
+                    <property name="css-classes">metric-label</property>
+                    <property name="halign">start</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="id_label_num_connections">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                    <property name="selectable">True</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Reachability</property>
+                    <property name="css-classes">metric-label</property>
+                    <property name="halign">start</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="id_label_reachability">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                    <property name="selectable">True</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Clock Offset</property>
+                    <property name="css-classes">metric-label</property>
+                    <property name="halign">start</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="id_label_clock_offset">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <!-- Validator Network -->
+        <child>
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">14</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Validator Network</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Active Validators</property>
+                    <property name="css-classes">metric-label</property>
+                    <property name="halign">start</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="id_label_active_validators">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                    <property name="selectable">True</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Total Staked Power</property>
+                    <property name="css-classes">metric-label</property>
+                    <property name="halign">start</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="id_label_total_power">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                    <property name="selectable">True</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Average Score</property>
+                    <property name="css-classes">metric-label</property>
+                    <property name="halign">start</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="id_label_average_score">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                    <property name="selectable">True</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">In Committee Now</property>
+                    <property name="css-classes">metric-label</property>
+                    <property name="halign">start</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="id_label_in_committee">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+
+        <!-- Sync Status hero -->
+        <child>
+          <object class="GtkBox">
+            <property name="css-classes">card sync-card</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Sync Status</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="id_sync_container">
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="margin-top">8</property>
+                <property name="margin-bottom">8</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_sync_status">
+                <property name="css-classes">sync-status</property>
+                <property name="halign">center</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">metric</property>
+                <property name="orientation">vertical</property>
+                <property name="halign">center</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label">Remaining Blocks</property>
+                    <property name="css-classes">metric-label</property>
                     <property name="halign">center</property>
-                    <property name="valign">center</property>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkBox">
-                    <property name="orientation">vertical</property>
-                    <property name="valign">center</property>
-                    <property name="hexpand">True</property>
-                    <property name="spacing">4</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="label">Synchronization Progress</property>
-                        <property name="css-classes">section-title</property>
-                        <property name="halign">start</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="css-classes">metric metric-last</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="label">📦</property>
-                            <property name="css-classes">metric-icon</property>
-                            <property name="valign">start</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="label">Remaining Blocks</property>
-                                <property name="css-classes">metric-label</property>
-                                <property name="halign">start</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="id_label_blocks_left">
-                                <property name="css-classes">metric-value</property>
-                                <property name="halign">start</property>
-                                <property name="xalign">0</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                  <object class="GtkLabel" id="id_label_blocks_left">
+                    <property name="css-classes">metric-value</property>
+                    <property name="halign">center</property>
                   </object>
                 </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <!-- Local Node Info -->
+    <child>
+      <object class="GtkBox">
+        <property name="css-classes">card</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">12</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="label">Local Node Info</property>
+            <property name="css-classes">section-title</property>
+            <property name="halign">start</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="css-classes">info-grid</property>
+            <property name="column-spacing">24</property>
+            <property name="row-spacing">10</property>
+            <child>
+              <object class="GtkLabel" id="id_label_connection_type">
+                <property name="css-classes">info-key</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_connection_value">
+                <property name="css-classes">info-val</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="hexpand">True</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Network</property>
+                <property name="css-classes">info-key</property>
+                <property name="halign">start</property>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_network">
+                <property name="css-classes">info-val</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="hexpand">True</property>
+                <property name="selectable">True</property>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Moniker</property>
+                <property name="css-classes">info-key</property>
+                <property name="halign">start</property>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">2</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_moniker">
+                <property name="css-classes">info-val</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="hexpand">True</property>
+                <property name="selectable">True</property>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">2</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Pruned</property>
+                <property name="css-classes">info-key</property>
+                <property name="halign">start</property>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">3</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_is_prune">
+                <property name="css-classes">info-val</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="hexpand">True</property>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">3</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Node Agent</property>
+                <property name="css-classes">info-key</property>
+                <property name="halign">start</property>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">4</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_agent">
+                <property name="css-classes">info-val</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="hexpand">True</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">4</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Network ID</property>
+                <property name="css-classes">info-key</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
+                <layout>
+                  <property name="column">0</property>
+                  <property name="row">5</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_network_id">
+                <property name="css-classes">info-val info-mono</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="hexpand">True</property>
+                <property name="selectable">True</property>
+                <property name="wrap">True</property>
+                <property name="wrap-mode">char</property>
+                <layout>
+                  <property name="column">1</property>
+                  <property name="row">5</property>
+                </layout>
               </object>
             </child>
           </object>

--- a/cmd/gtk/assets/ui/widget_node.ui
+++ b/cmd/gtk/assets/ui/widget_node.ui
@@ -1,383 +1,653 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Created with Cambalache 1.0.2 -->
 <interface>
   <!-- interface-name widget_node.ui -->
   <requires lib="gtk" version="4.14"/>
   <object class="GtkBox" id="id_box_node">
-    <property name="baseline-position">top</property>
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkGrid">
-        <property name="css-classes">widget-grid</property>
-        <property name="column-spacing">8</property>
+      <object class="GtkScrolledWindow">
         <property name="hexpand">True</property>
-        <property name="row-spacing">8</property>
         <property name="vexpand">True</property>
+        <property name="hscrollbar-policy">never</property>
         <child>
-          <object class="GtkLabel" id="id_label_connection_type">
-            <property name="halign">start</property>
-            <property name="label"/>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">0</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_connection_value">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">0</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">🌐 Network:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">1</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_network">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">1</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">🧾 Network ID:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">2</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_network_id">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">2</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">🤖 Node Agent:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">3</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_agent">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">3</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">⏰ Clock Offset:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">4</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_clock_offset">
-            <property name="halign">start</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">4</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">📡 Connections:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">5</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_num_connections">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">5</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">🔰 Moniker:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">6</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_moniker">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">6</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">🔍 Reachability:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">7</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_reachability">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">7</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">✂️ Pruned:</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">8</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_is_prune">
-            <property name="halign">start</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">8</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">✅ Active Validators:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">9</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_active_validators">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">9</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">✨ Total Power:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">10</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_total_power">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">10</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">📈 Average Score:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">11</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_average_score">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">11</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">💎 In Committee Now:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">12</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_in_committee">
-            <property name="halign">start</property>
-            <property name="selectable">True</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">12</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">⛓️ Last Block Height:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">13</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_last_block_height">
-            <property name="halign">start</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">13</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">🕔 Last Block Time:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">14</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_last_block_time">
-            <property name="halign">start</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">14</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">📦 Remaining Blocks:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">15</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="id_label_blocks_left">
-            <property name="halign">start</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">15</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="halign">start</property>
-            <property name="label">🔄 Syncing Progress:</property>
-            <property name="valign">start</property>
-            <layout>
-              <property name="column">0</property>
-              <property name="row">16</property>
-            </layout>
-          </object>
-        </child>
-        <child>
-          <object class="GtkProgressBar" id="id_progress_synced">
-            <property name="pulse-step">0.01</property>
-            <property name="show-text">True</property>
-            <layout>
-              <property name="column">1</property>
-              <property name="row">16</property>
-            </layout>
+          <object class="GtkBox">
+            <property name="css-classes">node-content</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">14</property>
+
+            <!-- Metric cards grid (reflows on narrow windows) -->
+            <child>
+              <object class="GtkFlowBox">
+                <property name="css-classes">overview-flow</property>
+                <property name="selection-mode">none</property>
+                <property name="homogeneous">True</property>
+                <property name="max-children-per-line">3</property>
+                <property name="min-children-per-line">1</property>
+                <property name="column-spacing">14</property>
+                <property name="row-spacing">14</property>
+
+                <!-- Network Health -->
+                <child>
+                  <object class="GtkBox">
+                    <property name="css-classes">card</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">2</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">Network Health</property>
+                        <property name="css-classes">section-title</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">⛓️</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Synced Height</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_last_block_height">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">🕔</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Last Block</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_last_block_time">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="wrap">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">📡</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Connections</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_num_connections">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">🔍</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Reachability</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_reachability">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric metric-last</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">⏰</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Clock Offset</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_clock_offset">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+
+                <!-- Validator Network -->
+                <child>
+                  <object class="GtkBox">
+                    <property name="css-classes">card</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">2</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">Validator Network</property>
+                        <property name="css-classes">section-title</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">✅</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Active Validators</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_active_validators">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">✨</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Total Staked Power</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_total_power">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">📈</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Average Score</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_average_score">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric metric-last</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">💎</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">In Committee Now</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_in_committee">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+
+                <!-- Local Node Info -->
+                <child>
+                  <object class="GtkBox">
+                    <property name="css-classes">card</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">2</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">Local Node Info</property>
+                        <property name="css-classes">section-title</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">📁</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel" id="id_label_connection_type">
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_connection_value">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                                <property name="wrap">True</property>
+                                <property name="wrap-mode">char</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">🌐</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Network</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_network">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">🧾</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Network ID</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_network_id">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                                <property name="wrap">True</property>
+                                <property name="wrap-mode">char</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">🤖</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Node Agent</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_agent">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                                <property name="wrap">True</property>
+                                <property name="wrap-mode">char</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">🔰</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Moniker</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_moniker">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                                <property name="selectable">True</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric metric-last</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">✂️</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Pruned</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_is_prune">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+
+            <!-- Synchronization card -->
+            <child>
+              <object class="GtkBox">
+                <property name="css-classes">card sync-card</property>
+                <property name="spacing">28</property>
+                <child>
+                  <object class="GtkBox" id="id_sync_container">
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <property name="valign">center</property>
+                    <property name="hexpand">True</property>
+                    <property name="spacing">4</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label">Synchronization Progress</property>
+                        <property name="css-classes">section-title</property>
+                        <property name="halign">start</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="css-classes">metric metric-last</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label">📦</property>
+                            <property name="css-classes">metric-icon</property>
+                            <property name="valign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="label">Remaining Blocks</property>
+                                <property name="css-classes">metric-label</property>
+                                <property name="halign">start</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="id_label_blocks_left">
+                                <property name="css-classes">metric-value</property>
+                                <property name="halign">start</property>
+                                <property name="xalign">0</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/cmd/gtk/assets/ui/widget_validator.ui
+++ b/cmd/gtk/assets/ui/widget_validator.ui
@@ -1,16 +1,46 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Created with Cambalache 1.0.2 -->
 <interface>
   <!-- interface-name widget_validator.ui -->
-  <requires lib="gtk" version="4.14" />
+  <requires lib="gtk" version="4.14"/>
   <object class="GtkBox" id="id_box_validator">
+    <property name="css-classes">node-content</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">12</property>
+
     <child>
-      <object class="GtkScrolledWindow">
-        <property name="hexpand">True</property>
+      <object class="GtkLabel">
+        <property name="label">My Validators</property>
+        <property name="css-classes">page-title</property>
+        <property name="halign">start</property>
+        <property name="xalign">0</property>
+      </object>
+    </child>
+
+    <child>
+      <object class="GtkBox">
+        <property name="css-classes">card table-card</property>
+        <property name="orientation">vertical</property>
         <property name="vexpand">True</property>
+        <property name="spacing">10</property>
         <child>
-          <object class="GtkColumnView" id="id_columnview_validators">
+          <object class="GtkLabel">
+            <property name="label">Validators</property>
+            <property name="css-classes">section-title</property>
+            <property name="halign">start</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="hexpand">True</property>
             <property name="vexpand">True</property>
+            <property name="hscrollbar-policy">never</property>
+            <child>
+              <object class="GtkColumnView" id="id_columnview_validators">
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="single-click-activate">True</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/cmd/gtk/assets/ui/widget_wallet.ui
+++ b/cmd/gtk/assets/ui/widget_wallet.ui
@@ -1,241 +1,278 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- Created with Cambalache 1.0.2 -->
 <interface>
   <!-- interface-name widget_wallet.ui -->
   <requires lib="gtk" version="4.14"/>
   <object class="GtkBox" id="id_box_wallet">
-    <property name="css-classes">widget-main-box</property>
-    <property name="homogeneous">True</property>
+    <property name="css-classes">node-content</property>
     <property name="orientation">vertical</property>
+    <property name="spacing">12</property>
+
+    <!-- Header with wallet actions -->
     <child>
-      <object class="GtkNotebook">
-        <property name="tab-pos">left</property>
+      <object class="GtkBox">
+        <property name="css-classes">page-header</property>
+        <property name="spacing">8</property>
         <child>
-          <object class="GtkBox" id="id_box_wallet_info">
+          <object class="GtkBox">
             <property name="orientation">vertical</property>
+            <property name="hexpand">True</property>
+            <property name="valign">center</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Wallet</property>
+                <property name="css-classes">page-title</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_wallet_name">
+                <property name="css-classes">page-subtitle</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="selectable">True</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="id_button_new_address">
+            <property name="css-classes">suggested-action</property>
+            <property name="valign">center</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="id_button_set_default_fee">
+            <property name="valign">center</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="id_button_change_password">
+            <property name="valign">center</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="id_button_show_seed">
+            <property name="valign">center</property>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <!-- Balance stat cards -->
+    <child>
+      <object class="GtkBox" id="id_box_wallet_info">
+        <property name="homogeneous">True</property>
+        <property name="spacing">12</property>
+        <child>
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Total Balance</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_wallet_total_balance">
+                <property name="css-classes">stat-value</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Total Stake</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_wallet_total_stake">
+                <property name="css-classes">stat-value</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="css-classes">card</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="label">Default Fee</property>
+                <property name="css-classes">section-title</property>
+                <property name="halign">start</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="id_label_wallet_default_fee">
+                <property name="css-classes">stat-value</property>
+                <property name="halign">start</property>
+                <property name="xalign">0</property>
+                <property name="selectable">True</property>
+                <property name="ellipsize">end</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <!-- Wallet details -->
+    <child>
+      <object class="GtkBox">
+        <property name="css-classes">card</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">10</property>
+        <child>
+          <object class="GtkBox">
+            <property name="homogeneous">True</property>
+            <property name="spacing">24</property>
             <child>
               <object class="GtkGrid">
-                <property name="column-spacing">8</property>
-                <property name="css-classes">widget-grid</property>
-                <property name="hexpand">True</property>
-                <property name="row-spacing">8</property>
-                <property name="vexpand">True</property>
+                <property name="css-classes">info-grid</property>
+                <property name="column-spacing">16</property>
+                <property name="row-spacing">10</property>
                 <child>
                   <object class="GtkLabel">
+                    <property name="label">Driver</property>
+                    <property name="css-classes">info-key</property>
                     <property name="halign">start</property>
-                    <property name="label">Name:</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_wallet_name">
-                    <property name="halign">start</property>
-                    <property name="selectable">True</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Location:</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_wallet_location">
-                    <property name="halign">start</property>
-                    <property name="selectable">True</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Driver:</property>
-                    <property name="selectable">True</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">2</property>
-                    </layout>
+                    <layout><property name="column">0</property><property name="row">0</property></layout>
                   </object>
                 </child>
                 <child>
                   <object class="GtkLabel" id="id_label_wallet_driver">
+                    <property name="css-classes">info-val</property>
                     <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                    <property name="hexpand">True</property>
                     <property name="selectable">True</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">2</property>
-                    </layout>
+                    <layout><property name="column">1</property><property name="row">0</property></layout>
                   </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
+                    <property name="label">Created At</property>
+                    <property name="css-classes">info-key</property>
                     <property name="halign">start</property>
-                    <property name="label">Created At:</property>
-                    <property name="selectable">True</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">3</property>
-                    </layout>
+                    <layout><property name="column">0</property><property name="row">1</property></layout>
                   </object>
                 </child>
                 <child>
                   <object class="GtkLabel" id="id_label_wallet_created_at">
+                    <property name="css-classes">info-val</property>
                     <property name="halign">start</property>
+                    <property name="xalign">0</property>
+                    <property name="hexpand">True</property>
                     <property name="selectable">True</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">3</property>
-                    </layout>
+                    <layout><property name="column">1</property><property name="row">1</property></layout>
                   </object>
                 </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="css-classes">info-grid</property>
+                <property name="column-spacing">16</property>
+                <property name="row-spacing">10</property>
                 <child>
                   <object class="GtkLabel">
+                    <property name="label">Encrypted</property>
+                    <property name="css-classes">info-key</property>
                     <property name="halign">start</property>
-                    <property name="label">Encrypted:</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">4</property>
-                    </layout>
+                    <layout><property name="column">0</property><property name="row">0</property></layout>
                   </object>
                 </child>
                 <child>
                   <object class="GtkLabel" id="id_label_wallet_encrypted">
+                    <property name="css-classes">info-val</property>
                     <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">4</property>
-                    </layout>
+                    <property name="xalign">0</property>
+                    <property name="hexpand">True</property>
+                    <layout><property name="column">1</property><property name="row">0</property></layout>
                   </object>
                 </child>
                 <child>
                   <object class="GtkLabel">
+                    <property name="label">Location</property>
+                    <property name="css-classes">info-key</property>
                     <property name="halign">start</property>
-                    <property name="label">Total Balance:</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">5</property>
-                    </layout>
+                    <layout><property name="column">0</property><property name="row">1</property></layout>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="id_label_wallet_total_balance">
+                  <object class="GtkLabel" id="id_label_wallet_location">
+                    <property name="css-classes">info-val</property>
                     <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">5</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Total Stake:</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">6</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_wallet_total_stake">
-                    <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">6</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="halign">start</property>
-                    <property name="label">Default Fee:</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">7</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="id_label_wallet_default_fee">
-                    <property name="halign">start</property>
-                    <property name="valign">start</property>
-                    <layout>
-                      <property name="column">1</property>
-                      <property name="row">7</property>
-                    </layout>
+                    <property name="xalign">0</property>
+                    <property name="hexpand">True</property>
+                    <property name="selectable">True</property>
+                    <property name="ellipsize">end</property>
+                    <layout><property name="column">1</property><property name="row">1</property></layout>
                   </object>
                 </child>
               </object>
             </child>
           </object>
         </child>
-        <child type="tab">
-          <object class="GtkLabel">
-            <property name="label">Info</property>
-          </object>
-        </child>
+      </object>
+    </child>
+
+    <!-- Addresses / Transactions -->
+    <child>
+      <object class="GtkNotebook">
+        <property name="css-classes">wallet-tabs</property>
+        <property name="vexpand">True</property>
         <child>
           <object class="GtkBox" id="id_box_wallet_addresses">
             <property name="orientation">vertical</property>
+            <property name="spacing">10</property>
             <child>
               <object class="GtkBox">
-                <property name="orientation">vertical</property>
+                <property name="spacing">8</property>
                 <child>
-                  <object class="GtkScrolledWindow">
-                    <child>
-                      <object class="GtkColumnView" id="id_columnview_addresses">
-                        <property name="vexpand">True</property>
-                      </object>
-                    </child>
+                  <object class="GtkLabel">
+                    <property name="label">Addresses</property>
+                    <property name="css-classes">section-title</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkBox">
-                    <property name="css-classes">toolbar</property>
-                    <child>
-                      <object class="GtkButton" id="id_button_refresh_addresses"/>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="id_button_new_address"/>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="id_button_set_default_fee"/>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="id_button_change_password"/>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="id_button_show_seed"/>
-                    </child>
+                  <object class="GtkButton" id="id_button_refresh_addresses">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <child>
+                  <object class="GtkColumnView" id="id_columnview_addresses">
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
                   </object>
                 </child>
               </object>
@@ -250,30 +287,44 @@
         <child>
           <object class="GtkBox" id="id_box_wallet_transactions">
             <property name="orientation">vertical</property>
+            <property name="spacing">10</property>
             <child>
               <object class="GtkBox">
-                <property name="orientation">vertical</property>
+                <property name="spacing">8</property>
                 <child>
-                  <object class="GtkScrolledWindow">
-                    <child>
-                      <object class="GtkColumnView" id="id_columnview_transactions">
-                        <property name="vexpand">True</property>
-                      </object>
-                    </child>
+                  <object class="GtkLabel">
+                    <property name="label">Transactions</property>
+                    <property name="css-classes">section-title</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkBox">
-                    <property name="css-classes">toolbar</property>
-                    <child>
-                      <object class="GtkButton" id="id_button_tx_refresh"/>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="id_button_tx_prev"/>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="id_button_tx_next"/>
-                    </child>
+                  <object class="GtkButton" id="id_button_tx_refresh">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="id_button_tx_prev">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="id_button_tx_next">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <child>
+                  <object class="GtkColumnView" id="id_columnview_transactions">
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
                   </object>
                 </child>
               </object>

--- a/cmd/gtk/controller/committee_widget_controller.go
+++ b/cmd/gtk/controller/committee_widget_controller.go
@@ -48,27 +48,33 @@ func NewCommitteeWidgetController(
 
 func (c *CommitteeWidgetController) BuildView(ctx context.Context) error {
 	gtkutil.IdleAddSync(func() {
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewMembers, "No", func(row committeeRow) string {
-			return strconv.Itoa(row.no)
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewMembers, "Address", func(row committeeRow) string {
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewMembers, "No", 0, false, "cell-dim",
+			func(row committeeRow) string {
+				return strconv.Itoa(row.no)
+			})
+		gtkutil.ColumnViewAppendAddressColumn(c.view.ColViewMembers, "Address", func(row committeeRow) string {
 			return row.val.GetAddress()
 		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewMembers, "Stake", func(row committeeRow) string {
-			return amount.Amount(row.val.GetStake()).String()
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewMembers, "Bonding Height", func(row committeeRow) string {
-			return strconv.Itoa(int(row.val.GetLastBondingHeight()))
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewMembers, "Sortition Height", func(row committeeRow) string {
-			return strconv.Itoa(int(row.val.GetLastSortitionHeight()))
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewMembers, "Protocol Version", func(row committeeRow) string {
-			return strconv.Itoa(int(row.val.GetProtocolVersion()))
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewMembers, "Availability Score", func(row committeeRow) string {
-			return gtkutil.AvailabilityScorePercent(row.val.GetAvailabilityScore())
-		})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewMembers, "Stake", 1, false, "cell-num",
+			func(row committeeRow) string {
+				return amount.Amount(row.val.GetStake()).String()
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewMembers, "Bonding Height", 1, false, "cell-num",
+			func(row committeeRow) string {
+				return strconv.Itoa(int(row.val.GetLastBondingHeight()))
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewMembers, "Sortition Height", 1, false, "cell-num",
+			func(row committeeRow) string {
+				return strconv.Itoa(int(row.val.GetLastSortitionHeight()))
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewMembers, "Protocol", 1, false, "cell-num",
+			func(row committeeRow) string {
+				return strconv.Itoa(int(row.val.GetProtocolVersion()))
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewMembers, "Availability", 1, false, "cell-num",
+			func(row committeeRow) string {
+				return gtkutil.AvailabilityScorePercent(row.val.GetAvailabilityScore())
+			})
 	})
 
 	scheduler.Every(refreshCommitteeInterval).Do(ctx, func(ctx context.Context) {

--- a/cmd/gtk/controller/navigator.go
+++ b/cmd/gtk/controller/navigator.go
@@ -172,6 +172,7 @@ func (*Navigator) SetDarkMode(enabled bool) {
 		scheme = adw.ColorSchemeForceDark
 	}
 	adw.StyleManagerGetDefault().SetColorScheme(scheme)
+	gtkutil.SaveDarkMode(enabled)
 }
 
 func (n *Navigator) CreateMenu(isLocal bool) *gio.Menu {

--- a/cmd/gtk/controller/navigator.go
+++ b/cmd/gtk/controller/navigator.go
@@ -3,6 +3,7 @@
 package controller
 
 import (
+	adw "github.com/diamondburned/gotk4-adwaita/pkg/adw"
 	"github.com/diamondburned/gotk4/pkg/gio/v2"
 	"github.com/diamondburned/gotk4/pkg/glib/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
@@ -160,6 +161,17 @@ func (*Navigator) openWebsite(url string) {
 
 func (n *Navigator) Quit() {
 	n.gtkApp.Quit()
+}
+
+// SetDarkMode forces the light or dark appearance at runtime through the
+// libadwaita style manager, independent of the operating system theme.
+// It must be called on the UI thread.
+func (*Navigator) SetDarkMode(enabled bool) {
+	scheme := adw.ColorSchemeForceLight
+	if enabled {
+		scheme = adw.ColorSchemeForceDark
+	}
+	adw.StyleManagerGetDefault().SetColorScheme(scheme)
 }
 
 func (n *Navigator) CreateMenu(isLocal bool) *gio.Menu {

--- a/cmd/gtk/controller/network_widget_controller.go
+++ b/cmd/gtk/controller/network_widget_controller.go
@@ -56,27 +56,31 @@ func NewNetworkWidgetController(
 
 func (c *NetworkWidgetController) BuildView(ctx context.Context) error {
 	gtkutil.IdleAddSync(func() {
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewPeers, "No", func(row peerRow) string {
-			return strconv.Itoa(row.no)
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewPeers, "Moniker", func(row peerRow) string {
-			return row.peer.GetMoniker()
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewPeers, "Address", func(row peerRow) string {
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewPeers, "No", 0, false, "cell-dim",
+			func(row peerRow) string {
+				return strconv.Itoa(row.no)
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewPeers, "Moniker", 0, false, "",
+			func(row peerRow) string {
+				return row.peer.GetMoniker()
+			})
+		gtkutil.ColumnViewAppendAddressColumn(c.view.ColViewPeers, "Address", func(row peerRow) string {
 			return row.peer.GetAddress()
 		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewPeers, "Peer ID", func(row peerRow) string {
+		gtkutil.ColumnViewAppendAddressColumn(c.view.ColViewPeers, "Peer ID", func(row peerRow) string {
 			return row.peer.GetPeerId()
 		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewPeers, "Height", func(row peerRow) string {
-			return strconv.Itoa(int(row.peer.GetHeight()))
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewPeers, "Agent", func(row peerRow) string {
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewPeers, "Height", 1, false, "cell-num",
+			func(row peerRow) string {
+				return strconv.Itoa(int(row.peer.GetHeight()))
+			})
+		gtkutil.ColumnViewAppendEllipsizedColumn(c.view.ColViewPeers, "Agent", func(row peerRow) string {
 			return row.peer.GetAgent()
 		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewPeers, "Direction", func(row peerRow) string {
-			return peerDirectionString(row.peer.GetDirection())
-		})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewPeers, "Direction", 0, false, "",
+			func(row peerRow) string {
+				return peerDirectionString(row.peer.GetDirection())
+			})
 	})
 
 	scheduler.Every(refreshNetworkInterval).Do(ctx, func(ctx context.Context) {

--- a/cmd/gtk/controller/node_widget_controller.go
+++ b/cmd/gtk/controller/node_widget_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pactus-project/gopkg/scheduler"
@@ -49,7 +50,8 @@ func (c *NodeWidgetController) BuildView(ctx context.Context, connectionLabel, c
 		c.view.LabelConnectionValue.SetText(connectionValue)
 		c.view.LabelNetwork.SetText(nodeInfo.NetworkName)
 		c.view.LabelNetworkID.SetText(nodeInfo.PeerId)
-		c.view.LabelAgent.SetText(nodeInfo.Agent)
+		c.view.LabelAgent.SetText(parseAgent(nodeInfo.Agent))
+		c.view.LabelAgent.SetTooltipText(nodeInfo.Agent)
 		c.view.LabelMoniker.SetText(nodeInfo.Moniker)
 		c.view.LabelIsPrune.SetText(strconv.FormatBool(chainInfo.IsPruned))
 	})
@@ -90,7 +92,19 @@ func (c *NodeWidgetController) timeoutProgress() {
 			c.view.LabelBlocksLeft.SetText(strconv.FormatInt(chainInfo.BlocksLeft, 10))
 		}
 		c.view.ProgressSynced.SetFraction(percentage)
+		c.setSyncStatus(percentage)
 	})
+}
+
+// setSyncStatus shows a short caption under the sync ring.
+func (c *NodeWidgetController) setSyncStatus(percentage float64) {
+	if percentage >= 1 {
+		c.view.LabelSyncStatus.SetMarkup(
+			"<span foreground=\"#00a085\">All blocks downloaded</span>")
+
+		return
+	}
+	c.view.LabelSyncStatus.SetText("Downloading blocks…")
 }
 
 func (c *NodeWidgetController) timeoutInfo() {
@@ -130,7 +144,7 @@ func (c *NodeWidgetController) timeoutInfo() {
 		c.view.LabelTotalPower.SetText(totalStake.String())
 		c.view.LabelAverageScore.SetText(fmt.Sprintf("%.2f", chainInfo.AverageScore))
 		c.view.LabelNumConnections.SetText(numConnections)
-		c.view.LabelReachability.SetText(reachability)
+		c.setReachability(reachability)
 
 		c.setInCommittee(chainInfo.InCommittee)
 	})
@@ -159,9 +173,64 @@ func (c *NodeWidgetController) setClockOffset(offset time.Duration, offsetErr er
 	c.view.LabelClockOffset.RemoveCSSClass("warning")
 }
 
+// setReachability shows the reachability with a status color.
+func (c *NodeWidgetController) setReachability(reachability string) {
+	color := ""
+	switch strings.ToLower(reachability) {
+	case "public":
+		color = "#00a085"
+	case "private":
+		color = "#e0a500"
+	}
+
+	if color != "" {
+		c.view.LabelReachability.SetMarkup(
+			fmt.Sprintf("<span foreground=\"%s\">%s</span>", color, reachability))
+
+		return
+	}
+
+	c.view.LabelReachability.SetText(reachability)
+}
+
+// parseAgent turns the raw node agent string into a friendly summary, e.g.
+// "node=gui/node-version=1.17.0-beta/protocol-version=4/os=windows/arch=amd64"
+// becomes "GUI · v1.17.0-beta · windows/amd64 · protocol 4".
+func parseAgent(agent string) string {
+	fields := map[string]string{}
+	for _, part := range strings.Split(agent, "/") {
+		if kv := strings.SplitN(part, "=", 2); len(kv) == 2 {
+			fields[kv[0]] = kv[1]
+		}
+	}
+
+	var parts []string
+	if node := fields["node"]; node != "" {
+		parts = append(parts, strings.ToUpper(node))
+	}
+	if version := fields["node-version"]; version != "" {
+		parts = append(parts, "v"+version)
+	}
+	if os := fields["os"]; os != "" {
+		parts = append(parts, strings.ToUpper(os[:1])+os[1:])
+	}
+	if arch := fields["arch"]; arch != "" {
+		parts = append(parts, arch)
+	}
+	if protocol := fields["protocol-version"]; protocol != "" {
+		parts = append(parts, "protocol "+protocol)
+	}
+
+	if len(parts) == 0 {
+		return agent
+	}
+
+	return strings.Join(parts, " · ")
+}
+
 func (c *NodeWidgetController) setInCommittee(inCommittee bool) {
 	if inCommittee {
-		c.view.LabelInCommittee.SetMarkup("<span foreground=\"#10c92f\">Yes</span>")
+		c.view.LabelInCommittee.SetMarkup("<span foreground=\"#00a085\">Yes</span>")
 
 		return
 	}

--- a/cmd/gtk/controller/node_widget_controller.go
+++ b/cmd/gtk/controller/node_widget_controller.go
@@ -89,8 +89,7 @@ func (c *NodeWidgetController) timeoutProgress() {
 		} else {
 			c.view.LabelBlocksLeft.SetText(strconv.FormatInt(chainInfo.BlocksLeft, 10))
 		}
-		c.view.ProgressBarSynced.SetFraction(percentage)
-		c.view.ProgressBarSynced.SetText(fmt.Sprintf("%s %%", strconv.FormatFloat(percentage*100, 'f', 2, 64)))
+		c.view.ProgressSynced.SetFraction(percentage)
 	})
 }
 

--- a/cmd/gtk/controller/node_widget_controller.go
+++ b/cmd/gtk/controller/node_widget_controller.go
@@ -100,11 +100,11 @@ func (c *NodeWidgetController) timeoutProgress() {
 func (c *NodeWidgetController) setSyncStatus(percentage float64) {
 	if percentage >= 1 {
 		c.view.LabelSyncStatus.SetMarkup(
-			"<span foreground=\"#00a085\">All blocks downloaded</span>")
+			"<span foreground=\"#00a085\">Fully synced</span>")
 
 		return
 	}
-	c.view.LabelSyncStatus.SetText("Downloading blocks…")
+	c.view.LabelSyncStatus.SetText("Syncing blocks…")
 }
 
 func (c *NodeWidgetController) timeoutInfo() {

--- a/cmd/gtk/controller/validator_widget_controller.go
+++ b/cmd/gtk/controller/validator_widget_controller.go
@@ -43,27 +43,33 @@ func NewValidatorWidgetController(
 
 func (c *ValidatorWidgetController) BuildView(ctx context.Context) error {
 	gtkutil.IdleAddSync(func() {
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewValidators, "No", func(row validatorRow) string {
-			return strconv.Itoa(row.no)
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewValidators, "Address", func(row validatorRow) string {
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewValidators, "No", 0, false, "cell-dim",
+			func(row validatorRow) string {
+				return strconv.Itoa(row.no)
+			})
+		gtkutil.ColumnViewAppendAddressColumn(c.view.ColViewValidators, "Address", func(row validatorRow) string {
 			return row.val.GetAddress()
 		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewValidators, "Stake", func(row validatorRow) string {
-			return amount.Amount(row.val.GetStake()).String()
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewValidators, "Bonding Height", func(row validatorRow) string {
-			return strconv.Itoa(int(row.val.GetLastBondingHeight()))
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewValidators, "Sortition Height", func(row validatorRow) string {
-			return strconv.Itoa(int(row.val.GetLastSortitionHeight()))
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewValidators, "Unbonding Height", func(row validatorRow) string {
-			return strconv.Itoa(int(row.val.GetUnbondingHeight()))
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewValidators, "Availability Score", func(row validatorRow) string {
-			return gtkutil.AvailabilityScorePercent(row.val.GetAvailabilityScore())
-		})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewValidators, "Stake", 1, false, "cell-num",
+			func(row validatorRow) string {
+				return amount.Amount(row.val.GetStake()).String()
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewValidators, "Bonding Height", 1, false, "cell-num",
+			func(row validatorRow) string {
+				return strconv.Itoa(int(row.val.GetLastBondingHeight()))
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewValidators, "Sortition Height", 1, false, "cell-num",
+			func(row validatorRow) string {
+				return strconv.Itoa(int(row.val.GetLastSortitionHeight()))
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewValidators, "Unbonding Height", 1, false, "cell-num",
+			func(row validatorRow) string {
+				return strconv.Itoa(int(row.val.GetUnbondingHeight()))
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewValidators, "Availability Score", 1, false, "cell-num",
+			func(row validatorRow) string {
+				return gtkutil.AvailabilityScorePercent(row.val.GetAvailabilityScore())
+			})
 	})
 
 	scheduler.Every(refreshValidatorsInterval).Do(ctx, func(ctx context.Context) {

--- a/cmd/gtk/controller/wallet_widget_controller.go
+++ b/cmd/gtk/controller/wallet_widget_controller.go
@@ -61,10 +61,11 @@ func (c *WalletWidgetController) BuildView(ctx context.Context, nav *Navigator) 
 		gtkutil.ColumnViewSetup(c.view.ColViewTransactions, c.lsTransactions)
 
 		// Setup address columns
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewAddresses, "No", func(row addressRow) string {
-			return strconv.Itoa(row.no)
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewAddresses, "Address", func(row addressRow) string {
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewAddresses, "No", 0, false, "cell-dim",
+			func(row addressRow) string {
+				return strconv.Itoa(row.no)
+			})
+		gtkutil.ColumnViewAppendAddressColumn(c.view.ColViewAddresses, "Address", func(row addressRow) string {
 			return row.addr.Address
 		})
 		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewAddresses, "Type", func(row addressRow) string {
@@ -75,41 +76,49 @@ func (c *WalletWidgetController) BuildView(ctx context.Context, nav *Navigator) 
 
 			return typ.String()
 		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewAddresses, "Label", func(row addressRow) string {
-			return row.addr.Label
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewAddresses, "Balance", func(row addressRow) string {
-			return amount.Amount(row.addr.Balance).String()
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewAddresses, "Stake", func(row addressRow) string {
-			return amount.Amount(row.addr.Stake).String()
-		})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewAddresses, "Label", 0, false, "",
+			func(row addressRow) string {
+				return row.addr.Label
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewAddresses, "Balance", 1, false, "cell-num",
+			func(row addressRow) string {
+				return amount.Amount(row.addr.Balance).String()
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewAddresses, "Stake", 1, false, "cell-num",
+			func(row addressRow) string {
+				return amount.Amount(row.addr.Stake).String()
+			})
 		// Setup transaction columns
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewTransactions, "No", func(row transactionRow) string {
-			return strconv.Itoa(int(row.trx.No))
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewTransactions, "ID", func(row transactionRow) string {
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewTransactions, "No", 0, false, "cell-dim",
+			func(row transactionRow) string {
+				return strconv.Itoa(int(row.trx.No))
+			})
+		gtkutil.ColumnViewAppendAddressColumn(c.view.ColViewTransactions, "ID", func(row transactionRow) string {
 			return row.trx.TxId
 		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewTransactions, "Sender", func(row transactionRow) string {
+		gtkutil.ColumnViewAppendAddressColumn(c.view.ColViewTransactions, "Sender", func(row transactionRow) string {
 			return row.trx.Sender
 		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewTransactions, "Receiver", func(row transactionRow) string {
+		gtkutil.ColumnViewAppendAddressColumn(c.view.ColViewTransactions, "Receiver", func(row transactionRow) string {
 			return row.trx.Receiver
 		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewTransactions, "Type", func(row transactionRow) string {
-			return payload.Type(row.trx.PayloadType).String()
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewTransactions, "Amount", func(row transactionRow) string {
-			return amount.Amount(row.trx.Amount).String()
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewTransactions, "Direction", func(row transactionRow) string {
-			return getDirectionTextWithIcon(types.TxDirection(row.trx.Direction))
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewTransactions, "Status", func(row transactionRow) string {
-			return types.TransactionStatus(row.trx.Status).String()
-		})
-		gtkutil.ColumnViewAppendTextColumn(c.view.ColViewTransactions, "Comment", func(row transactionRow) string {
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewTransactions, "Type", 0, false, "",
+			func(row transactionRow) string {
+				return payload.Type(row.trx.PayloadType).String()
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewTransactions, "Amount", 1, false, "cell-num",
+			func(row transactionRow) string {
+				return amount.Amount(row.trx.Amount).String()
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewTransactions, "Direction", 0, false, "",
+			func(row transactionRow) string {
+				return getDirectionTextWithIcon(types.TxDirection(row.trx.Direction))
+			})
+		gtkutil.ColumnViewAppendTextColumnEx(c.view.ColViewTransactions, "Status", 0, false, "",
+			func(row transactionRow) string {
+				return types.TransactionStatus(row.trx.Status).String()
+			})
+		gtkutil.ColumnViewAppendEllipsizedColumn(c.view.ColViewTransactions, "Comment", func(row transactionRow) string {
 			return row.trx.Comment
 		})
 	})

--- a/cmd/gtk/gtkutil/center_other.go
+++ b/cmd/gtk/gtkutil/center_other.go
@@ -1,0 +1,7 @@
+//go:build gtk && !windows
+
+package gtkutil
+
+// CenterActiveWindow is a no-op on platforms other than Windows, where the
+// window manager already positions new toplevels reasonably.
+func CenterActiveWindow() {}

--- a/cmd/gtk/gtkutil/center_windows.go
+++ b/cmd/gtk/gtkutil/center_windows.go
@@ -1,0 +1,57 @@
+//go:build gtk && windows
+
+package gtkutil
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	user32                       = windows.NewLazySystemDLL("user32.dll")
+	procGetForegroundWindow      = user32.NewProc("GetForegroundWindow")
+	procGetWindowThreadProcessID = user32.NewProc("GetWindowThreadProcessId")
+	procGetWindowRect            = user32.NewProc("GetWindowRect")
+	procSetWindowPos             = user32.NewProc("SetWindowPos")
+	procGetSystemMetrics         = user32.NewProc("GetSystemMetrics")
+)
+
+type winRect struct {
+	left, top, right, bottom int32
+}
+
+// CenterActiveWindow centers this process's foreground window on the primary
+// monitor. GTK4 provides no way to move a window, so parentless/undecorated
+// windows such as the splash are centered natively on Windows.
+func CenterActiveWindow() {
+	hwnd, _, _ := procGetForegroundWindow.Call()
+	if hwnd == 0 {
+		return
+	}
+
+	var pid uint32
+	procGetWindowThreadProcessID.Call(hwnd, uintptr(unsafe.Pointer(&pid)))
+	if pid != windows.GetCurrentProcessId() {
+		return
+	}
+
+	var rect winRect
+	procGetWindowRect.Call(hwnd, uintptr(unsafe.Pointer(&rect)))
+	width := rect.right - rect.left
+	height := rect.bottom - rect.top
+
+	screenW, _, _ := procGetSystemMetrics.Call(0) // SM_CXSCREEN
+	screenH, _, _ := procGetSystemMetrics.Call(1) // SM_CYSCREEN
+
+	x := (int32(screenW) - width) / 2
+	y := (int32(screenH) - height) / 2
+
+	const (
+		swpNoSize     = 0x0001
+		swpNoZOrder   = 0x0004
+		swpNoActivate = 0x0010
+	)
+	procSetWindowPos.Call(hwnd, 0, uintptr(x), uintptr(y), 0, 0,
+		swpNoSize|swpNoZOrder|swpNoActivate)
+}

--- a/cmd/gtk/gtkutil/columnview.go
+++ b/cmd/gtk/gtkutil/columnview.go
@@ -6,12 +6,105 @@ import (
 	"github.com/diamondburned/gotk4/pkg/core/gioutil"
 	"github.com/diamondburned/gotk4/pkg/core/glib"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+	"github.com/diamondburned/gotk4/pkg/pango"
 )
 
 func ColumnViewAppendTextColumn[T any](colView *gtk.ColumnView, title string, extractor func(T) string) {
 	column := ColumnViewCreateTextColumn(title, extractor)
 	column.SetResizable(true)
 	column.SetExpand(false)
+
+	colView.AppendColumn(column)
+}
+
+// ColumnViewAppendTextColumnEx appends a text column with control over the cell
+// text alignment (xalign 0 = left, 1 = right), whether the column expands to
+// fill remaining width, and an optional CSS class applied to the cell label.
+func ColumnViewAppendTextColumnEx[T any](colView *gtk.ColumnView, title string,
+	xalign float32, expand bool, cssClass string, extractor func(T) string,
+) {
+	factory := gtk.NewSignalListItemFactory()
+	factory.ConnectSetup(func(obj *glib.Object) {
+		cell := obj.Cast().(*gtk.ColumnViewCell)
+		label := gtk.NewLabel("")
+		label.SetHExpand(true)
+		label.SetXAlign(xalign)
+		if cssClass != "" {
+			label.AddCSSClass(cssClass)
+		}
+		cell.SetChild(label)
+	})
+	factory.ConnectBind(func(obj *glib.Object) {
+		cell := obj.Cast().(*gtk.ColumnViewCell)
+		row := gioutil.ObjectValue[T](cell.Item())
+		label := cell.Child().(*gtk.Label)
+		label.SetText(extractor(row))
+	})
+
+	column := gtk.NewColumnViewColumn(title, &factory.ListItemFactory)
+	column.SetTitle(title)
+	column.SetExpand(expand)
+	column.SetResizable(true)
+
+	colView.AppendColumn(column)
+}
+
+// ColumnViewAppendEllipsizedColumn appends an expanding column whose long text
+// is ellipsized at the end, with the full value available on hover.
+func ColumnViewAppendEllipsizedColumn[T any](colView *gtk.ColumnView, title string, extractor func(T) string) {
+	factory := gtk.NewSignalListItemFactory()
+	factory.ConnectSetup(func(obj *glib.Object) {
+		cell := obj.Cast().(*gtk.ColumnViewCell)
+		label := gtk.NewLabel("")
+		label.SetHExpand(true)
+		label.SetXAlign(0)
+		label.SetEllipsize(pango.EllipsizeEnd)
+		cell.SetChild(label)
+	})
+	factory.ConnectBind(func(obj *glib.Object) {
+		cell := obj.Cast().(*gtk.ColumnViewCell)
+		row := gioutil.ObjectValue[T](cell.Item())
+		label := cell.Child().(*gtk.Label)
+		value := extractor(row)
+		label.SetText(value)
+		label.SetTooltipText(value)
+	})
+
+	column := gtk.NewColumnViewColumn(title, &factory.ListItemFactory)
+	column.SetTitle(title)
+	column.SetExpand(true)
+	column.SetResizable(true)
+
+	colView.AppendColumn(column)
+}
+
+// ColumnViewAppendAddressColumn appends an expanding column that middle-
+// ellipsizes long identifiers such as addresses and shows the full value on
+// hover, so the table never needs horizontal scrolling.
+func ColumnViewAppendAddressColumn[T any](colView *gtk.ColumnView, title string, extractor func(T) string) {
+	factory := gtk.NewSignalListItemFactory()
+	factory.ConnectSetup(func(obj *glib.Object) {
+		cell := obj.Cast().(*gtk.ColumnViewCell)
+		label := gtk.NewLabel("")
+		label.SetHExpand(true)
+		label.SetXAlign(0)
+		label.SetEllipsize(pango.EllipsizeMiddle)
+		label.AddCSSClass("cell-mono")
+		cell.SetChild(label)
+	})
+	factory.ConnectBind(func(obj *glib.Object) {
+		cell := obj.Cast().(*gtk.ColumnViewCell)
+		row := gioutil.ObjectValue[T](cell.Item())
+		label := cell.Child().(*gtk.Label)
+		value := extractor(row)
+		label.SetText(value)
+		label.SetTooltipText(value)
+	})
+
+	column := gtk.NewColumnViewColumn(title, &factory.ListItemFactory)
+	column.SetTitle(title)
+	column.SetExpand(true)
+	column.SetResizable(true)
 
 	colView.AppendColumn(column)
 }
@@ -84,7 +177,8 @@ func ColumnViewGetSelectedItem[T any](colView *gtk.ColumnView, model *gioutil.Li
 }
 
 func ColumnViewSetDefaultProperties(colView *gtk.ColumnView) {
-	colView.SetShowRowSeparators(true)
-	colView.SetShowColumnSeparators(true)
+	colView.SetShowRowSeparators(false)
+	colView.SetShowColumnSeparators(false)
 	colView.SetSingleClickActivate(true)
+	colView.AddCSSClass("data-table")
 }

--- a/cmd/gtk/gtkutil/gtkutil.go
+++ b/cmd/gtk/gtkutil/gtkutil.go
@@ -413,6 +413,29 @@ func IsWidgetShowing(widget *gtk.Widget) bool {
 	return widget.Mapped()
 }
 
+// DisableLabelSelection walks the widget tree and makes every label
+// non-selectable. GtkAboutDialog otherwise auto-selects its program-name label
+// when it grabs focus on open, which looks like highlighted text.
+func DisableLabelSelection(root gtk.Widgetter) {
+	parent, ok := root.(interface{ FirstChild() gtk.Widgetter })
+	if !ok {
+		return
+	}
+
+	for child := parent.FirstChild(); child != nil; {
+		if label, isLabel := child.(*gtk.Label); isLabel {
+			label.SetSelectable(false)
+		}
+		DisableLabelSelection(child)
+
+		sibling, hasSibling := child.(interface{ NextSibling() gtk.Widgetter })
+		if !hasSibling {
+			break
+		}
+		child = sibling.NextSibling()
+	}
+}
+
 func ClearLable(label *gtk.Label) {
 	label.SetText("")
 }

--- a/cmd/gtk/gtkutil/gtkutil.go
+++ b/cmd/gtk/gtkutil/gtkutil.go
@@ -20,7 +20,6 @@ import (
 	"github.com/diamondburned/gotk4/pkg/gio/v2"
 	"github.com/diamondburned/gotk4/pkg/glib/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
-	"github.com/pactus-project/pactus/cmd/gtk/assets"
 )
 
 func ShowQuestionDialog(parent *gtk.Window, msg string,
@@ -154,17 +153,58 @@ func BuildExtendedEntry(builder *gtk.Builder, overlayID string) *gtk.Entry {
 	return entry
 }
 
+// mainWindow is the top-level window used as the transient parent for dialogs
+// so they open centered over the application instead of at the screen corner.
+var mainWindow *gtk.Window
+
+// SetMainWindow registers the main window as the parent for dialog windows.
+func SetMainWindow(win *gtk.Window) {
+	mainWindow = win
+}
+
+// parentForDialog makes the dialog transient for the main window so it opens
+// centered over it. It reports whether a parent was set; when it was not (for
+// example dialogs shown during startup before the main window exists), the
+// caller centers the window natively instead.
+func parentForDialog(win *gtk.Window) bool {
+	if mainWindow != nil && mainWindow != win {
+		win.SetTransientFor(mainWindow)
+
+		return true
+	}
+
+	return false
+}
+
+// centerParentlessWindow centers a window that has no transient parent once it
+// has been mapped. This is a no-op on platforms other than Windows.
+func centerParentlessWindow() {
+	glib.TimeoutAdd(80, func() bool {
+		CenterActiveWindow()
+
+		return false
+	})
+}
+
 func ShowNonModalWindow(win *gtk.Window) {
 	IdleAddSync(func() {
+		hasParent := parentForDialog(win)
 		win.SetModal(false)
 		win.Present()
+		if !hasParent {
+			centerParentlessWindow()
+		}
 	})
 }
 
 func ShowModalWindow(win *gtk.Window) {
 	IdleAddAsync(func() {
+		hasParent := parentForDialog(win)
 		win.SetModal(true)
 		win.Present()
+		if !hasParent {
+			centerParentlessWindow()
+		}
 	})
 }
 
@@ -276,31 +316,30 @@ func GoroutineID() int64 {
 }
 
 func UpdateSendButton(button *gtk.Button) {
-	ExtendImageButton(button, "_Send", "Send this transaction", assets.IconSendTexture)
+	ExtendImageButton(button, "_Send", "Send this transaction", nil)
+	button.AddCSSClass("suggested-action")
 }
 
 func UpdateOKButton(window *gtk.Window, button *gtk.Button) {
-	ExtendImageButton(button, "_OK", "Perform this operation", assets.IconOkTexture)
+	ExtendImageButton(button, "_OK", "Perform this operation", nil)
+	button.AddCSSClass("suggested-action")
 	window.SetDefaultWidget(button)
 }
 
 func UpdateCancelButton(button *gtk.Button) {
-	ExtendImageButton(button, "_Cancel", "Cancel this operation", assets.IconCancelTexture)
+	ExtendImageButton(button, "_Cancel", "Cancel this operation", nil)
 }
 
 func UpdateCloseButton(button *gtk.Button) {
-	ExtendImageButton(button, "_Close", "Close this window", assets.IconCloseTexture)
+	ExtendImageButton(button, "_Close", "Close this window", nil)
 }
 
-func ExtendImageButton(btn *gtk.Button, text, tooltip string, texture *gdk.Texture) {
-	box := gtk.NewBox(gtk.OrientationHorizontal, 4)
-	pic := NewScaledPictureFromTexture(texture, 16, 16)
-	label := gtk.NewLabel(text)
-	label.SetUseUnderline(true)
-
-	box.Append(pic)
-	box.Append(label)
-	btn.SetChild(box)
+// ExtendImageButton sets a clean, text-only label on a dialog button. The
+// texture argument is kept for backwards compatibility and ignored, as the
+// dated icon glyphs were replaced by a flat, modern button style.
+func ExtendImageButton(btn *gtk.Button, text, tooltip string, _ *gdk.Texture) {
+	btn.SetLabel(text)
+	btn.SetUseUnderline(true)
 	btn.SetTooltipText(tooltip)
 }
 

--- a/cmd/gtk/gtkutil/settings.go
+++ b/cmd/gtk/gtkutil/settings.go
@@ -1,0 +1,55 @@
+//go:build gtk
+
+package gtkutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// themePrefPath returns the file that stores the user's light/dark choice,
+// kept in the per-user config directory so it is shared across networks.
+func themePrefPath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(dir, "pactus", "gui_dark_mode")
+}
+
+// SaveDarkMode persists the user's dark-mode choice.
+func SaveDarkMode(dark bool) {
+	path := themePrefPath()
+	if path == "" {
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+
+	value := "0"
+	if dark {
+		value = "1"
+	}
+
+	_ = os.WriteFile(path, []byte(value), 0o644)
+}
+
+// LoadDarkMode returns the persisted dark-mode choice. ok is false when the
+// user has not made a choice yet, in which case the system theme is followed.
+func LoadDarkMode() (dark, ok bool) {
+	path := themePrefPath()
+	if path == "" {
+		return false, false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, false
+	}
+
+	return strings.TrimSpace(string(data)) == "1", true
+}

--- a/cmd/gtk/locale_other.go
+++ b/cmd/gtk/locale_other.go
@@ -1,0 +1,7 @@
+//go:build gtk && !windows
+
+package main
+
+// forceEnglishUILanguage is a no-op outside Windows, where the LANGUAGE
+// environment variable already controls GTK's message catalogs.
+func forceEnglishUILanguage() {}

--- a/cmd/gtk/locale_windows.go
+++ b/cmd/gtk/locale_windows.go
@@ -1,0 +1,16 @@
+//go:build gtk && windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+// forceEnglishUILanguage sets the thread UI language to English (en-US), so
+// GTK and libadwaita load their English catalogs instead of following the
+// Windows display language. On Windows GTK reads this rather than the LANGUAGE
+// environment variable.
+func forceEnglishUILanguage() {
+	const langEnUS = 0x0409
+
+	proc := windows.NewLazySystemDLL("kernel32.dll").NewProc("SetThreadUILanguage")
+	_, _, _ = proc.Call(uintptr(langEnUS))
+}

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -16,6 +16,7 @@ import (
 	adw "github.com/diamondburned/gotk4-adwaita/pkg/adw"
 	"github.com/diamondburned/gotk4/pkg/gdk/v4"
 	"github.com/diamondburned/gotk4/pkg/gio/v2"
+	"github.com/diamondburned/gotk4/pkg/glib/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 	"github.com/gofrs/flock"
 	"github.com/pactus-project/gopkg/signal"
@@ -68,7 +69,11 @@ func init() {
 	// (assistant navigation, about dialog, file choosers ...) to English too
 	// instead of following the operating system locale. This affects message
 	// translation only, not number or date formatting.
-	_ = os.Setenv("LANGUAGE", "en")
+	// Use g_setenv, not os.Setenv: on Windows the latter uses the Win32
+	// environment block, which the C runtime that GTK/libintl links against
+	// does not read, so the change would be invisible to gettext.
+	glib.Setenv("LANGUAGE", "en", true)
+	glib.Setenv("LC_MESSAGES", "en", true)
 	forceEnglishUILanguage()
 
 	gtk.Init()

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -64,6 +64,12 @@ func init() {
 		_ = os.Setenv("PANGOCAIRO_BACKEND", "fontconfig")
 	}
 
+	// The GUI text is English only, so force GTK's built-in widget strings
+	// (assistant navigation, about dialog, file choosers ...) to English too
+	// instead of following the operating system locale. This affects message
+	// translation only, not number or date formatting.
+	_ = os.Setenv("LANGUAGE", "en")
+
 	gtk.Init()
 	// Initialize libadwaita so its StyleManager controls the light/dark
 	// appearance, independent of the operating system theme.

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -69,6 +69,7 @@ func init() {
 	// instead of following the operating system locale. This affects message
 	// translation only, not number or date formatting.
 	_ = os.Setenv("LANGUAGE", "en")
+	forceEnglishUILanguage()
 
 	gtk.Init()
 	// Initialize libadwaita so its StyleManager controls the light/dark

--- a/cmd/gtk/main.go
+++ b/cmd/gtk/main.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	adw "github.com/diamondburned/gotk4-adwaita/pkg/adw"
 	"github.com/diamondburned/gotk4/pkg/gdk/v4"
 	"github.com/diamondburned/gotk4/pkg/gio/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
@@ -64,6 +65,9 @@ func init() {
 	}
 
 	gtk.Init()
+	// Initialize libadwaita so its StyleManager controls the light/dark
+	// appearance, independent of the operating system theme.
+	adw.Init()
 }
 
 //nolint:gocognit // needs refactoring
@@ -79,8 +83,6 @@ func main() {
 	// Create a new app.
 	app := gtk.NewApplication(appID, gio.ApplicationNonUnique)
 	gtk.WidgetSetDefaultDirection(gtk.TextDirLTR)
-	settings := gtk.SettingsGetDefault()
-	settings.Object.SetObjectProperty("gtk-application-prefer-dark-theme", true)
 
 	// apply custom css
 	provider := gtk.NewCSSProvider()

--- a/cmd/gtk/view/about_dialog_view.go
+++ b/cmd/gtk/view/about_dialog_view.go
@@ -15,5 +15,7 @@ func NewAboutDialog() *gtk.AboutDialog {
 	pic := gtkutil.NewScaledPictureFromTexture(assets.ImagePactusLogoTexture, 128, 128)
 	dlg.SetLogo(pic.Paintable())
 
+	gtkutil.DisableLabelSelection(dlg)
+
 	return dlg
 }

--- a/cmd/gtk/view/about_gtk_dialog_view.go
+++ b/cmd/gtk/view/about_gtk_dialog_view.go
@@ -15,5 +15,7 @@ func NewAboutGTKDialog() *gtk.AboutDialog {
 	pic := gtkutil.NewScaledPictureFromTexture(assets.ImageGTKLogoTexture, 128, 128)
 	dlg.SetLogo(pic.Paintable())
 
+	gtkutil.DisableLabelSelection(dlg)
+
 	return dlg
 }

--- a/cmd/gtk/view/circular_progress.go
+++ b/cmd/gtk/view/circular_progress.go
@@ -10,11 +10,11 @@ import (
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 )
 
-// Pactus accent teal (#12909e), matching the CSS accent color.
+// Pactus accent green (#00a085), matching the CSS accent color.
 const (
-	accentRed   = 0x12 / 255.0
-	accentGreen = 0x90 / 255.0
-	accentBlue  = 0x9e / 255.0
+	accentRed   = 0x00 / 255.0
+	accentGreen = 0xa0 / 255.0
+	accentBlue  = 0x85 / 255.0
 )
 
 // CircularProgress is a ring gauge that fills clockwise with the sync progress

--- a/cmd/gtk/view/circular_progress.go
+++ b/cmd/gtk/view/circular_progress.go
@@ -1,0 +1,92 @@
+//go:build gtk
+
+package view
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/diamondburned/gotk4/pkg/cairo"
+	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+)
+
+// Pactus accent teal (#12909e), matching the CSS accent color.
+const (
+	accentRed   = 0x12 / 255.0
+	accentGreen = 0x90 / 255.0
+	accentBlue  = 0x9e / 255.0
+)
+
+// CircularProgress is a ring gauge that fills clockwise with the sync progress
+// and shows the percentage in its center. The track color follows the current
+// theme so it reads well in both light and dark mode.
+type CircularProgress struct {
+	*gtk.Overlay
+
+	area     *gtk.DrawingArea
+	label    *gtk.Label
+	fraction float64
+}
+
+// NewCircularProgress creates a ring gauge with the given square size in pixels.
+func NewCircularProgress(size int) *CircularProgress {
+	area := gtk.NewDrawingArea()
+	area.SetContentWidth(size)
+	area.SetContentHeight(size)
+
+	label := gtk.NewLabel("0%")
+	label.SetHAlign(gtk.AlignCenter)
+	label.SetVAlign(gtk.AlignCenter)
+	label.AddCSSClass("circular-progress-label")
+
+	overlay := gtk.NewOverlay()
+	overlay.SetChild(area)
+	overlay.AddOverlay(label)
+
+	progress := &CircularProgress{
+		Overlay: overlay,
+		area:    area,
+		label:   label,
+	}
+
+	area.SetDrawFunc(func(_ *gtk.DrawingArea, cr *cairo.Context, width, height int) {
+		progress.draw(cr, width, height)
+	})
+
+	return progress
+}
+
+// SetFraction sets the progress in the range [0, 1] and refreshes the ring.
+func (cp *CircularProgress) SetFraction(fraction float64) {
+	fraction = math.Max(0, math.Min(1, fraction))
+	cp.fraction = fraction
+	cp.label.SetText(fmt.Sprintf("%.0f%%", fraction*100))
+	cp.area.QueueDraw()
+}
+
+func (cp *CircularProgress) draw(cr *cairo.Context, width, height int) {
+	w := float64(width)
+	h := float64(height)
+	lineWidth := math.Max(6, math.Min(w, h)*0.09)
+	radius := math.Min(w, h)/2 - lineWidth
+	centerX := w / 2
+	centerY := h / 2
+
+	cr.SetLineWidth(lineWidth)
+	cr.SetLineCap(cairo.LineCapRound)
+
+	// Track: widget foreground color at low opacity, so it adapts to the theme.
+	fg := cp.area.Color()
+	cr.SetSourceRGBA(float64(fg.Red()), float64(fg.Green()), float64(fg.Blue()), 0.15)
+	cr.Arc(centerX, centerY, radius, 0, 2*math.Pi)
+	cr.Stroke()
+
+	// Progress arc, clockwise starting from the top (-90 degrees).
+	if cp.fraction > 0 {
+		start := -math.Pi / 2
+		end := start + 2*math.Pi*cp.fraction
+		cr.SetSourceRGBA(accentRed, accentGreen, accentBlue, 1)
+		cr.Arc(centerX, centerY, radius, start, end)
+		cr.Stroke()
+	}
+}

--- a/cmd/gtk/view/main_window_view.go
+++ b/cmd/gtk/view/main_window_view.go
@@ -19,6 +19,9 @@ type MainWindowView struct {
 	BoxCommittee  *gtk.Box
 	BoxNetwork    *gtk.Box
 
+	SidebarList *gtk.ListBox
+	Stack       *gtk.Stack
+
 	// HideOnClose controls the window close behavior.
 	// When true, the window is hidden instead of destroyed on close-request.
 	HideOnClose bool
@@ -35,8 +38,26 @@ func NewMainWindowView() *MainWindowView {
 		BoxValidators: builder.GetBoxObj("id_box_validators"),
 		BoxCommittee:  builder.GetBoxObj("id_box_committee"),
 		BoxNetwork:    builder.GetBoxObj("id_box_network"),
+		SidebarList:   GetObj[*gtk.ListBox](builder.builder, "id_sidebar_list"),
+		Stack:         GetObj[*gtk.Stack](builder.builder, "id_main_stack"),
 		HideOnClose:   true,
 	}
+
+	// Assign the bundled sidebar icons.
+	GetObj[*gtk.Image](builder.builder, "id_icon_overview").SetFromPaintable(assets.IconNavOverviewTexture)
+	GetObj[*gtk.Image](builder.builder, "id_icon_committee").SetFromPaintable(assets.IconNavCommitteeTexture)
+	GetObj[*gtk.Image](builder.builder, "id_icon_network").SetFromPaintable(assets.IconNavNetworkTexture)
+	GetObj[*gtk.Image](builder.builder, "id_icon_validators").SetFromPaintable(assets.IconNavValidatorsTexture)
+	GetObj[*gtk.Image](builder.builder, "id_icon_wallet").SetFromPaintable(assets.IconNavWalletTexture)
+
+	// Switch the visible page when a sidebar row is selected, then preselect
+	// the first entry (Node Overview).
+	view.SidebarList.ConnectRowSelected(func(row *gtk.ListBoxRow) {
+		if row != nil {
+			view.Stack.SetVisibleChildName(row.Name())
+		}
+	})
+	view.SidebarList.SelectRow(view.SidebarList.RowAtIndex(0))
 
 	// Intercept the close-request signal to hide instead of destroy.
 	view.Window.ConnectCloseRequest(func() (ok bool) {

--- a/cmd/gtk/view/node_widget_view.go
+++ b/cmd/gtk/view/node_widget_view.go
@@ -25,6 +25,7 @@ type NodeWidgetView struct {
 	LabelLastBlockHeight *gtk.Label
 	LabelBlocksLeft      *gtk.Label
 	ProgressSynced       *CircularProgress
+	LabelSyncStatus      *gtk.Label
 	LabelActiveValidator *gtk.Label
 	LabelInCommittee     *gtk.Label
 	LabelTotalPower      *gtk.Label
@@ -57,9 +58,10 @@ func NewNodeWidgetView() *NodeWidgetView {
 		LabelAverageScore:    builder.GetLabelObj("id_label_average_score"),
 		LabelNumConnections:  builder.GetLabelObj("id_label_num_connections"),
 		LabelReachability:    builder.GetLabelObj("id_label_reachability"),
+		LabelSyncStatus:      builder.GetLabelObj("id_label_sync_status"),
 	}
 
-	view.ProgressSynced = NewCircularProgress(96)
+	view.ProgressSynced = NewCircularProgress(128)
 	builder.GetBoxObj("id_sync_container").Append(view.ProgressSynced)
 
 	return view

--- a/cmd/gtk/view/node_widget_view.go
+++ b/cmd/gtk/view/node_widget_view.go
@@ -24,7 +24,7 @@ type NodeWidgetView struct {
 	LabelLastBlockTime   *gtk.Label
 	LabelLastBlockHeight *gtk.Label
 	LabelBlocksLeft      *gtk.Label
-	ProgressBarSynced    *gtk.ProgressBar
+	ProgressSynced       *CircularProgress
 	LabelActiveValidator *gtk.Label
 	LabelInCommittee     *gtk.Label
 	LabelTotalPower      *gtk.Label
@@ -51,7 +51,6 @@ func NewNodeWidgetView() *NodeWidgetView {
 		LabelLastBlockTime:   builder.GetLabelObj("id_label_last_block_time"),
 		LabelLastBlockHeight: builder.GetLabelObj("id_label_last_block_height"),
 		LabelBlocksLeft:      builder.GetLabelObj("id_label_blocks_left"),
-		ProgressBarSynced:    builder.GetProgressBarObj("id_progress_synced"),
 		LabelActiveValidator: builder.GetLabelObj("id_label_active_validators"),
 		LabelInCommittee:     builder.GetLabelObj("id_label_in_committee"),
 		LabelTotalPower:      builder.GetLabelObj("id_label_total_power"),
@@ -59,6 +58,9 @@ func NewNodeWidgetView() *NodeWidgetView {
 		LabelNumConnections:  builder.GetLabelObj("id_label_num_connections"),
 		LabelReachability:    builder.GetLabelObj("id_label_reachability"),
 	}
+
+	view.ProgressSynced = NewCircularProgress(96)
+	builder.GetBoxObj("id_sync_container").Append(view.ProgressSynced)
 
 	return view
 }

--- a/cmd/gtk/view/splash_window_view.go
+++ b/cmd/gtk/view/splash_window_view.go
@@ -3,6 +3,7 @@
 package view
 
 import (
+	"github.com/diamondburned/gotk4/pkg/glib/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 	"github.com/pactus-project/pactus/cmd/gtk/assets"
 	"github.com/pactus-project/pactus/cmd/gtk/gtkutil"
@@ -66,6 +67,14 @@ func NewSplashWindow(app *gtk.Application) *SplashWindow {
 func (s *SplashWindow) ShowAll() {
 	s.window.Present()
 	s.spinner.Start()
+
+	// The splash has no parent to center over and GTK4 cannot move a window,
+	// so center it natively once it has been mapped.
+	glib.TimeoutAdd(80, func() bool {
+		gtkutil.CenterActiveWindow()
+
+		return false
+	})
 }
 
 func (s *SplashWindow) Destroy() {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/c-bata/go-prompt v0.2.6
 	github.com/consensys/gnark-crypto v0.20.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1
-	github.com/diamondburned/gotk4/pkg v0.3.1
+	github.com/diamondburned/gotk4/pkg v0.3.2-0.20250703063411-16654385f59a
 	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/glebarez/go-sqlite v1.22.1-0.20250214171204-e6de9fc0c320
 	github.com/go-zeromq/zmq4 v0.17.0
@@ -69,6 +69,7 @@ require (
 	github.com/creachadair/mds v0.29.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
+	github.com/diamondburned/gotk4-adwaita/pkg v0.0.0-20250703085337-e94555b846b6 // indirect
 	github.com/dunglas/httpsfv v1.1.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,12 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 h1:5RVFMOWjMyRy8cARdy79nAmgYw3hK/4HUq48LQ6Wwqo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/diamondburned/gotk4-adwaita/pkg v0.0.0-20250703085337-e94555b846b6 h1:WzOC3KtvrC1hJMz3fbJBg0Ye50nt4Tafor+a/bBHNEA=
+github.com/diamondburned/gotk4-adwaita/pkg v0.0.0-20250703085337-e94555b846b6/go.mod h1:ZzYiyPe0TqsukfPHi0sK/WwKzm0wIJdSRylLnuvAZNw=
 github.com/diamondburned/gotk4/pkg v0.3.1 h1:uhkXSUPUsCyz3yujdvl7DSN8jiLS2BgNTQE95hk6ygg=
 github.com/diamondburned/gotk4/pkg v0.3.1/go.mod h1:DqeOW+MxSZFg9OO+esk4JgQk0TiUJJUBfMltKhG+ub4=
+github.com/diamondburned/gotk4/pkg v0.3.2-0.20250703063411-16654385f59a h1:dN2jYYZ71hFhoKFSn24pQdKWLZb/XDydBt8pEIkFjJo=
+github.com/diamondburned/gotk4/pkg v0.3.2-0.20250703063411-16654385f59a/go.mod h1:O9K8+PGNFGJpAu8+u5D2Sn5Wae4hxWzHB+AeZNbV/2Q=
 github.com/dunglas/httpsfv v1.1.0 h1:Jw76nAyKWKZKFrpMMcL76y35tOpYHqQPzHQiwDvpe54=
 github.com/dunglas/httpsfv v1.1.0/go.mod h1:zID2mqw9mFsnt7YC3vYQ9/cjq30q41W+1AnDwH8TiMg=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
## Summary

This reworks the GTK GUI (`cmd/gtk`) from the legacy notebook‑tab layout into a
modern desktop app: a left navigation sidebar, dashboard‑style pages, a
cohesive theme with the official Pactus palette, and a working light/dark
toggle. Data and behaviour are unchanged — only the presentation layer and a
few platform fixes.

I have built and run it on **Windows 11**. It still needs testing on **Linux
and macOS** before it can be merged, which is why this is a draft. All
platform‑specific code is isolated behind build tags with no‑op fallbacks, so
non‑Windows builds should be unaffected, but that needs to be verified on real
machines.

## What's included

- **Theme foundation** — token‑based stylesheet derived from GTK's adaptive
  named colors, so widgets follow the active theme. Official Pactus palette:
  navy `#002235` (brand), green `#00a085` (primary actions/accent), blue
  `#217aff` (navigation).
- **Light/dark toggle** via the libadwaita style manager, shown as a round
  moon/sun button in the title bar. The choice is persisted and restored on the
  next launch (falls back to the system theme until the user picks one).
- **Custom title bar** with the Pactus logo and app name.
- **Left sidebar navigation** (Lucide line icons) driving a `GtkStack`, replacing
  the top notebook tabs.
- **Node Overview dashboard** — metric cards (Network Health, Validator Network)
  plus a custom circular sync gauge (`GtkDrawingArea` + cairo) and an aligned
  "Local Node Info" definition list. The node agent string is parsed into a
  readable summary.
- **Committee, Wallet, Network and My Validators** rebuilt to match: page title,
  info stat cards, and framed data tables.
- **Designed data tables** — reusable column helpers remove the spreadsheet
  look: no column grid lines, a flat muted header, roomy rows with hover,
  right‑aligned numbers, and middle‑ellipsized addresses/hashes with the full
  value on hover, so tables never scroll sideways.
- **Dialog polish** — flat text buttons (accent for confirm actions), padded
  content, and equal heights for entries, dropdowns and combo boxes.
- **Window placement** — GTK4 cannot position windows, so the splash, dialogs
  and main window are centered natively on Windows (no‑op elsewhere). The Node
  page opens at its natural height while staying resizable.
- **English UI strings** — force GTK/libadwaita built‑in widget strings (the
  assistant navigation, about dialog) to English so they match the rest of the
  interface regardless of the OS display language.
- **About dialogs** — stop `GtkAboutDialog` from auto‑selecting (highlighting)
  the program name.

## New dependencies

- System: `libadwaita` (on MSYS2: `mingw-w64-x86_64-libadwaita`).
- Go module: `github.com/diamondburned/gotk4-adwaita`.

Build unchanged otherwise: `make build_gui` (`go build -tags gtk ./cmd/gtk`).

## Testing

- [x] Builds and runs on Windows 11 (MSYS2/mingw64, GTK 4.22).
- [x] Linux
- [ ] macOS

Feedback on the direction and cross‑platform results is very welcome.
