### PR TITLE
feat(wallet): add migration from legacy JSON to SQLite storage

### DIFF
--- a/wallet/storage/sqlitestorage/migrate.go
+++ b/wallet/storage/sqlitestorage/migrate.go
@@ -1,0 +1,66 @@
+package sqlitestorage
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pactus-project/pactus/wallet/storage/jsonstorage"
+)
+
+// Migrate converts a legacy JSON wallet to the SQLite format and saves it at
+// the given path (a directory). The wallet metadata (network, default fee,
+// UUID and creation time), the vault and all addresses are preserved.
+// The legacy JSON wallet file is left untouched; it is up to the caller to
+// decide whether to remove it.
+func Migrate(ctx context.Context, jsonPath, path string, opts ...Option) (*Storage, error) {
+	jsonStrg, err := jsonstorage.Open(jsonPath)
+	if err != nil {
+		return nil, err
+	}
+
+	info := jsonStrg.WalletInfo()
+
+	strg, err := Create(ctx, path, info.Network, jsonStrg.Vault(), opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the partially created storage on failure.
+	cleanup := func() {
+		_ = strg.Close()
+		_ = os.RemoveAll(path)
+	}
+
+	// Preserve the wallet metadata from the legacy wallet.
+	if err := strg.SetDefaultFee(info.DefaultFee); err != nil {
+		cleanup()
+
+		return nil, err
+	}
+
+	if err := strg.updateWalletEntry(keyUUID, info.UUID); err != nil {
+		cleanup()
+
+		return nil, err
+	}
+	strg.info.UUID = info.UUID
+
+	if err := strg.updateWalletEntry(keyCreatedAt, fmt.Sprintf("%d", info.CreatedAt.Unix())); err != nil {
+		cleanup()
+
+		return nil, err
+	}
+	strg.info.CreatedAt = info.CreatedAt
+
+	// Copy all addresses from the legacy wallet.
+	for _, addrInfo := range jsonStrg.AllAddresses() {
+		if err := strg.InsertAddress(addrInfo); err != nil {
+			cleanup()
+
+			return nil, err
+		}
+	}
+
+	return strg, nil
+}

--- a/wallet/storage/sqlitestorage/migrate_test.go
+++ b/wallet/storage/sqlitestorage/migrate_test.go
@@ -1,0 +1,119 @@
+package sqlitestorage
+
+import (
+	"testing"
+
+	"github.com/pactus-project/pactus/genesis"
+	"github.com/pactus-project/pactus/types/amount"
+	"github.com/pactus-project/pactus/util"
+	"github.com/pactus-project/pactus/util/testsuite"
+	"github.com/pactus-project/pactus/wallet/addresspath"
+	"github.com/pactus-project/pactus/wallet/encrypter"
+	"github.com/pactus-project/pactus/wallet/storage/jsonstorage"
+	"github.com/pactus-project/pactus/wallet/types"
+	"github.com/pactus-project/pactus/wallet/vault"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrate(t *testing.T) {
+	ts := testsuite.NewTestSuite(t)
+
+	opts := []encrypter.Option{
+		encrypter.OptionIteration(1),
+		encrypter.OptionMemory(8),
+		encrypter.OptionParallelism(1),
+	}
+	vlt, err := vault.CreateVaultFromMnemonic(testMnemonic, addresspath.CoinTypePactusTestnet, "password", opts...)
+	require.NoError(t, err)
+
+	jsonPath := util.TempFilePath()
+	jsonStrg, err := jsonstorage.Create(jsonPath, genesis.Testnet, vlt)
+	require.NoError(t, err)
+
+	// Add some addresses to the legacy wallet.
+	expectedAddrs := make([]*types.AddressInfo, 3)
+	for i := 0; i < len(expectedAddrs); i++ {
+		addrInfo := &types.AddressInfo{
+			Address:   ts.RandAccAddress().String(),
+			PublicKey: ts.RandString(32),
+			Label:     ts.RandString(16),
+			Path:      ts.RandString(16),
+		}
+		require.NoError(t, jsonStrg.InsertAddress(addrInfo))
+		expectedAddrs[i] = addrInfo
+	}
+
+	jsonInfo := jsonStrg.WalletInfo()
+
+	sqlitePath := util.TempDirPath()
+	strg, err := Migrate(t.Context(), jsonPath, sqlitePath)
+	require.NoError(t, err)
+	defer func() { _ = strg.Close() }()
+
+	// The legacy JSON wallet should be left untouched.
+	assert.True(t, util.PathExists(jsonPath))
+
+	// The wallet metadata should be preserved.
+	info := strg.WalletInfo()
+	assert.Equal(t, "SQLite", info.Driver)
+	assert.Equal(t, jsonInfo.Network, info.Network)
+	assert.Equal(t, jsonInfo.DefaultFee, info.DefaultFee)
+	assert.Equal(t, jsonInfo.UUID, info.UUID)
+	assert.True(t, jsonInfo.CreatedAt.Equal(info.CreatedAt))
+
+	// The vault should be preserved.
+	assert.Equal(t, jsonStrg.Vault(), strg.Vault())
+
+	// The addresses should be preserved.
+	require.Equal(t, len(expectedAddrs), strg.AddressCount())
+	for _, expected := range expectedAddrs {
+		got, err := strg.AddressInfo(expected.Address)
+		require.NoError(t, err)
+		assert.Equal(t, expected.Address, got.Address)
+		assert.Equal(t, expected.PublicKey, got.PublicKey)
+		assert.Equal(t, expected.Label, got.Label)
+		assert.Equal(t, expected.Path, got.Path)
+	}
+}
+
+func TestMigrateInvalidJSON(t *testing.T) {
+	jsonPath := util.TempFilePath()
+	require.NoError(t, util.WriteFile(jsonPath, []byte("invalid_data")))
+
+	_, err := Migrate(t.Context(), jsonPath, util.TempDirPath())
+	require.Error(t, err)
+
+	// The invalid file should not be deleted.
+	assert.True(t, util.PathExists(jsonPath))
+}
+
+// TestMigrateLegacyWallet migrates a real legacy (version 4) JSON wallet that
+// needs to be upgraded to the latest version before the migration.
+func TestMigrateLegacyWallet(t *testing.T) {
+	data, err := util.ReadFile("../jsonstorage/testdata/wallet_version_4")
+	require.NoError(t, err)
+
+	jsonPath := util.TempFilePath()
+	require.NoError(t, util.WriteFile(jsonPath, data))
+
+	sqlitePath := util.TempDirPath()
+	strg, err := Migrate(t.Context(), jsonPath, sqlitePath)
+	require.NoError(t, err)
+	defer func() { _ = strg.Close() }()
+
+	// The legacy JSON wallet should be left untouched.
+	assert.True(t, util.PathExists(jsonPath))
+
+	// The wallet metadata should be preserved.
+	info := strg.WalletInfo()
+	assert.Equal(t, VersionLatest, info.Version)
+	assert.Equal(t, genesis.Mainnet, info.Network)
+	assert.Equal(t, amount.Amount(2e7), info.DefaultFee) // 0.02 PAC
+
+	// The vault should be intact.
+	assert.True(t, strg.Vault().IsEncrypted())
+
+	// The addresses should be preserved (wallet_version_4 has 5 addresses).
+	assert.Equal(t, 5, strg.AddressCount())
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pactus-project/gopkg/logger"
 	"github.com/pactus-project/gopkg/pipeline"
@@ -108,6 +109,37 @@ func Open(ctx context.Context, walletPath string, opts ...OpenWalletOption) (*Wa
 	}
 
 	return New(ctx, jsonStrg, opts...)
+}
+
+// Migrate converts a legacy JSON wallet to the SQLite format and saves it at
+// the given path (a directory). The wallet metadata (network, default fee,
+// UUID and creation time), the vault and all addresses are preserved.
+// The legacy JSON wallet file is left untouched; it is up to the caller to
+// decide whether to remove it.
+func Migrate(ctx context.Context, jsonPath, sqlitePath string, opts ...OpenWalletOption) (*Wallet, error) {
+	jsonPath = util.MakeAbs(jsonPath)
+	sqlitePath = util.MakeAbs(sqlitePath)
+
+	if util.IsDir(jsonPath) {
+		return nil, fmt.Errorf("not a legacy JSON wallet: %s", jsonPath)
+	}
+
+	if util.PathExists(sqlitePath) {
+		return nil, ExitsError{Path: sqlitePath}
+	}
+
+	cfg := defaultOpenWalletConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	strg, err := sqlitestorage.Migrate(ctx, jsonPath, sqlitePath,
+		sqlitestorage.WithLockingMode(cfg.lockMode))
+	if err != nil {
+		return nil, err
+	}
+
+	return New(ctx, strg, opts...)
 }
 
 type openWalletConfig struct {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/pactus-project/pactus/wallet/provider"
 	"github.com/pactus-project/pactus/wallet/provider/offline"
 	"github.com/pactus-project/pactus/wallet/storage"
+	"github.com/pactus-project/pactus/wallet/storage/jsonstorage"
 	wtypes "github.com/pactus-project/pactus/wallet/types"
 	"github.com/pactus-project/pactus/wallet/vault"
 	"github.com/stretchr/testify/assert"
@@ -779,5 +781,94 @@ func TestUpdatePassword(t *testing.T) {
 		err := td.wallet.UpdatePassword(td.password, "new-password", opts...)
 		require.NoError(t, err)
 		assert.True(t, td.testVault.IsEncrypted())
+	})
+}
+
+func TestMigrate(t *testing.T) {
+	newTestVault := func(t *testing.T) *vault.Vault {
+		t.Helper()
+
+		opts := []encrypter.Option{
+			encrypter.OptionIteration(1),
+			encrypter.OptionMemory(8),
+			encrypter.OptionParallelism(1),
+		}
+		mnemonic, _ := GenerateMnemonic(128)
+		vlt, err := vault.CreateVaultFromMnemonic(mnemonic, addresspath.CoinTypePactusTestnet, "password", opts...)
+		require.NoError(t, err)
+
+		return vlt
+	}
+
+	t.Run("Migrate legacy JSON wallet", func(t *testing.T) {
+		ts := testsuite.NewTestSuite(t)
+
+		vlt := newTestVault(t)
+		jsonPath := util.TempFilePath()
+		jsonStrg, err := jsonstorage.Create(jsonPath, genesis.Testnet, vlt)
+		require.NoError(t, err)
+
+		addrInfo := &wtypes.AddressInfo{
+			Address:   ts.RandAccAddress().String(),
+			PublicKey: ts.RandString(32),
+			Label:     ts.RandString(16),
+			Path:      ts.RandString(16),
+		}
+		require.NoError(t, jsonStrg.InsertAddress(addrInfo))
+		jsonInfo := jsonStrg.WalletInfo()
+
+		sqlitePath := filepath.Join(util.TempDirPath(), "wallet")
+		wlt, err := Migrate(t.Context(), jsonPath, sqlitePath, WithOfflineProvider())
+		require.NoError(t, err)
+		defer wlt.Close()
+
+		// The legacy JSON file should be left untouched.
+		assert.True(t, util.PathExists(jsonPath))
+
+		// The wallet info should be preserved.
+		info := wlt.Info()
+		assert.Equal(t, "SQLite", info.Driver)
+		assert.Equal(t, jsonInfo.Network, info.Network)
+		assert.Equal(t, jsonInfo.DefaultFee, info.DefaultFee)
+		assert.Equal(t, jsonInfo.UUID, info.UUID)
+		assert.True(t, jsonInfo.CreatedAt.Equal(info.CreatedAt))
+
+		// The address should be preserved.
+		migratedAddr, err := wlt.AddressInfo(addrInfo.Address)
+		require.NoError(t, err)
+		assert.Equal(t, addrInfo.Address, migratedAddr.Address)
+		assert.Equal(t, addrInfo.PublicKey, migratedAddr.PublicKey)
+		assert.Equal(t, addrInfo.Label, migratedAddr.Label)
+		assert.Equal(t, addrInfo.Path, migratedAddr.Path)
+	})
+
+	t.Run("Invalid legacy wallet", func(t *testing.T) {
+		jsonPath := util.TempFilePath()
+		require.NoError(t, util.WriteFile(jsonPath, []byte("invalid_data")))
+
+		_, err := Migrate(t.Context(), jsonPath, util.TempDirPath(), WithOfflineProvider())
+		require.Error(t, err)
+
+		// The invalid file should not be deleted.
+		assert.True(t, util.PathExists(jsonPath))
+	})
+
+	t.Run("Destination already exists", func(t *testing.T) {
+		vlt := newTestVault(t)
+		jsonPath := util.TempFilePath()
+		_, err := jsonstorage.Create(jsonPath, genesis.Testnet, vlt)
+		require.NoError(t, err)
+
+		sqlitePath := util.TempDirPath()
+		_, err = Migrate(t.Context(), jsonPath, sqlitePath, WithOfflineProvider())
+		require.ErrorIs(t, err, ExitsError{Path: sqlitePath})
+
+		// The legacy file should not be deleted.
+		assert.True(t, util.PathExists(jsonPath))
+	})
+
+	t.Run("Invalid source path", func(t *testing.T) {
+		_, err := Migrate(t.Context(), util.TempDirPath(), util.TempDirPath(), WithOfflineProvider())
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Description

Adds a `wallet.Migrate` function that converts a legacy JSON wallet to the SQLite format:

- Preserves the vault, all addresses, network, default fee, UUID and creation time
- Stores the migrated wallet as a directory (SQLite layout) at a new path
- Leaves the legacy JSON wallet file untouched; it is up to the caller to decide whether to remove it
- On any failure, the legacy file is left untouched (rolls back the partially created SQLite storage)

The conversion itself lives in `sqlitestorage.Migrate`, while `wallet.Migrate` provides the public API mirroring the existing `Create`/`Open` pattern and returns a usable SQLite-backed wallet.

## Related Issue

Fixes #2387