### PR TITLE
feat(cmd): add migrate command for legacy JSON wallets

### DIFF
--- a/cmd/wallet/main.go
+++ b/cmd/wallet/main.go
@@ -91,6 +91,7 @@ func main() {
 	buildTransactionCmd(rootCmd)
 	buildInfoCmd(rootCmd)
 	buildNeuterCmd(rootCmd)
+	buildMigrateCmd(rootCmd)
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/cmd/wallet/migrate.go
+++ b/cmd/wallet/migrate.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pactus-project/pactus/util/terminal"
+	"github.com/pactus-project/pactus/wallet"
+	"github.com/spf13/cobra"
+)
+
+// buildMigrateCmd builds the migrate command to convert a legacy JSON wallet
+// to the SQLite format.
+func buildMigrateCmd(parentCmd *cobra.Command) {
+	migrateCmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "migrate the legacy JSON wallet to the SQLite format",
+	}
+	parentCmd.AddCommand(migrateCmd)
+
+	toOpt := migrateCmd.Flags().String("to", "",
+		"path to save the migrated SQLite wallet (default: the source path without the .json extension)")
+
+	migrateCmd.Run = func(_ *cobra.Command, _ []string) {
+		srcPath := *pathOpt
+		dstPath := *toOpt
+		if dstPath == "" {
+			dstPath = strings.TrimSuffix(srcPath, ".json")
+			if dstPath == srcPath {
+				dstPath = srcPath + ".sqlite"
+			}
+		}
+
+		wlt, err := wallet.Migrate(context.Background(), srcPath, dstPath, wallet.WithOfflineProvider())
+		terminal.FatalErrorCheck(err)
+		defer wlt.Close()
+
+		terminal.PrintSuccessMsgf("wallet migrated to %s", dstPath)
+		terminal.PrintInfoMsgf("the legacy JSON wallet is kept at %s; remove it manually if it is no longer needed", srcPath)
+	}
+}


### PR DESCRIPTION
## Description

Adds a `migrate` command to the wallet CLI that converts a legacy JSON wallet to the SQLite format, building on the `wallet.Migrate` API added in #2388:

```
pactus-wallet migrate --path <legacy-json-wallet>
```

- Default destination: the source path without the `.json` extension (a SQLite wallet directory), e.g. `default_wallet.json` → `default_wallet`
- Optional `--to` flag to specify the destination path
- Runs offline (`wallet.WithOfflineProvider`); no node connection is required
- The legacy JSON wallet file is kept after migration; the command informs the user it can be removed manually

## Related Issue

Fixes #2389