### PR TITLE
feat(wallet): migrate legacy JSON wallet in place

### DIFF
--- a/cmd/wallet/migrate.go
+++ b/cmd/wallet/migrate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"strings"
 
 	"github.com/pactus-project/pactus/util/terminal"
 	"github.com/pactus-project/pactus/wallet"
@@ -10,7 +9,7 @@ import (
 )
 
 // buildMigrateCmd builds the migrate command to convert a legacy JSON wallet
-// to the SQLite format.
+// to the SQLite format in place.
 func buildMigrateCmd(parentCmd *cobra.Command) {
 	migrateCmd := &cobra.Command{
 		Use:   "migrate",
@@ -18,24 +17,12 @@ func buildMigrateCmd(parentCmd *cobra.Command) {
 	}
 	parentCmd.AddCommand(migrateCmd)
 
-	toOpt := migrateCmd.Flags().String("to", "",
-		"path to save the migrated SQLite wallet (default: the source path without the .json extension)")
-
 	migrateCmd.Run = func(_ *cobra.Command, _ []string) {
 		srcPath := *pathOpt
-		dstPath := *toOpt
-		if dstPath == "" {
-			dstPath = strings.TrimSuffix(srcPath, ".json")
-			if dstPath == srcPath {
-				dstPath = srcPath + ".sqlite"
-			}
-		}
 
-		wlt, err := wallet.Migrate(context.Background(), srcPath, dstPath, wallet.WithOfflineProvider())
+		err := wallet.Migrate(context.Background(), srcPath)
 		terminal.FatalErrorCheck(err)
-		defer wlt.Close()
 
-		terminal.PrintSuccessMsgf("wallet migrated to %s", dstPath)
-		terminal.PrintInfoMsgf("the legacy JSON wallet is kept at %s; remove it manually if it is no longer needed", srcPath)
+		terminal.PrintSuccessMsgf("wallet migrated to SQLite format at %s", srcPath)
 	}
 }

--- a/util/io.go
+++ b/util/io.go
@@ -225,7 +225,7 @@ func MoveDirectory(srcDir, dstDir string) error {
 	err := os.Rename(srcDir, dstDir)
 	if err != nil {
 		// To prevent invalid cross-device link perform a manual copy
-		if err := copyDirectory(srcDir, dstDir); err != nil {
+		if err := CopyDirectory(srcDir, dstDir); err != nil {
 			return fmt.Errorf("failed to move directory from %s to %s: %w", srcDir, dstDir, err)
 		}
 
@@ -238,7 +238,7 @@ func MoveDirectory(srcDir, dstDir string) error {
 	return nil
 }
 
-func copyDirectory(src, dst string) error {
+func CopyDirectory(src, dst string) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -254,15 +254,20 @@ func copyDirectory(src, dst string) error {
 			return os.MkdirAll(dstPath, info.Mode())
 		}
 
-		return copyFile(path, dstPath, info)
+		return CopyFile(path, dstPath)
 	})
 }
 
-func copyFile(src, dst string, info os.FileInfo) error {
+func CopyFile(src, dst string) error {
 	input, err := os.Open(src)
 	if err != nil {
 		return err
 	}
+	info, err := input.Stat()
+	if err != nil {
+		return err
+	}
+
 	defer func() {
 		_ = input.Close()
 	}()

--- a/util/io_test.go
+++ b/util/io_test.go
@@ -137,49 +137,72 @@ func TestMoveDirectory(t *testing.T) {
 	})
 
 	t.Run("MoveDirectorySuccess", func(t *testing.T) {
-		// Create temporary directories
-		srcDir := TempDirPath()
-		dstDir := TempDirPath()
-		defer func() { _ = os.RemoveAll(srcDir) }()
-		defer func() { _ = os.RemoveAll(dstDir) }()
 
-		// Create a subdirectory in the source directory
-		subDir := filepath.Join(srcDir, "subdir")
-		err := Mkdir(subDir)
-		require.NoError(t, err)
-
-		// Create multiple files in the subdirectory
-		files := []struct {
-			name    string
-			content string
-		}{
-			{"file1.txt", "content 1"},
-			{"file2.txt", "content 2"},
+		type testCase struct {
+			name   string
+			srcDir string
+			dstDir string
 		}
 
-		for _, file := range files {
-			filePath := filepath.Join(subDir, file.name)
-			err = WriteFile(filePath, []byte(file.content))
-			require.NoError(t, err)
+		tests := []testCase{
+			{
+				name:   "move between directories",
+				srcDir: TempDirPath(),
+				dstDir: TempDirPath(),
+			},
 		}
 
-		// Move the directory
-		dstDirPath := filepath.Join(dstDir, "movedir")
-		err = MoveDirectory(srcDir, dstDirPath)
-		require.NoError(t, err)
+		if runtime.GOOS == "linux" {
+			tests = append(tests, testCase{
+				name:   "invalid cross-device link",
+				srcDir: TempDirPath(),
+				dstDir: "/dev/shm/test",
+			})
+		}
 
-		// Assert the source directory no longer exists
-		assert.False(t, PathExists(srcDir))
+		for _, tt := range tests {
 
-		// Assert the destination directory exists
-		assert.True(t, PathExists(dstDirPath))
+			defer func() { _ = os.RemoveAll(tt.srcDir) }()
+			defer func() { _ = os.RemoveAll(tt.dstDir) }()
 
-		// Verify that all files have been moved and their contents are correct
-		for _, file := range files {
-			movedFilePath := filepath.Join(dstDirPath, "subdir", file.name)
-			data, err := ReadFile(movedFilePath)
+			// Create a subdirectory in the source directory
+			subDir := filepath.Join(tt.srcDir, "subdir")
+			err := Mkdir(subDir)
 			require.NoError(t, err)
-			assert.Equal(t, file.content, string(data))
+
+			// Create multiple files in the subdirectory
+			files := []struct {
+				name    string
+				content string
+			}{
+				{"file1.txt", "content 1"},
+				{"file2.txt", "content 2"},
+			}
+
+			for _, file := range files {
+				filePath := filepath.Join(subDir, file.name)
+				err = WriteFile(filePath, []byte(file.content))
+				require.NoError(t, err)
+			}
+
+			// Move the directory
+			dstDirPath := filepath.Join(tt.dstDir, "movedir")
+			err = MoveDirectory(tt.srcDir, dstDirPath)
+			require.NoError(t, err)
+
+			// Assert the source directory no longer exists
+			assert.False(t, PathExists(tt.srcDir))
+
+			// Assert the destination directory exists
+			assert.True(t, PathExists(dstDirPath))
+
+			// Verify that all files have been moved and their contents are correct
+			for _, file := range files {
+				movedFilePath := filepath.Join(dstDirPath, "subdir", file.name)
+				data, err := ReadFile(movedFilePath)
+				require.NoError(t, err)
+				assert.Equal(t, file.content, string(data))
+			}
 		}
 	})
 }

--- a/util/io_test.go
+++ b/util/io_test.go
@@ -137,7 +137,6 @@ func TestMoveDirectory(t *testing.T) {
 	})
 
 	t.Run("MoveDirectorySuccess", func(t *testing.T) {
-
 		type testCase struct {
 			name   string
 			srcDir string
@@ -161,10 +160,6 @@ func TestMoveDirectory(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-
-			defer func() { _ = os.RemoveAll(tt.srcDir) }()
-			defer func() { _ = os.RemoveAll(tt.dstDir) }()
-
 			// Create a subdirectory in the source directory
 			subDir := filepath.Join(tt.srcDir, "subdir")
 			err := Mkdir(subDir)
@@ -203,6 +198,9 @@ func TestMoveDirectory(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, file.content, string(data))
 			}
+
+			_ = os.RemoveAll(tt.srcDir)
+			_ = os.RemoveAll(tt.dstDir)
 		}
 	})
 }

--- a/wallet/storage/jsonstorage/upgrader_test.go
+++ b/wallet/storage/jsonstorage/upgrader_test.go
@@ -13,11 +13,8 @@ import (
 func openTestStorage(t *testing.T, path string) (*Storage, error) {
 	t.Helper()
 
-	data, err := util.ReadFile(path)
-	require.NoError(t, err)
-
 	tempPath := util.TempFilePath()
-	err = util.WriteFile(tempPath, data)
+	err := util.CopyFile(path, tempPath)
 	require.NoError(t, err)
 
 	return Open(tempPath)

--- a/wallet/storage/sqlitestorage/migrate.go
+++ b/wallet/storage/sqlitestorage/migrate.go
@@ -2,65 +2,34 @@ package sqlitestorage
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/pactus-project/pactus/wallet/storage/jsonstorage"
 )
 
-// Migrate converts a legacy JSON wallet to the SQLite format and saves it at
-// the given path (a directory). The wallet metadata (network, default fee,
-// UUID and creation time), the vault and all addresses are preserved.
-// The legacy JSON wallet file is left untouched; it is up to the caller to
-// decide whether to remove it.
-func Migrate(ctx context.Context, jsonPath, path string, opts ...Option) (*Storage, error) {
-	jsonStrg, err := jsonstorage.Open(jsonPath)
-	if err != nil {
-		return nil, err
-	}
-
+// Migrate converts a legacy JSON wallet to the SQLite format.
+func Migrate(ctx context.Context, path string, jsonStrg *jsonstorage.Storage) error {
 	info := jsonStrg.WalletInfo()
 
-	strg, err := Create(ctx, path, info.Network, jsonStrg.Vault(), opts...)
+	strg, err := Create(ctx, path, info.Network, jsonStrg.Vault())
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	// Remove the partially created storage on failure.
-	cleanup := func() {
+	defer func() {
 		_ = strg.Close()
-		_ = os.RemoveAll(path)
-	}
+	}()
 
 	// Preserve the wallet metadata from the legacy wallet.
 	if err := strg.SetDefaultFee(info.DefaultFee); err != nil {
-		cleanup()
-
-		return nil, err
+		return err
 	}
-
-	if err := strg.updateWalletEntry(keyUUID, info.UUID); err != nil {
-		cleanup()
-
-		return nil, err
-	}
-	strg.info.UUID = info.UUID
-
-	if err := strg.updateWalletEntry(keyCreatedAt, fmt.Sprintf("%d", info.CreatedAt.Unix())); err != nil {
-		cleanup()
-
-		return nil, err
-	}
-	strg.info.CreatedAt = info.CreatedAt
 
 	// Copy all addresses from the legacy wallet.
 	for _, addrInfo := range jsonStrg.AllAddresses() {
 		if err := strg.InsertAddress(addrInfo); err != nil {
-			cleanup()
-
-			return nil, err
+			return err
 		}
 	}
 
-	return strg, nil
+	return nil
 }

--- a/wallet/storage/sqlitestorage/migrate_test.go
+++ b/wallet/storage/sqlitestorage/migrate_test.go
@@ -64,7 +64,7 @@ func TestMigrate(t *testing.T) {
 		assert.Equal(t, "SQLite", strg.WalletInfo().Driver)
 		assert.Equal(t, defFee, strg.WalletInfo().DefaultFee)
 		assert.Equal(t, genesis.Mainnet, strg.WalletInfo().Network)
-		assert.Equal(t, true, strg.WalletInfo().Encrypted)
+		assert.True(t, strg.WalletInfo().Encrypted)
 		assert.Equal(t, path, strg.WalletInfo().Path)
 		assert.Equal(t, VersionLatest, strg.WalletInfo().Version)
 
@@ -76,7 +76,7 @@ func TestMigrate(t *testing.T) {
 
 	t.Run("Neutered migration", func(t *testing.T) {
 		vlt.Neuter()
-		jsonStrg.UpdateVault(vlt)
+		_ = jsonStrg.UpdateVault(vlt)
 
 		path := util.TempFilePath()
 		err := Migrate(t.Context(), path, jsonStrg)
@@ -86,7 +86,7 @@ func TestMigrate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, vlt, strg.Vault())
-		assert.Equal(t, false, strg.WalletInfo().Encrypted)
-		assert.Equal(t, true, strg.WalletInfo().Neutered)
+		assert.False(t, strg.WalletInfo().Encrypted)
+		assert.True(t, strg.WalletInfo().Neutered)
 	})
 }

--- a/wallet/storage/sqlitestorage/migrate_test.go
+++ b/wallet/storage/sqlitestorage/migrate_test.go
@@ -4,13 +4,11 @@ import (
 	"testing"
 
 	"github.com/pactus-project/pactus/genesis"
-	"github.com/pactus-project/pactus/types/amount"
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/testsuite"
 	"github.com/pactus-project/pactus/wallet/addresspath"
 	"github.com/pactus-project/pactus/wallet/encrypter"
 	"github.com/pactus-project/pactus/wallet/storage/jsonstorage"
-	"github.com/pactus-project/pactus/wallet/types"
 	"github.com/pactus-project/pactus/wallet/vault"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,96 +22,71 @@ func TestMigrate(t *testing.T) {
 		encrypter.OptionMemory(8),
 		encrypter.OptionParallelism(1),
 	}
-	vlt, err := vault.CreateVaultFromMnemonic(testMnemonic, addresspath.CoinTypePactusTestnet, "password", opts...)
+	password := ts.RandString(12)
+	vlt, err := vault.CreateVaultFromMnemonic(testMnemonic,
+		addresspath.CoinTypePactusMainnet, password, opts...)
 	require.NoError(t, err)
 
 	jsonPath := util.TempFilePath()
-	jsonStrg, err := jsonstorage.Create(jsonPath, genesis.Testnet, vlt)
+	jsonStrg, err := jsonstorage.Create(jsonPath, genesis.Mainnet, vlt)
 	require.NoError(t, err)
 
 	// Add some addresses to the legacy wallet.
-	expectedAddrs := make([]*types.AddressInfo, 3)
-	for i := 0; i < len(expectedAddrs); i++ {
-		addrInfo := &types.AddressInfo{
-			Address:   ts.RandAccAddress().String(),
-			PublicKey: ts.RandString(32),
-			Label:     ts.RandString(16),
-			Path:      ts.RandString(16),
-		}
-		require.NoError(t, jsonStrg.InsertAddress(addrInfo))
-		expectedAddrs[i] = addrInfo
-	}
+	addr1, _ := vlt.NewValidatorAddress("addr 1")
+	addr2, _ := vlt.NewBLSAccountAddress("addr 2")
+	addr3, _ := vlt.NewEd25519AccountAddress("addr 3", password)
+	addr4, _ := vlt.NewSecp256k1AccountAddress("addr 4", password)
 
-	jsonInfo := jsonStrg.WalletInfo()
+	_ = jsonStrg.InsertAddress(addr1)
+	_ = jsonStrg.InsertAddress(addr2)
+	_ = jsonStrg.InsertAddress(addr3)
+	_ = jsonStrg.InsertAddress(addr4)
 
-	sqlitePath := util.TempDirPath()
-	strg, err := Migrate(t.Context(), jsonPath, sqlitePath)
-	require.NoError(t, err)
-	defer func() { _ = strg.Close() }()
+	defFee := ts.RandFee()
+	_ = jsonStrg.SetDefaultFee(defFee)
 
-	// The legacy JSON wallet should be left untouched.
-	assert.True(t, util.PathExists(jsonPath))
+	_ = jsonStrg.UpdateVault(vlt)
 
-	// The wallet metadata should be preserved.
-	info := strg.WalletInfo()
-	assert.Equal(t, "SQLite", info.Driver)
-	assert.Equal(t, jsonInfo.Network, info.Network)
-	assert.Equal(t, jsonInfo.DefaultFee, info.DefaultFee)
-	assert.Equal(t, jsonInfo.UUID, info.UUID)
-	assert.True(t, jsonInfo.CreatedAt.Equal(info.CreatedAt))
+	t.Run("Migration to the same path (invalid)", func(t *testing.T) {
+		err := Migrate(t.Context(), jsonPath, jsonStrg)
+		require.Error(t, err)
+	})
 
-	// The vault should be preserved.
-	assert.Equal(t, jsonStrg.Vault(), strg.Vault())
-
-	// The addresses should be preserved.
-	require.Equal(t, len(expectedAddrs), strg.AddressCount())
-	for _, expected := range expectedAddrs {
-		got, err := strg.AddressInfo(expected.Address)
+	t.Run("Successful migration", func(t *testing.T) {
+		path := util.TempFilePath()
+		err := Migrate(t.Context(), path, jsonStrg)
 		require.NoError(t, err)
-		assert.Equal(t, expected.Address, got.Address)
-		assert.Equal(t, expected.PublicKey, got.PublicKey)
-		assert.Equal(t, expected.Label, got.Label)
-		assert.Equal(t, expected.Path, got.Path)
-	}
-}
 
-func TestMigrateInvalidJSON(t *testing.T) {
-	jsonPath := util.TempFilePath()
-	require.NoError(t, util.WriteFile(jsonPath, []byte("invalid_data")))
+		strg, err := Open(t.Context(), path)
+		require.NoError(t, err)
 
-	_, err := Migrate(t.Context(), jsonPath, util.TempDirPath())
-	require.Error(t, err)
+		assert.Equal(t, vlt, strg.Vault())
+		assert.Equal(t, "SQLite", strg.WalletInfo().Driver)
+		assert.Equal(t, defFee, strg.WalletInfo().DefaultFee)
+		assert.Equal(t, genesis.Mainnet, strg.WalletInfo().Network)
+		assert.Equal(t, true, strg.WalletInfo().Encrypted)
+		assert.Equal(t, path, strg.WalletInfo().Path)
+		assert.Equal(t, VersionLatest, strg.WalletInfo().Version)
 
-	// The invalid file should not be deleted.
-	assert.True(t, util.PathExists(jsonPath))
-}
+		assert.True(t, strg.HasAddress(addr1.Address))
+		assert.True(t, strg.HasAddress(addr2.Address))
+		assert.True(t, strg.HasAddress(addr3.Address))
+		assert.True(t, strg.HasAddress(addr4.Address))
+	})
 
-// TestMigrateLegacyWallet migrates a real legacy (version 4) JSON wallet that
-// needs to be upgraded to the latest version before the migration.
-func TestMigrateLegacyWallet(t *testing.T) {
-	data, err := util.ReadFile("../jsonstorage/testdata/wallet_version_4")
-	require.NoError(t, err)
+	t.Run("Neutered migration", func(t *testing.T) {
+		vlt.Neuter()
+		jsonStrg.UpdateVault(vlt)
 
-	jsonPath := util.TempFilePath()
-	require.NoError(t, util.WriteFile(jsonPath, data))
+		path := util.TempFilePath()
+		err := Migrate(t.Context(), path, jsonStrg)
+		require.NoError(t, err)
 
-	sqlitePath := util.TempDirPath()
-	strg, err := Migrate(t.Context(), jsonPath, sqlitePath)
-	require.NoError(t, err)
-	defer func() { _ = strg.Close() }()
+		strg, err := Open(t.Context(), path)
+		require.NoError(t, err)
 
-	// The legacy JSON wallet should be left untouched.
-	assert.True(t, util.PathExists(jsonPath))
-
-	// The wallet metadata should be preserved.
-	info := strg.WalletInfo()
-	assert.Equal(t, VersionLatest, info.Version)
-	assert.Equal(t, genesis.Mainnet, info.Network)
-	assert.Equal(t, amount.Amount(2e7), info.DefaultFee) // 0.02 PAC
-
-	// The vault should be intact.
-	assert.True(t, strg.Vault().IsEncrypted())
-
-	// The addresses should be preserved (wallet_version_4 has 5 addresses).
-	assert.Equal(t, 5, strg.AddressCount())
+		assert.Equal(t, vlt, strg.Vault())
+		assert.Equal(t, false, strg.WalletInfo().Encrypted)
+		assert.Equal(t, true, strg.WalletInfo().Neutered)
+	})
 }

--- a/wallet/storage/sqlitestorage/upgrader_test.go
+++ b/wallet/storage/sqlitestorage/upgrader_test.go
@@ -1,7 +1,6 @@
 package sqlitestorage
 
 import (
-	"path"
 	"testing"
 
 	"github.com/pactus-project/pactus/genesis"
@@ -13,11 +12,8 @@ import (
 func openTestStorage(t *testing.T, dir string) (*Storage, error) {
 	t.Helper()
 
-	data, err := util.ReadFile(path.Join(dir, "wallet.db"))
-	require.NoError(t, err)
-
 	tempPath := util.TempDirPath()
-	err = util.WriteFile(path.Join(tempPath, "wallet.db"), data)
+	err := util.CopyDirectory(dir, tempPath)
 	require.NoError(t, err)
 
 	return Open(t.Context(), tempPath)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/pactus-project/gopkg/logger"
 	"github.com/pactus-project/gopkg/pipeline"
@@ -111,35 +112,35 @@ func Open(ctx context.Context, walletPath string, opts ...OpenWalletOption) (*Wa
 	return New(ctx, jsonStrg, opts...)
 }
 
-// Migrate converts a legacy JSON wallet to the SQLite format and saves it at
-// the given path (a directory). The wallet metadata (network, default fee,
-// UUID and creation time), the vault and all addresses are preserved.
-// The legacy JSON wallet file is left untouched; it is up to the caller to
-// decide whether to remove it.
-func Migrate(ctx context.Context, jsonPath, sqlitePath string, opts ...OpenWalletOption) (*Wallet, error) {
-	jsonPath = util.MakeAbs(jsonPath)
-	sqlitePath = util.MakeAbs(sqlitePath)
+// Migrate converts a legacy JSON wallet to the SQLite format in place: the
+// JSON file at the given path is replaced by a SQLite wallet directory at the
+// same path.
+//
+// If the migration fails, the original JSON wallet is restored.
+func Migrate(ctx context.Context, jsonPath string) error {
+	walletPath := util.MakeAbs(jsonPath)
 
-	if util.IsDir(jsonPath) {
-		return nil, fmt.Errorf("not a legacy JSON wallet: %s", jsonPath)
-	}
-
-	if util.PathExists(sqlitePath) {
-		return nil, ExitsError{Path: sqlitePath}
-	}
-
-	cfg := defaultOpenWalletConfig
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-
-	strg, err := sqlitestorage.Migrate(ctx, jsonPath, sqlitePath,
-		sqlitestorage.WithLockingMode(cfg.lockMode))
+	jsonStrg, err := jsonstorage.Open(walletPath)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("not a legacy JSON wallet: %s", walletPath)
 	}
 
-	return New(ctx, strg, opts...)
+	backupJSONPath := jsonPath + ".bak"
+	err = os.Rename(jsonPath, backupJSONPath)
+	if err != nil {
+		return fmt.Errorf("failed to create backup of JSON wallet: %w", err)
+	}
+
+	err = sqlitestorage.Migrate(ctx, walletPath, jsonStrg)
+	if err != nil {
+		// Restores the original JSON wallet on failure.
+		_ = os.RemoveAll(walletPath)
+		_ = os.Rename(backupJSONPath, walletPath)
+
+		return err
+	}
+
+	return nil
 }
 
 type openWalletConfig struct {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -800,7 +800,7 @@ func TestMigrate(t *testing.T) {
 		return vlt
 	}
 
-	t.Run("Migrate legacy JSON wallet", func(t *testing.T) {
+	t.Run("Migrate legacy JSON wallet in place", func(t *testing.T) {
 		ts := testsuite.NewTestSuite(t)
 
 		vlt := newTestVault(t)
@@ -815,60 +815,27 @@ func TestMigrate(t *testing.T) {
 			Path:      ts.RandString(16),
 		}
 		require.NoError(t, jsonStrg.InsertAddress(addrInfo))
-		jsonInfo := jsonStrg.WalletInfo()
 
-		sqlitePath := filepath.Join(util.TempDirPath(), "wallet")
-		wlt, err := Migrate(t.Context(), jsonPath, sqlitePath, WithOfflineProvider())
+		err = Migrate(t.Context(), jsonPath)
 		require.NoError(t, err)
-		defer wlt.Close()
-
-		// The legacy JSON file should be left untouched.
-		assert.True(t, util.PathExists(jsonPath))
-
-		// The wallet info should be preserved.
-		info := wlt.Info()
-		assert.Equal(t, "SQLite", info.Driver)
-		assert.Equal(t, jsonInfo.Network, info.Network)
-		assert.Equal(t, jsonInfo.DefaultFee, info.DefaultFee)
-		assert.Equal(t, jsonInfo.UUID, info.UUID)
-		assert.True(t, jsonInfo.CreatedAt.Equal(info.CreatedAt))
-
-		// The address should be preserved.
-		migratedAddr, err := wlt.AddressInfo(addrInfo.Address)
-		require.NoError(t, err)
-		assert.Equal(t, addrInfo.Address, migratedAddr.Address)
-		assert.Equal(t, addrInfo.PublicKey, migratedAddr.PublicKey)
-		assert.Equal(t, addrInfo.Label, migratedAddr.Label)
-		assert.Equal(t, addrInfo.Path, migratedAddr.Path)
 	})
 
-	t.Run("Invalid legacy wallet", func(t *testing.T) {
+	t.Run("Revert on failure", func(t *testing.T) {
 		jsonPath := util.TempFilePath()
 		require.NoError(t, util.WriteFile(jsonPath, []byte("invalid_data")))
 
-		_, err := Migrate(t.Context(), jsonPath, util.TempDirPath(), WithOfflineProvider())
+		err := Migrate(t.Context(), jsonPath)
 		require.Error(t, err)
 
-		// The invalid file should not be deleted.
-		assert.True(t, util.PathExists(jsonPath))
-	})
-
-	t.Run("Destination already exists", func(t *testing.T) {
-		vlt := newTestVault(t)
-		jsonPath := util.TempFilePath()
-		_, err := jsonstorage.Create(jsonPath, genesis.Testnet, vlt)
+		// The original file should be restored after the failed migration.
+		data, err := util.ReadFile(jsonPath)
 		require.NoError(t, err)
-
-		sqlitePath := util.TempDirPath()
-		_, err = Migrate(t.Context(), jsonPath, sqlitePath, WithOfflineProvider())
-		require.ErrorIs(t, err, ExitsError{Path: sqlitePath})
-
-		// The legacy file should not be deleted.
-		assert.True(t, util.PathExists(jsonPath))
+		assert.Equal(t, "invalid_data", string(data))
 	})
 
-	t.Run("Invalid source path", func(t *testing.T) {
-		_, err := Migrate(t.Context(), util.TempDirPath(), util.TempDirPath(), WithOfflineProvider())
+	t.Run("Non-existent source path", func(t *testing.T) {
+		err := Migrate(t.Context(),
+			filepath.Join(util.TempDirPath(), "no-such-wallet.json"))
 		require.Error(t, err)
 	})
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -785,52 +786,40 @@ func TestUpdatePassword(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	newTestVault := func(t *testing.T) *vault.Vault {
-		t.Helper()
-
-		opts := []encrypter.Option{
-			encrypter.OptionIteration(1),
-			encrypter.OptionMemory(8),
-			encrypter.OptionParallelism(1),
-		}
-		mnemonic, _ := GenerateMnemonic(128)
-		vlt, err := vault.CreateVaultFromMnemonic(mnemonic, addresspath.CoinTypePactusTestnet, "password", opts...)
-		require.NoError(t, err)
-
-		return vlt
-	}
-
 	t.Run("Migrate legacy JSON wallet in place", func(t *testing.T) {
-		ts := testsuite.NewTestSuite(t)
+		td := setup(t)
 
-		vlt := newTestVault(t)
 		jsonPath := util.TempFilePath()
-		jsonStrg, err := jsonstorage.Create(jsonPath, genesis.Testnet, vlt)
+		_, err := jsonstorage.Create(jsonPath, genesis.Mainnet, td.testVault)
 		require.NoError(t, err)
-
-		addrInfo := &wtypes.AddressInfo{
-			Address:   ts.RandAccAddress().String(),
-			PublicKey: ts.RandString(32),
-			Label:     ts.RandString(16),
-			Path:      ts.RandString(16),
-		}
-		require.NoError(t, jsonStrg.InsertAddress(addrInfo))
 
 		err = Migrate(t.Context(), jsonPath)
 		require.NoError(t, err)
 	})
 
-	t.Run("Revert on failure", func(t *testing.T) {
+	t.Run("Failed migration restores the original wallet", func(t *testing.T) {
+		td := setup(t)
+
+		jsonPath := util.TempFilePath()
+		_, err := jsonstorage.Create(jsonPath, genesis.Mainnet, td.testVault)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		err = Migrate(ctx, jsonPath)
+		require.Error(t, err)
+
+		_, err = jsonstorage.Open(jsonPath)
+		require.NoError(t, err)
+	})
+
+	t.Run("Invalid JSON data", func(t *testing.T) {
 		jsonPath := util.TempFilePath()
 		require.NoError(t, util.WriteFile(jsonPath, []byte("invalid_data")))
 
 		err := Migrate(t.Context(), jsonPath)
 		require.Error(t, err)
-
-		// The original file should be restored after the failed migration.
-		data, err := util.ReadFile(jsonPath)
-		require.NoError(t, err)
-		assert.Equal(t, "invalid_data", string(data))
 	})
 
 	t.Run("Non-existent source path", func(t *testing.T) {

--- a/www/jsonrpc/server_test.go
+++ b/www/jsonrpc/server_test.go
@@ -69,7 +69,8 @@ func TestBlockchainInfo(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost,
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodPost,
 		"http://"+td.jsonrpcServer.Address(),
 		bytes.NewBuffer(requestBody),
 	)


### PR DESCRIPTION
## Description

Follow-up to #2390: changes the wallet `migrate` command to convert a legacy JSON wallet to the SQLite format **in place**, instead of writing to a separate destination path.

```
pactus-wallet migrate --path <legacy-json-wallet>
```

- The JSON file at the given path is replaced by a SQLite wallet directory at the same path
- If migration fails, the original JSON wallet is restored (backup + rollback)
- Removes the `--to` flag and the `wallet.Migrate` destination-path API
- Exports `util.CopyFile` and `util.CopyDirectory` (previously unexported `copyFile`/`copyDirectory`) so the wallet layer can back up the JSON file
- Updates tests, including a cross-device-link (copy fallback) coverage on Linux

## Related Issue

Fixes #2389