### PR TITLE
refactor(state): use ProtocolVersionLatest for block version upgrade

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -410,9 +410,9 @@ func (st *state) ProposeBlock(valKey *bls.ValidatorKey, rewardAddr crypto.Addres
 // Based on PIP-51, if more than 75% of the committee's power supports a higher
 // version, the proposer increases the block version.
 func (st *state) proposeBlockVersion() protocol.Version {
-	if st.params.BlockVersion < protocol.ProtocolVersion4 &&
-		st.committee.SupportProtocolVersion(protocol.ProtocolVersion4) {
-		return protocol.ProtocolVersion4
+	if st.params.BlockVersion < protocol.ProtocolVersionLatest &&
+		st.committee.SupportProtocolVersion(protocol.ProtocolVersionLatest) {
+		return protocol.ProtocolVersionLatest
 	}
 
 	return st.params.BlockVersion

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -829,6 +829,35 @@ func TestBlockVersionUpgrade(t *testing.T) {
 	assert.Equal(t, protocol.ProtocolVersionLatest, td2.state.Params().BlockVersion)
 }
 
+func TestProposeBlockVersion(t *testing.T) {
+	t.Run("Committee supports the latest version", func(t *testing.T) {
+		td := setupWithVersion(t, protocol.ProtocolVersionLatest-1)
+
+		// Update all committee validators to support the latest protocol version
+		vals := td.state.committee.Validators()
+		for _, val := range vals {
+			val.UpdateProtocolVersion(protocol.ProtocolVersionLatest)
+		}
+		td.state.committee.Update(0, vals)
+
+		assert.True(t, td.state.committee.SupportProtocolVersion(protocol.ProtocolVersionLatest))
+		assert.Equal(t, protocol.ProtocolVersionLatest, td.state.proposeBlockVersion())
+	})
+
+	t.Run("Committee does not support the latest version", func(t *testing.T) {
+		td := setupWithVersion(t, protocol.ProtocolVersionLatest-1)
+
+		assert.False(t, td.state.committee.SupportProtocolVersion(protocol.ProtocolVersionLatest))
+		assert.Equal(t, protocol.ProtocolVersionLatest-1, td.state.proposeBlockVersion())
+	})
+
+	t.Run("Block version is already the latest", func(t *testing.T) {
+		td := setupWithVersion(t, protocol.ProtocolVersionLatest)
+
+		assert.Equal(t, protocol.ProtocolVersionLatest, td.state.proposeBlockVersion())
+	})
+}
+
 func TestChainInfo(t *testing.T) {
 	td := setup(t)
 


### PR DESCRIPTION
## Description

The `proposeBlockVersion` function hardcodes `protocol.ProtocolVersion4` for the PIP-51 block version upgrade. This means that when a new protocol version (e.g. v5) is introduced in the future, the proposer will never bump the block version to the newest version.

This PR replaces the hardcoded `ProtocolVersion4` with `protocol.ProtocolVersionLatest`, making the upgrade logic permanent: the proposer automatically upgrades the block version to the latest protocol version supported by more than 75% of the committee's power (per PIP-51), without any code changes for future versions.

A new unit test (`TestProposeBlockVersion`) is added covering three scenarios:
- Committee supports the latest version -> block version bumps to the latest
- Committee does not support the latest version -> block version stays at the current one
- Block version is already the latest -> remains the latest

## Related Issue

Fixes #2391