### PR TITLE
feat(execution): remove secp256k1 account restrictions after protocol v4

### DIFF
--- a/execution/executor/batch_transfer.go
+++ b/execution/executor/batch_transfer.go
@@ -5,7 +5,6 @@ import (
 	"github.com/pactus-project/pactus/sandbox"
 	"github.com/pactus-project/pactus/types/account"
 	"github.com/pactus-project/pactus/types/amount"
-	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 )
@@ -33,11 +32,6 @@ func newBatchTransferExecutor(trx *tx.Tx, sbx sandbox.Sandbox) (*BatchTransferEx
 
 	recipients := make([]batchRecipient, len(pld.Recipients))
 	for i, r := range pld.Recipients {
-		if r.To.Type() == crypto.AddressTypeSecp256k1Account &&
-			sbx.Params().BlockVersion <= protocol.ProtocolVersion3 {
-			return nil, ErrSecp256k1AccountNotSupported
-		}
-
 		if r.To == pld.From {
 			recipients[i].Account = sender
 		} else {

--- a/execution/executor/batch_transfer_test.go
+++ b/execution/executor/batch_transfer_test.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"testing"
 
-	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 	"github.com/stretchr/testify/assert"
@@ -91,25 +90,4 @@ func TestBatchTransferToSelf(t *testing.T) {
 	assert.Equal(t, firstBalance-amt1-fee, secondBalance, "balance should only decrease by fee and first amount")
 
 	td.checkTotalCoin(t, fee)
-}
-
-func TestBatchTransferSecp256k1(t *testing.T) {
-	td := setup(t)
-
-	senderAcc, senderAddr := td.addTestAccount(t)
-	amt, fee := td.randAmountFee(senderAcc.Balance())
-	lockTime := td.sbx.CurrentHeight()
-
-	recipients := []payload.BatchRecipient{
-		{To: td.RandAccAddressSecp256k1(), Amount: amt},
-	}
-	trx := tx.NewBatchTransferTx(lockTime, senderAddr, recipients, fee)
-
-	td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion3
-	td.check(t, trx, true, ErrSecp256k1AccountNotSupported)
-	td.check(t, trx, false, ErrSecp256k1AccountNotSupported)
-
-	td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion4
-	td.check(t, trx, true, nil)
-	td.check(t, trx, false, nil)
 }

--- a/execution/executor/errors.go
+++ b/execution/executor/errors.go
@@ -70,8 +70,6 @@ var ErrWithdrawMustGoToStakeOwner = errors.New("delegated validator withdraw mus
 // ErrInvalidDelegateOwner is returned when the delegate owner is invalid.
 var ErrInvalidDelegateOwner = errors.New("invalid delegate owner")
 
-var ErrSecp256k1AccountNotSupported = errors.New("secp256k1 account is not supported yet")
-
 // SmallStakeError is returned when the stake amount is less than the minimum stake.
 type SmallStakeError struct {
 	Minimum amount.Amount

--- a/execution/executor/transfer.go
+++ b/execution/executor/transfer.go
@@ -1,11 +1,9 @@
 package executor
 
 import (
-	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/sandbox"
 	"github.com/pactus-project/pactus/types/account"
 	"github.com/pactus-project/pactus/types/amount"
-	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 )
@@ -19,11 +17,6 @@ type TransferExecutor struct {
 
 func newTransferExecutor(trx *tx.Tx, sbx sandbox.Sandbox) (*TransferExecutor, error) {
 	pld := trx.Payload().(*payload.TransferPayload)
-
-	if pld.To.Type() == crypto.AddressTypeSecp256k1Account &&
-		sbx.Params().BlockVersion <= protocol.ProtocolVersion3 {
-		return nil, ErrSecp256k1AccountNotSupported
-	}
 
 	sender := sbx.Account(pld.From)
 	if sender == nil {

--- a/execution/executor/transfer_test.go
+++ b/execution/executor/transfer_test.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"testing"
 
-	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/stretchr/testify/assert"
 )
@@ -67,22 +66,4 @@ func TestTransferToSelf(t *testing.T) {
 	assert.Equal(t, firstBalance-fee, secondBalance, "balance should only decrease by fee")
 
 	td.checkTotalCoin(t, fee)
-}
-
-func TestTransferSecp256k1(t *testing.T) {
-	td := setup(t)
-
-	senderAcc, senderAddr := td.addTestAccount(t)
-	amt, fee := td.randAmountFee(senderAcc.Balance())
-	lockTime := td.sbx.CurrentHeight()
-
-	trx := tx.NewTransferTx(lockTime, senderAddr, td.RandAccAddressSecp256k1(), amt, fee)
-
-	td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion3
-	td.check(t, trx, true, ErrSecp256k1AccountNotSupported)
-	td.check(t, trx, false, ErrSecp256k1AccountNotSupported)
-
-	td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion4
-	td.check(t, trx, true, nil)
-	td.check(t, trx, false, nil)
 }

--- a/execution/executor/withdraw.go
+++ b/execution/executor/withdraw.go
@@ -1,11 +1,9 @@
 package executor
 
 import (
-	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/sandbox"
 	"github.com/pactus-project/pactus/types/account"
 	"github.com/pactus-project/pactus/types/amount"
-	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/pactus-project/pactus/types/tx/payload"
 	"github.com/pactus-project/pactus/types/validator"
@@ -20,11 +18,6 @@ type WithdrawExecutor struct {
 
 func newWithdrawExecutor(trx *tx.Tx, sbx sandbox.Sandbox) (*WithdrawExecutor, error) {
 	pld := trx.Payload().(*payload.WithdrawPayload)
-
-	if pld.To.Type() == crypto.AddressTypeSecp256k1Account &&
-		sbx.Params().BlockVersion <= protocol.ProtocolVersion3 {
-		return nil, ErrSecp256k1AccountNotSupported
-	}
 
 	sender := sbx.Validator(pld.From)
 	if sender == nil {

--- a/execution/executor/withdraw_test.go
+++ b/execution/executor/withdraw_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/pactus-project/pactus/types/amount"
-	"github.com/pactus-project/pactus/types/protocol"
 	"github.com/pactus-project/pactus/types/tx"
 	"github.com/stretchr/testify/assert"
 )
@@ -102,27 +101,4 @@ func TestExecuteDelegatedWithdrawTx(t *testing.T) {
 	updatedOwner := td.sbx.Account(owner)
 	assert.Equal(t, totalStake-amt-fee, updatedVal.Stake())
 	assert.Equal(t, amt, updatedOwner.Balance())
-}
-
-func TestWithdrawSecp256k1(t *testing.T) {
-	td := setup(t)
-
-	val := td.addTestValidator(t)
-	totalStake := val.Stake()
-	amt, fee := td.randAmountFee(totalStake)
-	senderAddr := val.Address()
-	receiverAddr := td.RandAccAddressSecp256k1()
-	lockTime := td.sbx.CurrentHeight()
-
-	t.Run("Should fail, secp256k1 account is not supported yet", func(t *testing.T) {
-		trx := tx.NewWithdrawTx(lockTime, senderAddr, receiverAddr, amt, fee)
-
-		td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion3
-		td.check(t, trx, true, ErrSecp256k1AccountNotSupported)
-		td.check(t, trx, false, ErrSecp256k1AccountNotSupported)
-
-		td.sbx.SbxParams.BlockVersion = protocol.ProtocolVersion4
-		td.check(t, trx, true, ErrValidatorBonded)
-		td.check(t, trx, false, ErrValidatorBonded)
-	})
 }


### PR DESCRIPTION
## Description

Removes the secp256k1 account restrictions in transfer, withdraw, and batch_transfer executors, since protocol v4 now fully supports secp256k1 accounts.

Previously, transactions to secp256k1 addresses were rejected when `BlockVersion <= ProtocolVersion3`. With the protocol v4 upgrade, these restrictions are no longer needed.

## Changes

- Removed `ErrSecp256k1AccountNotSupported` error
- Removed protocol v3 version checks from `Transfer`, `Withdraw`, and `BatchTransfer` executors
- Removed corresponding test cases (`TestTransferSecp256k1`, `TestWithdrawSecp256k1`, `TestBatchTransferSecp256k1`)
- Cleaned up unused imports (`crypto`, `protocol`)