### PR TITLE
chore(types): compact struct fields to minimize memory alignment padding

### DIFF
--- a/types/account/account_test.go
+++ b/types/account/account_test.go
@@ -3,6 +3,7 @@ package account_test
 import (
 	"encoding/hex"
 	"testing"
+	"unsafe"
 
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/types/account"
@@ -11,6 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMemoryAlignment(t *testing.T) {
+	s := unsafe.Sizeof(account.Account{})
+	assert.Equal(t, 16, int(s))
+}
 
 func TestFromBytes(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)

--- a/types/block/block_test.go
+++ b/types/block/block_test.go
@@ -3,6 +3,7 @@ package block_test
 import (
 	"encoding/hex"
 	"testing"
+	"unsafe"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/pactus-project/pactus/crypto/hash"
@@ -15,6 +16,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMemoryAlignment(t *testing.T) {
+	s1 := unsafe.Sizeof(block.Block{})
+	assert.Equal(t, 72, int(s1))
+
+	s2 := unsafe.Sizeof(block.Header{})
+	assert.Equal(t, 140, int(s2))
+}
 
 func TestBasicCheck(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)

--- a/types/block/header.go
+++ b/types/block/header.go
@@ -17,12 +17,12 @@ type Header struct {
 }
 
 type headerData struct {
-	Version         protocol.Version
 	UnixTime        uint32
 	PrevBlockHash   hash.Hash
 	StateRoot       hash.Hash
 	SortitionSeed   sortition.VerifiableSeed
 	ProposerAddress crypto.Address
+	Version         protocol.Version
 }
 
 // Version returns the block version.

--- a/types/tx/tx.go
+++ b/types/tx/tx.go
@@ -30,13 +30,13 @@ const (
 type ID = hash.Hash
 
 type Tx struct {
-	memorizedID  *ID
-	basicChecked bool
-
-	data txData
+	memorizedID *ID
+	data        txData
 }
 
 type txData struct {
+	basicChecked bool
+
 	Version   uint8
 	LockTime  types.Height
 	Fee       amount.Amount
@@ -124,17 +124,17 @@ func (tx *Tx) IsFreeTx() bool {
 }
 
 func (tx *Tx) SetSignature(sig crypto.Signature) {
-	tx.basicChecked = false
+	tx.data.basicChecked = false
 	tx.data.Signature = sig
 }
 
 func (tx *Tx) SetPublicKey(pub crypto.PublicKey) {
-	tx.basicChecked = false
+	tx.data.basicChecked = false
 	tx.data.PublicKey = pub
 }
 
 func (tx *Tx) BasicCheck() error {
-	if tx.basicChecked {
+	if tx.data.basicChecked {
 		return nil
 	}
 	if tx.Version() != versionLatest {
@@ -169,7 +169,7 @@ func (tx *Tx) BasicCheck() error {
 		return err
 	}
 
-	tx.basicChecked = true
+	tx.data.basicChecked = true
 
 	return nil
 }

--- a/types/tx/tx_test.go
+++ b/types/tx/tx_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/pactus-project/pactus/crypto"
@@ -21,6 +22,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMemoryAlignment(t *testing.T) {
+	assert.Equal(t, 88, int(unsafe.Sizeof(tx.Tx{})))
+}
 
 func TestCBORMarshaling(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)

--- a/types/validator/validator.go
+++ b/types/validator/validator.go
@@ -28,13 +28,13 @@ type validatorData struct {
 	LastSortitionHeight types.Height
 
 	// Optional delegation (PIP-49). Zero DelegateOwner means not delegated.
-	DelegateOwner  crypto.Address
-	DelegateShare  amount.Amount
 	DelegateExpiry types.Height
-
+	DelegateOwner  crypto.Address
 	// The protocol version of the validator.
 	// This is in memory and not saved to the blockchain.
 	ProtocolVersion protocol.Version
+
+	DelegateShare amount.Amount
 }
 
 const delegationPayloadSize = 21 + 8 + 4 // owner + share + expiry

--- a/types/validator/validator_test.go
+++ b/types/validator/validator_test.go
@@ -3,6 +3,7 @@ package validator_test
 import (
 	"encoding/hex"
 	"testing"
+	"unsafe"
 
 	"github.com/pactus-project/pactus/crypto/hash"
 	"github.com/pactus-project/pactus/types"
@@ -13,6 +14,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMemoryAlignment(t *testing.T) {
+	s := unsafe.Sizeof(validator.Validator{})
+	assert.Equal(t, 72, int(s))
+}
 
 func TestFromBytes(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)

--- a/types/vote/vote_test.go
+++ b/types/vote/vote_test.go
@@ -3,6 +3,7 @@ package vote_test
 import (
 	"encoding/hex"
 	"testing"
+	"unsafe"
 
 	"github.com/pactus-project/pactus/crypto"
 	"github.com/pactus-project/pactus/crypto/hash"
@@ -12,6 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMemoryAlignment(t *testing.T) {
+	s := unsafe.Sizeof(vote.Vote{})
+	assert.Equal(t, 80, int(s))
+}
 
 func TestVoteMarshaling(t *testing.T) {
 	tests := []struct {

--- a/types/vote/vote_type.go
+++ b/types/vote/vote_type.go
@@ -2,7 +2,7 @@ package vote
 
 import "fmt"
 
-type Type int
+type Type int8
 
 const (
 	VoteTypePrepare    = Type(1) // Deprecated  prepare vote


### PR DESCRIPTION
This PR improves Go struct memory layout by reordering fields to eliminate alignment padding without changing any behavior or wire format.
