### PR TITLE
perf(consensus): optimize CanVote with O(1) map lookup

### DIFF
--- a/consensus/log/log.go
+++ b/consensus/log/log.go
@@ -117,11 +117,7 @@ func (log *Log) MoveToNewHeight(validators []*validator.Validator) {
 }
 
 func (log *Log) CanVote(addr crypto.Address) bool {
-	for _, val := range log.validators {
-		if val.Address() == addr {
-			return true
-		}
-	}
+	_, ok := log.validators[addr]
 
-	return false
+	return ok
 }

--- a/consensusv2/log/log.go
+++ b/consensusv2/log/log.go
@@ -110,13 +110,9 @@ func (log *Log) MoveToNewHeight(validators []*validator.Validator) {
 }
 
 func (log *Log) CanVote(addr crypto.Address) bool {
-	for _, val := range log.validators {
-		if val.Address() == addr {
-			return true
-		}
-	}
+	_, ok := log.validators[addr]
 
-	return false
+	return ok
 }
 
 func (log *Log) TotalPower() int64 {


### PR DESCRIPTION
## Description

Replaces the O(n) linear scan in `CanVote` with a direct O(1) map lookup in both consensus v1 and v2 log modules.

The `validators` field is already a `map[crypto.Address]*validator.Validator`, so `CanVote` can use it directly instead of iterating over all validators.

## Changes

- **`consensus/log/log.go`**: replaced `CanVote` loop with `_, ok := log.validators[addr]`
- **`consensusv2/log/log.go`**: same fix